### PR TITLE
Removing StringString

### DIFF
--- a/docs/docs-ref-autogen/excel/excel/excel.application.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.application.yml
@@ -41,19 +41,19 @@ items:
             - 'excel!Excel.CalculationType:enum'
   - uid: 'excel!Excel.Application#calculate:member(2)'
     summary: Recalculate all currently opened workbooks in Excel.
-    name: calculate(calculationTypeStringString)
-    fullName: calculate(calculationTypeStringString)
+    name: calculate(calculationTypeString)
+    fullName: calculate(calculationTypeString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'calculate(calculationTypeStringString: "Recalculate" | "Full" | "FullRebuild"): void;'
+      content: 'calculate(calculationTypeString: "Recalculate" | "Full" | "FullRebuild"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: calculationTypeStringString
+        - id: calculationTypeString
           description: Specifies the calculation type to use. See Excel.CalculationType for details.
           type:
             - '"Recalculate" | "Full" | "FullRebuild"'

--- a/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.bindingcollection.yml
@@ -53,13 +53,13 @@ items:
             - string
   - uid: 'excel!Excel.BindingCollection#add:member(2)'
     summary: Add a new binding to a particular Range.
-    name: 'add(range, bindingTypeStringString, id)'
-    fullName: 'add(range, bindingTypeStringString, id)'
+    name: 'add(range, bindingTypeString, id)'
+    fullName: 'add(range, bindingTypeString, id)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'add(range: Range | string, bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
+      content: 'add(range: Range | string, bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
       return:
         type:
           - 'excel!Excel.Binding:class'
@@ -71,7 +71,7 @@ items:
             address, including the sheet name
           type:
             - 'excel!Excel.BindingCollection#add~1:complex'
-        - id: bindingTypeStringString
+        - id: bindingTypeString
           description: Type of binding. See Excel.BindingType.
           type:
             - '"Range" | "Table" | "Text"'
@@ -111,13 +111,13 @@ items:
     summary: >-
       Add a new binding based on a named item in the workbook. If the named item references to multiple areas, the
       "InvalidReference" error will be returned.
-    name: 'addFromNamedItem(name, bindingTypeStringString, id)'
-    fullName: 'addFromNamedItem(name, bindingTypeStringString, id)'
+    name: 'addFromNamedItem(name, bindingTypeString, id)'
+    fullName: 'addFromNamedItem(name, bindingTypeString, id)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'addFromNamedItem(name: string, bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
+      content: 'addFromNamedItem(name: string, bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
       return:
         type:
           - 'excel!Excel.Binding:class'
@@ -127,7 +127,7 @@ items:
           description: Name from which to create binding.
           type:
             - string
-        - id: bindingTypeStringString
+        - id: bindingTypeString
           description: Type of binding. See Excel.BindingType.
           type:
             - '"Range" | "Table" | "Text"'
@@ -163,19 +163,19 @@ items:
     summary: >-
       Add a new binding based on the current selection. If the selection has multiple areas, the "InvalidReference"
       error will be returned.
-    name: 'addFromSelection(bindingTypeStringString, id)'
-    fullName: 'addFromSelection(bindingTypeStringString, id)'
+    name: 'addFromSelection(bindingTypeString, id)'
+    fullName: 'addFromSelection(bindingTypeString, id)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'addFromSelection(bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
+      content: 'addFromSelection(bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;'
       return:
         type:
           - 'excel!Excel.Binding:class'
         description: ''
       parameters:
-        - id: bindingTypeStringString
+        - id: bindingTypeString
           description: Type of binding. See Excel.BindingType.
           type:
             - '"Range" | "Table" | "Text"'

--- a/docs/docs-ref-autogen/excel/excel/excel.chart.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chart.yml
@@ -208,14 +208,14 @@ items:
     summary: >-
       Renders the chart as a base64-encoded image by scaling the chart to fit the specified dimensions. The aspect ratio
       is preserved as part of the resizing.
-    name: 'getImage(width, height, fittingModeStringString)'
-    fullName: 'getImage(width, height, fittingModeStringString)'
+    name: 'getImage(width, height, fittingModeString)'
+    fullName: 'getImage(width, height, fittingModeString)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getImage(width?: number, height?: number, fittingModeStringString?: "Fit" | "FitAndCenter" | "Fill"):
+        getImage(width?: number, height?: number, fittingModeString?: "Fit" | "FitAndCenter" | "Fill"):
         ClientResult<string>;
       return:
         type:
@@ -230,7 +230,7 @@ items:
           description: (Optional) The desired height of the resulting image.
           type:
             - number
-        - id: fittingModeStringString
+        - id: fittingModeString
           description: >-
             (Optional) The method used to scale the chart to the specified to the specified dimensions (if both height
             and width are set).
@@ -464,13 +464,13 @@ items:
             - 'excel!Excel.ChartSeriesBy:enum'
   - uid: 'excel!Excel.Chart#setData:member(2)'
     summary: Resets the source data for the chart.
-    name: 'setData(sourceData, seriesByStringString)'
-    fullName: 'setData(sourceData, seriesByStringString)'
+    name: 'setData(sourceData, seriesByString)'
+    fullName: 'setData(sourceData, seriesByString)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setData(sourceData: Range, seriesByStringString?: "Auto" | "Columns" | "Rows"): void;'
+      content: 'setData(sourceData: Range, seriesByString?: "Auto" | "Columns" | "Rows"): void;'
       return:
         type:
           - void
@@ -480,7 +480,7 @@ items:
           description: The range object corresponding to the source data.
           type:
             - 'excel!Excel.Range:class'
-        - id: seriesByStringString
+        - id: seriesByString
           description: >-
             Specifies the way columns or rows are used as data series on the chart. Can be one of the following: Auto
             (default), Rows, and Columns. See Excel.ChartSeriesBy for details.

--- a/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartaxes.yml
@@ -68,21 +68,21 @@ items:
             - 'excel!Excel.ChartAxisGroup:enum'
   - uid: 'excel!Excel.ChartAxes#getItem:member(2)'
     summary: Returns the specific axis identified by type and group.
-    name: 'getItem(typeStringString, group)'
-    fullName: 'getItem(typeStringString, group)'
+    name: 'getItem(typeString, group)'
+    fullName: 'getItem(typeString, group)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getItem(typeStringString: "Invalid" | "Category" | "Value" | "Series", group?: "Primary" | "Secondary"):
+        getItem(typeString: "Invalid" | "Category" | "Value" | "Series", group?: "Primary" | "Secondary"):
         Excel.ChartAxis;
       return:
         type:
           - 'excel!Excel.ChartAxis:class'
         description: ''
       parameters:
-        - id: typeStringString
+        - id: typeString
           description: Specifies the axis type. See Excel.ChartAxisType for details.
           type:
             - '"Invalid" | "Category" | "Value" | "Series"'

--- a/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.chartcollection.yml
@@ -49,16 +49,16 @@ items:
             - 'excel!Excel.ChartSeriesBy:enum'
   - uid: 'excel!Excel.ChartCollection#add:member(2)'
     summary: Creates a new chart.
-    name: 'add(typeStringString, sourceData, seriesBy)'
-    fullName: 'add(typeStringString, sourceData, seriesBy)'
+    name: 'add(typeString, sourceData, seriesBy)'
+    fullName: 'add(typeString, sourceData, seriesBy)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        add(typeStringString: "Invalid" | "ColumnClustered" | "ColumnStacked" | "ColumnStacked100" | "3DColumnClustered"
-        | "3DColumnStacked" | "3DColumnStacked100" | "BarClustered" | "BarStacked" | "BarStacked100" | "3DBarClustered"
-        | "3DBarStacked" | "3DBarStacked100" | "LineStacked" | "LineStacked100" | "LineMarkers" | "LineMarkersStacked" |
+        add(typeString: "Invalid" | "ColumnClustered" | "ColumnStacked" | "ColumnStacked100" | "3DColumnClustered" |
+        "3DColumnStacked" | "3DColumnStacked100" | "BarClustered" | "BarStacked" | "BarStacked100" | "3DBarClustered" |
+        "3DBarStacked" | "3DBarStacked100" | "LineStacked" | "LineStacked100" | "LineMarkers" | "LineMarkersStacked" |
         "LineMarkersStacked100" | "PieOfPie" | "PieExploded" | "3DPieExploded" | "BarOfPie" | "XYScatterSmooth" |
         "XYScatterSmoothNoMarkers" | "XYScatterLines" | "XYScatterLinesNoMarkers" | "AreaStacked" | "AreaStacked100" |
         "3DAreaStacked" | "3DAreaStacked100" | "DoughnutExploded" | "RadarMarkers" | "RadarFilled" | "Surface" |
@@ -76,7 +76,7 @@ items:
           - 'excel!Excel.Chart:class'
         description: ''
       parameters:
-        - id: typeStringString
+        - id: typeString
           description: Represents the type of a chart. See Excel.ChartType for details.
           type:
             - >-

--- a/docs/docs-ref-autogen/excel/excel/excel.charttrendlinecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.charttrendlinecollection.yml
@@ -52,21 +52,21 @@ items:
             - 'excel!Excel.ChartTrendlineType:enum'
   - uid: 'excel!Excel.ChartTrendlineCollection#add:member(2)'
     summary: Adds a new trendline to trendline collection.
-    name: add(typeStringString)
-    fullName: add(typeStringString)
+    name: add(typeString)
+    fullName: add(typeString)
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        add(typeStringString?: "Linear" | "Exponential" | "Logarithmic" | "MovingAverage" | "Polynomial" | "Power"):
+        add(typeString?: "Linear" | "Exponential" | "Logarithmic" | "MovingAverage" | "Polynomial" | "Power"):
         Excel.ChartTrendline;
       return:
         type:
           - 'excel!Excel.ChartTrendline:class'
         description: ''
       parameters:
-        - id: typeStringString
+        - id: typeString
           description: Specifies the trendline type. The default value is "Linear". See Excel.ChartTrendline for details.
           type:
             - '"Linear" | "Exponential" | "Logarithmic" | "MovingAverage" | "Polynomial" | "Power"'

--- a/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentcollection.yml
@@ -73,15 +73,15 @@ items:
     summary: >-
       Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the
       provided range is larger than one cell.
-    name: 'add(cellAddress, content, contentTypeStringString)'
-    fullName: 'add(cellAddress, content, contentTypeStringString)'
+    name: 'add(cellAddress, content, contentTypeString)'
+    fullName: 'add(cellAddress, content, contentTypeString)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        add(cellAddress: Range | string, content: CommentRichContent | string, contentTypeStringString?: "Plain" |
-        "Mention"): Excel.Comment;
+        add(cellAddress: Range | string, content: CommentRichContent | string, contentTypeString?: "Plain" | "Mention"):
+        Excel.Comment;
       return:
         type:
           - 'excel!Excel.Comment:class'
@@ -100,7 +100,7 @@ items:
             text. CommentRichContent objects allow for other comment features, such as mentions.
           type:
             - 'excel!Excel.CommentCollection#add~3:complex'
-        - id: contentTypeStringString
+        - id: contentTypeString
           description: >-
             Optional. The type of content contained within the comment. The default value is enum
             `ContentType.Plain`<!-- -->.

--- a/docs/docs-ref-autogen/excel/excel/excel.commentreplycollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.commentreplycollection.yml
@@ -58,13 +58,13 @@ items:
             - 'excel!Excel.ContentType:enum'
   - uid: 'excel!Excel.CommentReplyCollection#add:member(2)'
     summary: Creates a comment reply for comment.
-    name: 'add(content, contentTypeStringString)'
-    fullName: 'add(content, contentTypeStringString)'
+    name: 'add(content, contentTypeString)'
+    fullName: 'add(content, contentTypeString)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'add(content: CommentRichContent | string, contentTypeStringString?: "Plain" | "Mention"): Excel.CommentReply;'
+      content: 'add(content: CommentRichContent | string, contentTypeString?: "Plain" | "Mention"): Excel.CommentReply;'
       return:
         type:
           - 'excel!Excel.CommentReply:class'
@@ -76,7 +76,7 @@ items:
             mentions).
           type:
             - 'excel!Excel.CommentReplyCollection#add~1:complex'
-        - id: contentTypeStringString
+        - id: contentTypeString
           description: >-
             Optional. The type of content contained within the comment. The default value is enum
             `ContentType.Plain`<!-- -->.

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalformatcollection.yml
@@ -58,21 +58,21 @@ items:
             - 'excel!Excel.ConditionalFormatType:enum'
   - uid: 'excel!Excel.ConditionalFormatCollection#add:member(2)'
     summary: Adds a new conditional format to the collection at the first/top priority.
-    name: add(typeStringString)
-    fullName: add(typeStringString)
+    name: add(typeString)
+    fullName: add(typeString)
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        add(typeStringString: "Custom" | "DataBar" | "ColorScale" | "IconSet" | "TopBottom" | "PresetCriteria" |
+        add(typeString: "Custom" | "DataBar" | "ColorScale" | "IconSet" | "TopBottom" | "PresetCriteria" |
         "ContainsText" | "CellValue"): Excel.ConditionalFormat;
       return:
         type:
           - 'excel!Excel.ConditionalFormat:class'
         description: ''
       parameters:
-        - id: typeStringString
+        - id: typeString
           description: The type of conditional format being added. See Excel.ConditionalFormatType for details.
           type:
             - >-

--- a/docs/docs-ref-autogen/excel/excel/excel.conditionalrangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.conditionalrangebordercollection.yml
@@ -78,19 +78,19 @@ items:
             - 'excel!Excel.ConditionalRangeBorderIndex:enum'
   - uid: 'excel!Excel.ConditionalRangeBorderCollection#getItem:member(2)'
     summary: Gets a border object using its name.
-    name: getItem(indexStringString)
-    fullName: getItem(indexStringString)
+    name: getItem(indexString)
+    fullName: getItem(indexString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getItem(indexStringString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"): Excel.ConditionalRangeBorder;'
+      content: 'getItem(indexString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"): Excel.ConditionalRangeBorder;'
       return:
         type:
           - 'excel!Excel.ConditionalRangeBorder:class'
         description: ''
       parameters:
-        - id: indexStringString
+        - id: indexString
           description: Index value of the border object to be retrieved. See Excel.ConditionalRangeBorderIndex for details.
           type:
             - '"EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"'

--- a/docs/docs-ref-autogen/excel/excel/excel.filter.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.filter.yml
@@ -127,13 +127,13 @@ items:
             - 'excel!Excel.FilterOperator:enum'
   - uid: 'excel!Excel.Filter#applyCustomFilter:member(2)'
     summary: Apply an "Icon" filter to the column for the given criteria strings.
-    name: 'applyCustomFilter(criteria1, criteria2, operStringString)'
-    fullName: 'applyCustomFilter(criteria1, criteria2, operStringString)'
+    name: 'applyCustomFilter(criteria1, criteria2, operString)'
+    fullName: 'applyCustomFilter(criteria1, criteria2, operString)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'applyCustomFilter(criteria1: string, criteria2?: string, operStringString?: "And" | "Or"): void;'
+      content: 'applyCustomFilter(criteria1: string, criteria2?: string, operString?: "And" | "Or"): void;'
       return:
         type:
           - void
@@ -147,7 +147,7 @@ items:
           description: Optional. The second criteria string.
           type:
             - string
-        - id: operStringString
+        - id: operString
           description: Optional. The operator that describes how the two criteria are joined.
           type:
             - '"And" | "Or"'
@@ -171,14 +171,14 @@ items:
             - 'excel!Excel.DynamicFilterCriteria:enum'
   - uid: 'excel!Excel.Filter#applyDynamicFilter:member(2)'
     summary: Apply a "Dynamic" filter to the column.
-    name: applyDynamicFilter(criteriaStringString)
-    fullName: applyDynamicFilter(criteriaStringString)
+    name: applyDynamicFilter(criteriaString)
+    fullName: applyDynamicFilter(criteriaString)
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        applyDynamicFilter(criteriaStringString: "Unknown" | "AboveAverage" | "AllDatesInPeriodApril" |
+        applyDynamicFilter(criteriaString: "Unknown" | "AboveAverage" | "AllDatesInPeriodApril" |
         "AllDatesInPeriodAugust" | "AllDatesInPeriodDecember" | "AllDatesInPeriodFebruray" | "AllDatesInPeriodJanuary" |
         "AllDatesInPeriodJuly" | "AllDatesInPeriodJune" | "AllDatesInPeriodMarch" | "AllDatesInPeriodMay" |
         "AllDatesInPeriodNovember" | "AllDatesInPeriodOctober" | "AllDatesInPeriodQuarter1" | "AllDatesInPeriodQuarter2"
@@ -191,7 +191,7 @@ items:
           - void
         description: ''
       parameters:
-        - id: criteriaStringString
+        - id: criteriaString
           description: The dynamic criteria to apply.
           type:
             - >-

--- a/docs/docs-ref-autogen/excel/excel/excel.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pagelayout.yml
@@ -529,21 +529,21 @@ items:
             - 'excel!Excel.PageLayoutMarginOptions:interface'
   - uid: 'excel!Excel.PageLayout#setPrintMargins:member(2)'
     summary: Sets the worksheet's page margins with units.
-    name: 'setPrintMargins(unitStringString, marginOptions)'
-    fullName: 'setPrintMargins(unitStringString, marginOptions)'
+    name: 'setPrintMargins(unitString, marginOptions)'
+    fullName: 'setPrintMargins(unitString, marginOptions)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        setPrintMargins(unitStringString: "Points" | "Inches" | "Centimeters", marginOptions:
-        Excel.PageLayoutMarginOptions): void;
+        setPrintMargins(unitString: "Points" | "Inches" | "Centimeters", marginOptions: Excel.PageLayoutMarginOptions):
+        void;
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: unitStringString
+        - id: unitString
           description: Measurement unit for the margins provided.
           type:
             - '"Points" | "Inches" | "Centimeters"'

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotfield.yml
@@ -209,21 +209,21 @@ items:
     summary: >-
       Sorts the PivotField by specified values in a given scope. The scope defines which specific values will be used to
       sort when there are multiple values from the same DataPivotHierarchy.
-    name: 'sortByValues(sortByStringString, valuesHierarchy, pivotItemScope)'
-    fullName: 'sortByValues(sortByStringString, valuesHierarchy, pivotItemScope)'
+    name: 'sortByValues(sortByString, valuesHierarchy, pivotItemScope)'
+    fullName: 'sortByValues(sortByString, valuesHierarchy, pivotItemScope)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        sortByValues(sortByStringString: "Ascending" | "Descending", valuesHierarchy: Excel.DataPivotHierarchy,
+        sortByValues(sortByString: "Ascending" | "Descending", valuesHierarchy: Excel.DataPivotHierarchy,
         pivotItemScope?: Array<PivotItem | string>): void;
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: sortByStringString
+        - id: sortByString
           description: Represents whether the sorting is done in an ascending or descending order.
           type:
             - '"Ascending" | "Descending"'

--- a/docs/docs-ref-autogen/excel/excel/excel.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.pivotlayout.yml
@@ -171,21 +171,21 @@ items:
             - 'excel!Excel.PivotLayout#getPivotItems~1:complex'
   - uid: 'excel!Excel.PivotLayout#getPivotItems:member(2)'
     summary: Gets the PivotItems from an axis that make up the value in a specified range within the PivotTable.
-    name: 'getPivotItems(axisStringString, cell)'
-    fullName: 'getPivotItems(axisStringString, cell)'
+    name: 'getPivotItems(axisString, cell)'
+    fullName: 'getPivotItems(axisString, cell)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getPivotItems(axisStringString: "Unknown" | "Row" | "Column" | "Data" | "Filter", cell: Range | string):
+        getPivotItems(axisString: "Unknown" | "Row" | "Column" | "Data" | "Filter", cell: Range | string):
         ClientResult<Excel.PivotItem[]>;
       return:
         type:
           - 'excel!Excel.PivotLayout#getPivotItems~2:complex'
         description: A collection of PivotItems that are used to calculate the values in the specified row.
       parameters:
-        - id: axisStringString
+        - id: axisString
           description: The axis from which to get the PivotItems. Must be either "row" or "column."
           type:
             - '"Unknown" | "Row" | "Column" | "Data" | "Filter"'
@@ -343,13 +343,13 @@ items:
     summary: >-
       Sets the PivotTable to automatically sort using the specified cell to automatically select all necessary criteria
       and context. This behaves identically to applying an autosort from the UI.
-    name: 'setAutoSortOnCell(cell, sortByStringString)'
-    fullName: 'setAutoSortOnCell(cell, sortByStringString)'
+    name: 'setAutoSortOnCell(cell, sortByString)'
+    fullName: 'setAutoSortOnCell(cell, sortByString)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setAutoSortOnCell(cell: Range | string, sortByStringString: "Ascending" | "Descending"): void;'
+      content: 'setAutoSortOnCell(cell: Range | string, sortByString: "Ascending" | "Descending"): void;'
       return:
         type:
           - void
@@ -359,7 +359,7 @@ items:
           description: A single cell to use get the criteria from for applying the autosort.
           type:
             - 'excel!Excel.PivotLayout#setAutoSortOnCell~1:complex'
-        - id: sortByStringString
+        - id: sortByString
           description: The direction of the sort.
           type:
             - '"Ascending" | "Descending"'

--- a/docs/docs-ref-autogen/excel/excel/excel.range.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.range.yml
@@ -203,15 +203,15 @@ items:
       For more information, read [Use AutoFill and Flash
       Fill](https://support.office.com/article/video-use-autofill-and-flash-fill-2e79a709-c814-4b27-8bc2-c4dc84d49464)<!--
       -->.
-    name: 'autoFill(destinationRange, autoFillTypeStringString)'
-    fullName: 'autoFill(destinationRange, autoFillTypeStringString)'
+    name: 'autoFill(destinationRange, autoFillTypeString)'
+    fullName: 'autoFill(destinationRange, autoFillTypeString)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        autoFill(destinationRange?: Range | string, autoFillTypeStringString?: "FillDefault" | "FillCopy" | "FillSeries"
-        | "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" |
+        autoFill(destinationRange?: Range | string, autoFillTypeString?: "FillDefault" | "FillCopy" | "FillSeries" |
+        "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" |
         "GrowthTrend" | "FlashFill"): void;
       return:
         type:
@@ -224,7 +224,7 @@ items:
             surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
           type:
             - 'excel!Excel.Range#autoFill~1:complex'
-        - id: autoFillTypeStringString
+        - id: autoFillTypeString
           description: >-
             The type of autofill. Specifies how the destination range is to be filled, based on the contents of the
             current range. Default is "FillDefault".
@@ -277,19 +277,19 @@ items:
             - 'excel!Excel.ClearApplyTo:enum'
   - uid: 'excel!Excel.Range#clear:member(2)'
     summary: 'Clear range values, format, fill, border, etc.'
-    name: clear(applyToStringString)
-    fullName: clear(applyToStringString)
+    name: clear(applyToString)
+    fullName: clear(applyToString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'clear(applyToStringString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;'
+      content: 'clear(applyToString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: applyToStringString
+        - id: applyToString
           description: Optional. Determines the type of clear action. See Excel.ClearApplyTo for details.
           type:
             - '"All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"'
@@ -448,15 +448,15 @@ items:
       Copies cell data or formatting from the source range or RangeAreas to the current range. The destination range can
       be a different size than the source range or RangeAreas. The destination will be expanded automatically if it is
       smaller than the source.
-    name: 'copyFrom(sourceRange, copyTypeStringString, skipBlanks, transpose)'
-    fullName: 'copyFrom(sourceRange, copyTypeStringString, skipBlanks, transpose)'
+    name: 'copyFrom(sourceRange, copyTypeString, skipBlanks, transpose)'
+    fullName: 'copyFrom(sourceRange, copyTypeString, skipBlanks, transpose)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeStringString?: "All" | "Formulas" | "Values" |
-        "Formats", skipBlanks?: boolean, transpose?: boolean): void;
+        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeString?: "All" | "Formulas" | "Values" | "Formats",
+        skipBlanks?: boolean, transpose?: boolean): void;
       return:
         type:
           - void
@@ -468,7 +468,7 @@ items:
             be able to be created by removing full rows or columns from a rectangular range.
           type:
             - 'excel!Excel.Range#copyFrom~1:complex'
-        - id: copyTypeStringString
+        - id: copyTypeString
           description: The type of cell data or formatting to copy over. Default is "All".
           type:
             - '"All" | "Formulas" | "Values" | "Formats"'
@@ -512,19 +512,19 @@ items:
             - 'excel!Excel.DeleteShiftDirection:enum'
   - uid: 'excel!Excel.Range#delete:member(2)'
     summary: Deletes the cells associated with the range.
-    name: delete(shiftStringString)
-    fullName: delete(shiftStringString)
+    name: delete(shiftString)
+    fullName: delete(shiftString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'delete(shiftStringString: "Up" | "Left"): void;'
+      content: 'delete(shiftString: "Up" | "Left"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: shiftStringString
+        - id: shiftString
           description: Specifies which way to shift the cells. See Excel.DeleteShiftDirection for details.
           type:
             - '"Up" | "Left"'
@@ -1269,24 +1269,23 @@ items:
     summary: >-
       Gets the RangeAreas object, comprising one or more rectangular ranges, that represents all the cells that match
       the specified type and value. If no special cells are found, an ItemNotFound error will be thrown.
-    name: 'getSpecialCells(cellTypeStringString, cellValueType)'
-    fullName: 'getSpecialCells(cellTypeStringString, cellValueType)'
+    name: 'getSpecialCells(cellTypeString, cellValueType)'
+    fullName: 'getSpecialCells(cellTypeString, cellValueType)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getSpecialCells(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" |
-        "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" |
-        "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
-        "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" |
-        "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCells(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" |
+        "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" |
+        "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" |
+        "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
       return:
         type:
           - 'excel!Excel.RangeAreas:class'
         description: ''
       parameters:
-        - id: cellTypeStringString
+        - id: cellTypeString
           description: The type of cells to include.
           type:
             - >-
@@ -1335,16 +1334,16 @@ items:
     summary: >-
       Gets the RangeAreas object, comprising one or more ranges, that represents all the cells that match the specified
       type and value. If no special cells are found, a null object will be returned.
-    name: 'getSpecialCellsOrNullObject(cellTypeStringString, cellValueType)'
-    fullName: 'getSpecialCellsOrNullObject(cellTypeStringString, cellValueType)'
+    name: 'getSpecialCellsOrNullObject(cellTypeString, cellValueType)'
+    fullName: 'getSpecialCellsOrNullObject(cellTypeString, cellValueType)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getSpecialCellsOrNullObject(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" |
-        "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" |
-        "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
+        getSpecialCellsOrNullObject(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" |
+        "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" |
+        "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
         "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" |
         "NumbersText" | "Text"): Excel.RangeAreas;
       return:
@@ -1352,7 +1351,7 @@ items:
           - 'excel!Excel.RangeAreas:class'
         description: ''
       parameters:
-        - id: cellTypeStringString
+        - id: cellTypeString
           description: The type of cells to include.
           type:
             - >-
@@ -1594,19 +1593,19 @@ items:
             - 'excel!Excel.GroupOption:enum'
   - uid: 'excel!Excel.Range#group:member(2)'
     summary: Groups columns and rows for an outline.
-    name: group(groupOptionStringString)
-    fullName: group(groupOptionStringString)
+    name: group(groupOptionString)
+    fullName: group(groupOptionString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'group(groupOptionStringString: "ByRows" | "ByColumns"): void;'
+      content: 'group(groupOptionString: "ByRows" | "ByColumns"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: groupOptionStringString
+        - id: groupOptionString
           description: >-
             Specifies how the range can be grouped by rows or columns. An `InvalidArgument` error is thrown when the
             group option differs from the range's `isEntireRow` or `isEntireColumn` property (i.e., `range.isEntireRow`
@@ -1657,19 +1656,19 @@ items:
             - 'excel!Excel.GroupOption:enum'
   - uid: 'excel!Excel.Range#hideGroupDetails:member(2)'
     summary: Hide details of the row or column group.
-    name: hideGroupDetails(groupOptionStringString)
-    fullName: hideGroupDetails(groupOptionStringString)
+    name: hideGroupDetails(groupOptionString)
+    fullName: hideGroupDetails(groupOptionString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'hideGroupDetails(groupOptionStringString: "ByRows" | "ByColumns"): void;'
+      content: 'hideGroupDetails(groupOptionString: "ByRows" | "ByColumns"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: groupOptionStringString
+        - id: groupOptionString
           description: Specifies whether to hide details of grouped rows or grouped columns.
           type:
             - '"ByRows" | "ByColumns"'
@@ -1740,19 +1739,19 @@ items:
     summary: >-
       Inserts a cell or a range of cells into the worksheet in place of this range, and shifts the other cells to make
       space. Returns a new Range object at the now blank space.
-    name: insert(shiftStringString)
-    fullName: insert(shiftStringString)
+    name: insert(shiftString)
+    fullName: insert(shiftString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'insert(shiftStringString: "Down" | "Right"): Excel.Range;'
+      content: 'insert(shiftString: "Down" | "Right"): Excel.Range;'
       return:
         type:
           - 'excel!Excel.Range:class'
         description: ''
       parameters:
-        - id: shiftStringString
+        - id: shiftString
           description: Specifies which way to shift the cells. See Excel.InsertShiftDirection for details.
           type:
             - '"Down" | "Right"'
@@ -2286,19 +2285,19 @@ items:
             - 'excel!Excel.GroupOption:enum'
   - uid: 'excel!Excel.Range#showGroupDetails:member(2)'
     summary: Show details of the row or column group.
-    name: showGroupDetails(groupOptionStringString)
-    fullName: showGroupDetails(groupOptionStringString)
+    name: showGroupDetails(groupOptionString)
+    fullName: showGroupDetails(groupOptionString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'showGroupDetails(groupOptionStringString: "ByRows" | "ByColumns"): void;'
+      content: 'showGroupDetails(groupOptionString: "ByRows" | "ByColumns"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: groupOptionStringString
+        - id: groupOptionString
           description: Specifies whether to show details of grouped rows or grouped columns.
           type:
             - '"ByRows" | "ByColumns"'
@@ -2457,19 +2456,19 @@ items:
             - 'excel!Excel.GroupOption:enum'
   - uid: 'excel!Excel.Range#ungroup:member(2)'
     summary: Ungroups columns and rows for an outline.
-    name: ungroup(groupOptionStringString)
-    fullName: ungroup(groupOptionStringString)
+    name: ungroup(groupOptionString)
+    fullName: ungroup(groupOptionString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'ungroup(groupOptionStringString: "ByRows" | "ByColumns"): void;'
+      content: 'ungroup(groupOptionString: "ByRows" | "ByColumns"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: groupOptionStringString
+        - id: groupOptionString
           description: Specifies how the range can be ungrouped by rows or columns.
           type:
             - '"ByRows" | "ByColumns"'

--- a/docs/docs-ref-autogen/excel/excel/excel.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangeareas.yml
@@ -147,19 +147,19 @@ items:
             - 'excel!Excel.ClearApplyTo:enum'
   - uid: 'excel!Excel.RangeAreas#clear:member(2)'
     summary: 'Clears values, format, fill, border, etc on each of the areas that comprise this RangeAreas object.'
-    name: clear(applyToStringString)
-    fullName: clear(applyToStringString)
+    name: clear(applyToString)
+    fullName: clear(applyToString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'clear(applyToStringString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;'
+      content: 'clear(applyToString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: applyToStringString
+        - id: applyToString
           description: Optional. Determines the type of clear action. See Excel.ClearApplyTo for details. Default is "All".
           type:
             - '"All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"'
@@ -266,15 +266,15 @@ items:
       Copies cell data or formatting from the source range or RangeAreas to the current RangeAreas. The destination
       rangeAreas can be a different size than the source range or RangeAreas. The destination will be expanded
       automatically if it is smaller than the source.
-    name: 'copyFrom(sourceRange, copyTypeStringString, skipBlanks, transpose)'
-    fullName: 'copyFrom(sourceRange, copyTypeStringString, skipBlanks, transpose)'
+    name: 'copyFrom(sourceRange, copyTypeString, skipBlanks, transpose)'
+    fullName: 'copyFrom(sourceRange, copyTypeString, skipBlanks, transpose)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeStringString?: "All" | "Formulas" | "Values" |
-        "Formats", skipBlanks?: boolean, transpose?: boolean): void;
+        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeString?: "All" | "Formulas" | "Values" | "Formats",
+        skipBlanks?: boolean, transpose?: boolean): void;
       return:
         type:
           - void
@@ -286,7 +286,7 @@ items:
             able to be created by removing full rows or columns from a rectangular range.
           type:
             - 'excel!Excel.RangeAreas#copyFrom~1:complex'
-        - id: copyTypeStringString
+        - id: copyTypeString
           description: The type of cell data or formatting to copy over. Default is "All".
           type:
             - '"All" | "Formulas" | "Values" | "Formats"'
@@ -472,24 +472,23 @@ items:
     summary: >-
       Returns a RangeAreas object that represents all the cells that match the specified type and value. Throws an error
       if no special cells are found that match the criteria.
-    name: 'getSpecialCells(cellTypeStringString, cellValueType)'
-    fullName: 'getSpecialCells(cellTypeStringString, cellValueType)'
+    name: 'getSpecialCells(cellTypeString, cellValueType)'
+    fullName: 'getSpecialCells(cellTypeString, cellValueType)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getSpecialCells(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" |
-        "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" |
-        "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
-        "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" |
-        "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCells(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" |
+        "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" |
+        "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" |
+        "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
       return:
         type:
           - 'excel!Excel.RangeAreas:class'
         description: ''
       parameters:
-        - id: cellTypeStringString
+        - id: cellTypeString
           description: The type of cells to include.
           type:
             - >-
@@ -538,16 +537,16 @@ items:
     summary: >-
       Returns a RangeAreas object that represents all the cells that match the specified type and value. Returns a null
       object if no special cells are found that match the criteria.
-    name: 'getSpecialCellsOrNullObject(cellTypeStringString, cellValueType)'
-    fullName: 'getSpecialCellsOrNullObject(cellTypeStringString, cellValueType)'
+    name: 'getSpecialCellsOrNullObject(cellTypeString, cellValueType)'
+    fullName: 'getSpecialCellsOrNullObject(cellTypeString, cellValueType)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getSpecialCellsOrNullObject(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" |
-        "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" |
-        "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
+        getSpecialCellsOrNullObject(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" |
+        "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" |
+        "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" |
         "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" |
         "NumbersText" | "Text"): Excel.RangeAreas;
       return:
@@ -555,7 +554,7 @@ items:
           - 'excel!Excel.RangeAreas:class'
         description: ''
       parameters:
-        - id: cellTypeStringString
+        - id: cellTypeString
           description: The type of cells to include.
           type:
             - >-

--- a/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangebordercollection.yml
@@ -63,21 +63,21 @@ items:
             - 'excel!Excel.BorderIndex:enum'
   - uid: 'excel!Excel.RangeBorderCollection#getItem:member(2)'
     summary: Gets a border object using its name.
-    name: getItem(indexStringString)
-    fullName: getItem(indexStringString)
+    name: getItem(indexString)
+    fullName: getItem(indexString)
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        getItem(indexStringString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight" | "InsideVertical" |
-        "InsideHorizontal" | "DiagonalDown" | "DiagonalUp"): Excel.RangeBorder;
+        getItem(indexString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight" | "InsideVertical" | "InsideHorizontal"
+        | "DiagonalDown" | "DiagonalUp"): Excel.RangeBorder;
       return:
         type:
           - 'excel!Excel.RangeBorder:class'
         description: ''
       parameters:
-        - id: indexStringString
+        - id: indexString
           description: Index value of the border object to be retrieved. See Excel.BorderIndex for details.
           type:
             - >-

--- a/docs/docs-ref-autogen/excel/excel/excel.rangesort.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.rangesort.yml
@@ -51,14 +51,14 @@ items:
             - 'excel!Excel.SortMethod:enum'
   - uid: 'excel!Excel.RangeSort#apply:member(2)'
     summary: Perform a sort operation.
-    name: 'apply(fields, matchCase, hasHeaders, orientationStringString, method)'
-    fullName: 'apply(fields, matchCase, hasHeaders, orientationStringString, method)'
+    name: 'apply(fields, matchCase, hasHeaders, orientationString, method)'
+    fullName: 'apply(fields, matchCase, hasHeaders, orientationString, method)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        apply(fields: Excel.SortField[], matchCase?: boolean, hasHeaders?: boolean, orientationStringString?: "Rows" |
+        apply(fields: Excel.SortField[], matchCase?: boolean, hasHeaders?: boolean, orientationString?: "Rows" |
         "Columns", method?: "PinYin" | "StrokeCount"): void;
       return:
         type:
@@ -77,7 +77,7 @@ items:
           description: Optional. Whether the range has a header.
           type:
             - boolean
-        - id: orientationStringString
+        - id: orientationString
           description: Optional. Whether the operation is sorting rows or columns.
           type:
             - '"Rows" | "Columns"'

--- a/docs/docs-ref-autogen/excel/excel/excel.shape.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shape.yml
@@ -284,19 +284,19 @@ items:
       Converts the shape to an image and returns the image as a base64-encoded string. The DPI is 96. The only supported
       formats are `Excel.PictureFormat.BMP`<!-- -->, `Excel.PictureFormat.PNG`<!-- -->, `Excel.PictureFormat.JPEG`<!--
       -->, and `Excel.PictureFormat.GIF`<!-- -->.
-    name: getAsImage(formatStringString)
-    fullName: getAsImage(formatStringString)
+    name: getAsImage(formatString)
+    fullName: getAsImage(formatString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'getAsImage(formatStringString: "UNKNOWN" | "BMP" | "JPEG" | "GIF" | "PNG" | "SVG"): ClientResult<string>;'
+      content: 'getAsImage(formatString: "UNKNOWN" | "BMP" | "JPEG" | "GIF" | "PNG" | "SVG"): ClientResult<string>;'
       return:
         type:
           - 'excel!Excel.Shape#getAsImage~1:complex'
         description: ''
       parameters:
-        - id: formatStringString
+        - id: formatString
           description: Specifies the format of the image.
           type:
             - '"UNKNOWN" | "BMP" | "JPEG" | "GIF" | "PNG" | "SVG"'
@@ -731,15 +731,15 @@ items:
       Scales the height of the shape by a specified factor. For images, you can indicate whether you want to scale the
       shape relative to the original or the current size. Shapes other than pictures are always scaled relative to their
       current height.
-    name: 'scaleHeight(scaleFactor, scaleTypeStringString, scaleFrom)'
-    fullName: 'scaleHeight(scaleFactor, scaleTypeStringString, scaleFrom)'
+    name: 'scaleHeight(scaleFactor, scaleTypeString, scaleFrom)'
+    fullName: 'scaleHeight(scaleFactor, scaleTypeString, scaleFrom)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        scaleHeight(scaleFactor: number, scaleTypeStringString: "CurrentSize" | "OriginalSize", scaleFrom?:
-        "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
+        scaleHeight(scaleFactor: number, scaleTypeString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft"
+        | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
       return:
         type:
           - void
@@ -749,7 +749,7 @@ items:
           description: Specifies the ratio between the height of the shape after you resize it and the current or original height.
           type:
             - number
-        - id: scaleTypeStringString
+        - id: scaleTypeString
           description: >-
             Specifies whether the shape is scaled relative to its original or current size. The original size scaling
             option only works for images.
@@ -799,15 +799,15 @@ items:
       Scales the width of the shape by a specified factor. For images, you can indicate whether you want to scale the
       shape relative to the original or the current size. Shapes other than pictures are always scaled relative to their
       current width.
-    name: 'scaleWidth(scaleFactor, scaleTypeStringString, scaleFrom)'
-    fullName: 'scaleWidth(scaleFactor, scaleTypeStringString, scaleFrom)'
+    name: 'scaleWidth(scaleFactor, scaleTypeString, scaleFrom)'
+    fullName: 'scaleWidth(scaleFactor, scaleTypeString, scaleFrom)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        scaleWidth(scaleFactor: number, scaleTypeStringString: "CurrentSize" | "OriginalSize", scaleFrom?:
-        "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
+        scaleWidth(scaleFactor: number, scaleTypeString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft"
+        | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
       return:
         type:
           - void
@@ -817,7 +817,7 @@ items:
           description: Specifies the ratio between the width of the shape after you resize it and the current or original width.
           type:
             - number
-        - id: scaleTypeStringString
+        - id: scaleTypeString
           description: >-
             Specifies whether the shape is scaled relative to its original or current size. The original size scaling
             option only works for images.
@@ -881,19 +881,19 @@ items:
             - 'excel!Excel.ShapeZOrder:enum'
   - uid: 'excel!Excel.Shape#setZOrder:member(2)'
     summary: 'Moves the specified shape up or down the collection''s z-order, which shifts it in front of or behind other shapes.'
-    name: setZOrder(positionStringString)
-    fullName: setZOrder(positionStringString)
+    name: setZOrder(positionString)
+    fullName: setZOrder(positionString)
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'setZOrder(positionStringString: "BringToFront" | "BringForward" | "SendToBack" | "SendBackward"): void;'
+      content: 'setZOrder(positionString: "BringToFront" | "BringForward" | "SendToBack" | "SendBackward"): void;'
       return:
         type:
           - void
         description: ''
       parameters:
-        - id: positionStringString
+        - id: positionString
           description: >-
             Where to move the shape in the z-order stack relative to the other shapes. See Excel.ShapeZOrder for
             details.

--- a/docs/docs-ref-autogen/excel/excel/excel.shapecollection.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.shapecollection.yml
@@ -57,14 +57,14 @@ items:
             - 'excel!Excel.GeometricShapeType:enum'
   - uid: 'excel!Excel.ShapeCollection#addGeometricShape:member(2)'
     summary: Adds a geometric shape to the worksheet. Returns a Shape object that represents the new shape.
-    name: addGeometricShape(geometricShapeTypeStringString)
-    fullName: addGeometricShape(geometricShapeTypeStringString)
+    name: addGeometricShape(geometricShapeTypeString)
+    fullName: addGeometricShape(geometricShapeTypeString)
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        addGeometricShape(geometricShapeTypeStringString: "LineInverse" | "Triangle" | "RightTriangle" | "Rectangle" |
+        addGeometricShape(geometricShapeTypeString: "LineInverse" | "Triangle" | "RightTriangle" | "Rectangle" |
         "Diamond" | "Parallelogram" | "Trapezoid" | "NonIsoscelesTrapezoid" | "Pentagon" | "Hexagon" | "Heptagon" |
         "Octagon" | "Decagon" | "Dodecagon" | "Star4" | "Star5" | "Star6" | "Star7" | "Star8" | "Star10" | "Star12" |
         "Star16" | "Star24" | "Star32" | "RoundRectangle" | "Round1Rectangle" | "Round2SameRectangle" |
@@ -100,7 +100,7 @@ items:
           - 'excel!Excel.Shape:class'
         description: ''
       parameters:
-        - id: geometricShapeTypeStringString
+        - id: geometricShapeTypeString
           description: Represents the type of the geometric shape. See Excel.GeometricShapeType for details.
           type:
             - >-
@@ -266,15 +266,15 @@ items:
             - 'excel!Excel.ConnectorType:enum'
   - uid: 'excel!Excel.ShapeCollection#addLine:member(2)'
     summary: Adds a line to worksheet. Returns a Shape object that represents the new line.
-    name: 'addLine(startLeft, startTop, endLeft, endTop, connectorTypeStringString)'
-    fullName: 'addLine(startLeft, startTop, endLeft, endTop, connectorTypeStringString)'
+    name: 'addLine(startLeft, startTop, endLeft, endTop, connectorTypeString)'
+    fullName: 'addLine(startLeft, startTop, endLeft, endTop, connectorTypeString)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        addLine(startLeft: number, startTop: number, endLeft: number, endTop: number, connectorTypeStringString?:
-        "Straight" | "Elbow" | "Curve"): Excel.Shape;
+        addLine(startLeft: number, startTop: number, endLeft: number, endTop: number, connectorTypeString?: "Straight" |
+        "Elbow" | "Curve"): Excel.Shape;
       return:
         type:
           - 'excel!Excel.Shape:class'
@@ -296,7 +296,7 @@ items:
           description: 'The distance, in points, from the end of the line to the top of the worksheet.'
           type:
             - number
-        - id: connectorTypeStringString
+        - id: connectorTypeString
           description: Represents the connector type. See Excel.ConnectorType for details.
           type:
             - '"Straight" | "Elbow" | "Curve"'

--- a/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.tablesort.yml
@@ -64,13 +64,13 @@ items:
             - 'excel!Excel.SortMethod:enum'
   - uid: 'excel!Excel.TableSort#apply:member(2)'
     summary: Perform a sort operation.
-    name: 'apply(fields, matchCase, methodStringString)'
-    fullName: 'apply(fields, matchCase, methodStringString)'
+    name: 'apply(fields, matchCase, methodString)'
+    fullName: 'apply(fields, matchCase, methodString)'
     langs:
       - typeScript
     type: method
     syntax:
-      content: 'apply(fields: Excel.SortField[], matchCase?: boolean, methodStringString?: "PinYin" | "StrokeCount"): void;'
+      content: 'apply(fields: Excel.SortField[], matchCase?: boolean, methodString?: "PinYin" | "StrokeCount"): void;'
       return:
         type:
           - void
@@ -84,7 +84,7 @@ items:
           description: Optional. Whether to have the casing impact string ordering.
           type:
             - boolean
-        - id: methodStringString
+        - id: methodString
           description: Optional. The ordering method used for Chinese characters.
           type:
             - '"PinYin" | "StrokeCount"'

--- a/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excel/excel.worksheet.yml
@@ -173,7 +173,6 @@ items:
 
           ```typescript
           async function main(context: Excel.RequestContext) {
-
               let myWorkbook = context.workbook;
               let sampleSheet = myWorkbook.worksheets.getActiveWorksheet();
               let copiedSheet = sampleSheet.copy("End")
@@ -201,21 +200,21 @@ items:
             - 'excel!Excel.Worksheet:class'
   - uid: 'excel!Excel.Worksheet#copy:member(2)'
     summary: Copies a worksheet and places it at the specified position.
-    name: 'copy(positionTypeStringString, relativeTo)'
-    fullName: 'copy(positionTypeStringString, relativeTo)'
+    name: 'copy(positionTypeString, relativeTo)'
+    fullName: 'copy(positionTypeString, relativeTo)'
     langs:
       - typeScript
     type: method
     syntax:
       content: >-
-        copy(positionTypeStringString?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?:
-        Excel.Worksheet): Excel.Worksheet;
+        copy(positionTypeString?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?: Excel.Worksheet):
+        Excel.Worksheet;
       return:
         type:
           - 'excel!Excel.Worksheet:class'
         description: The newly created worksheet.
       parameters:
-        - id: positionTypeStringString
+        - id: positionTypeString
           description: >-
             The location in the workbook to place the newly created worksheet. The default value is "None", which
             inserts the worksheet at the beginning of the worksheet.

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -849,9 +849,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param calculationTypeStringString - Specifies the calculation type to use. See Excel.CalculationType for details.
+         * @param calculationTypeString - Specifies the calculation type to use. See Excel.CalculationType for details.
          */
-        calculate(calculationTypeStringString: "Recalculate" | "Full" | "FullRebuild"): void;
+        calculate(calculationTypeString: "Recalculate" | "Full" | "FullRebuild"): void;
         /**
          *
          * Suspends calculation until the next "context.sync()" is called. Once set, it is the developer's responsibility to re-calc the workbook, to ensure that any dependencies are propagated.
@@ -1579,11 +1579,11 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param positionTypeStringString - The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
+         * @param positionTypeString - The location in the workbook to place the newly created worksheet. The default value is "None", which inserts the worksheet at the beginning of the worksheet.
          * @param relativeTo - The existing worksheet which determines the newly created worksheet's position. This is only needed if `positionType` is "Before" or "After".
          * @returns The newly created worksheet.
          */
-        copy(positionTypeStringString?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?: Excel.Worksheet): Excel.Worksheet;
+        copy(positionTypeString?: "None" | "Before" | "After" | "Beginning" | "End", relativeTo?: Excel.Worksheet): Excel.Worksheet;
         /**
          *
          * Deletes the worksheet from the workbook. Note that if the worksheet's visibility is set to "VeryHidden", the delete operation will fail with an `InvalidOperation` exception. You should first change its visibility to hidden or visible before deleting it.
@@ -2382,9 +2382,9 @@ export declare namespace Excel {
          * 
          *
          * @param destinationRange - The destination range to autofill. If the destination range is null, data is filled out based on the surrounding cells (which is the behavior when double-clicking the UI’s range fill handle).
-         * @param autoFillTypeStringString - The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
+         * @param autoFillTypeString - The type of autofill. Specifies how the destination range is to be filled, based on the contents of the current range. Default is "FillDefault".
          */
-        autoFill(destinationRange?: Range | string, autoFillTypeStringString?: "FillDefault" | "FillCopy" | "FillSeries" | "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" | "GrowthTrend" | "FlashFill"): void;
+        autoFill(destinationRange?: Range | string, autoFillTypeString?: "FillDefault" | "FillCopy" | "FillSeries" | "FillFormats" | "FillValues" | "FillDays" | "FillWeekdays" | "FillMonths" | "FillYears" | "LinearTrend" | "GrowthTrend" | "FlashFill"): void;
         /**
          *
          * Calculates a range of cells on a worksheet.
@@ -2407,9 +2407,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param applyToStringString - Optional. Determines the type of clear action. See Excel.ClearApplyTo for details.
+         * @param applyToString - Optional. Determines the type of clear action. See Excel.ClearApplyTo for details.
          */
-        clear(applyToStringString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;
+        clear(applyToString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;
         /**
          *
          * Converts the range cells with datatypes into text.
@@ -2448,11 +2448,11 @@ export declare namespace Excel {
          * 
          *
          * @param sourceRange - The source range or RangeAreas to copy from. When the source RangeAreas has multiple ranges, their form must be able to be created by removing full rows or columns from a rectangular range.
-         * @param copyTypeStringString - The type of cell data or formatting to copy over. Default is "All".
+         * @param copyTypeString - The type of cell data or formatting to copy over. Default is "All".
          * @param skipBlanks - True if to skip blank cells in the source range. Default is false.
          * @param transpose - True if to transpose the cells in the destination range. Default is false.
          */
-        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeStringString?: "All" | "Formulas" | "Values" | "Formats", skipBlanks?: boolean, transpose?: boolean): void;
+        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeString?: "All" | "Formulas" | "Values" | "Formats", skipBlanks?: boolean, transpose?: boolean): void;
         /**
          *
          * Deletes the cells associated with the range.
@@ -2468,9 +2468,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param shiftStringString - Specifies which way to shift the cells. See Excel.DeleteShiftDirection for details.
+         * @param shiftString - Specifies which way to shift the cells. See Excel.DeleteShiftDirection for details.
          */
-        delete(shiftStringString: "Up" | "Left"): void;
+        delete(shiftString: "Up" | "Left"): void;
         /**
          *
          * Finds the given string based on the criteria specified.
@@ -2714,10 +2714,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param cellTypeStringString - The type of cells to include.
+         * @param cellTypeString - The type of cells to include.
          * @param cellValueType - If cellType is either Constants or Formulas, this argument is used to determine which types of cells to include in the result. These values can be combined together to return more than one type. The default is to select all constants or formulas, no matter what the type.
          */
-        getSpecialCells(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCells(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
         /**
          *
          * Gets the RangeAreas object, comprising one or more ranges, that represents all the cells that match the specified type and value.
@@ -2736,10 +2736,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param cellTypeStringString - The type of cells to include.
+         * @param cellTypeString - The type of cells to include.
          * @param cellValueType - If cellType is either Constants or Formulas, this argument is used to determine which types of cells to include in the result. These values can be combined together to return more than one type. The default is to select all constants or formulas, no matter what the type.
          */
-        getSpecialCellsOrNullObject(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCellsOrNullObject(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
         /**
          *
          * Returns a Range object that represents the surrounding region for the top-left cell in this range. A surrounding region is a range bounded by any combination of blank rows and blank columns relative to this range.
@@ -2799,12 +2799,12 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param groupOptionStringString - Specifies how the range can be grouped by rows or columns.
+         * @param groupOptionString - Specifies how the range can be grouped by rows or columns.
             An `InvalidArgument` error is thrown when the group option differs from the range's
             `isEntireRow` or `isEntireColumn` property (i.e., `range.isEntireRow` is true and `groupOption` is "ByColumns"
             or `range.isEntireColumn` is true and `groupOption` is "ByRows").
          */
-        group(groupOptionStringString: "ByRows" | "ByColumns"): void;
+        group(groupOptionString: "ByRows" | "ByColumns"): void;
         /**
          *
          * Hide details of the row or column group.
@@ -2820,9 +2820,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param groupOptionStringString - Specifies whether to hide details of grouped rows or grouped columns.
+         * @param groupOptionString - Specifies whether to hide details of grouped rows or grouped columns.
          */
-        hideGroupDetails(groupOptionStringString: "ByRows" | "ByColumns"): void;
+        hideGroupDetails(groupOptionString: "ByRows" | "ByColumns"): void;
         /**
          *
          * Inserts a cell or a range of cells into the worksheet in place of this range, and shifts the other cells to make space. Returns a new Range object at the now blank space.
@@ -2838,9 +2838,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param shiftStringString - Specifies which way to shift the cells. See Excel.InsertShiftDirection for details.
+         * @param shiftString - Specifies which way to shift the cells. See Excel.InsertShiftDirection for details.
          */
-        insert(shiftStringString: "Down" | "Right"): Excel.Range;
+        insert(shiftString: "Down" | "Right"): Excel.Range;
         /**
          *
          * Merge the range cells into one region in the worksheet.
@@ -2946,9 +2946,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param groupOptionStringString - Specifies whether to show details of grouped rows or grouped columns.
+         * @param groupOptionString - Specifies whether to show details of grouped rows or grouped columns.
          */
-        showGroupDetails(groupOptionStringString: "ByRows" | "ByColumns"): void;
+        showGroupDetails(groupOptionString: "ByRows" | "ByColumns"): void;
         /**
          *
          * Ungroups columns and rows for an outline.
@@ -2964,9 +2964,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param groupOptionStringString - Specifies how the range can be ungrouped by rows or columns.
+         * @param groupOptionString - Specifies how the range can be ungrouped by rows or columns.
          */
-        ungroup(groupOptionStringString: "ByRows" | "ByColumns"): void;
+        ungroup(groupOptionString: "ByRows" | "ByColumns"): void;
         /**
          *
          * Unmerge the range cells into separate cells.
@@ -3192,9 +3192,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param applyToStringString - Optional. Determines the type of clear action. See Excel.ClearApplyTo for details. Default is "All".
+         * @param applyToString - Optional. Determines the type of clear action. See Excel.ClearApplyTo for details. Default is "All".
          */
-        clear(applyToStringString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;
+        clear(applyToString?: "All" | "Formats" | "Contents" | "Hyperlinks" | "RemoveHyperlinks"): void;
         /**
          *
          * Converts all cells in the RangeAreas with datatypes into text.
@@ -3233,11 +3233,11 @@ export declare namespace Excel {
          * 
          *
          * @param sourceRange - The source range or RangeAreas to copy from. When the source RangeAreas has multiple ranges, their form must able to be created by removing full rows or columns from a rectangular range.
-         * @param copyTypeStringString - The type of cell data or formatting to copy over. Default is "All".
+         * @param copyTypeString - The type of cell data or formatting to copy over. Default is "All".
          * @param skipBlanks - True if to skip blank cells in the source range or RangeAreas. Default is false.
          * @param transpose - True if to transpose the cells in the destination RangeAreas. Default is false.
          */
-        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeStringString?: "All" | "Formulas" | "Values" | "Formats", skipBlanks?: boolean, transpose?: boolean): void;
+        copyFrom(sourceRange: Range | RangeAreas | string, copyTypeString?: "All" | "Formulas" | "Values" | "Formats", skipBlanks?: boolean, transpose?: boolean): void;
         /**
          *
          * Returns a RangeAreas object that represents the entire columns of the RangeAreas (for example, if the current RangeAreas represents cells "B4:E11, H2", it returns a RangeAreas that represents columns "B:E, H:H").
@@ -3296,10 +3296,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param cellTypeStringString - The type of cells to include.
+         * @param cellTypeString - The type of cells to include.
          * @param cellValueType - If cellType is either Constants or Formulas, this argument is used to determine which types of cells to include in the result. These values can be combined together to return more than one type. The default is to select all constants or formulas, no matter what the type.
          */
-        getSpecialCells(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCells(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
         /**
          *
          * Returns a RangeAreas object that represents all the cells that match the specified type and value. Returns a null object if no special cells are found that match the criteria.
@@ -3316,10 +3316,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param cellTypeStringString - The type of cells to include.
+         * @param cellTypeString - The type of cells to include.
          * @param cellValueType - If cellType is either Constants or Formulas, this argument is used to determine which types of cells to include in the result. These values can be combined together to return more than one type. The default is to select all constants or formulas, no matter what the type.
          */
-        getSpecialCellsOrNullObject(cellTypeStringString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
+        getSpecialCellsOrNullObject(cellTypeString: "ConditionalFormats" | "DataValidations" | "Blanks" | "Constants" | "Formulas" | "SameConditionalFormat" | "SameDataValidation" | "Visible", cellValueType?: "All" | "Errors" | "ErrorsLogical" | "ErrorsNumbers" | "ErrorsText" | "ErrorsLogicalNumber" | "ErrorsLogicalText" | "ErrorsNumberText" | "Logical" | "LogicalNumbers" | "LogicalText" | "LogicalNumbersText" | "Numbers" | "NumbersText" | "Text"): Excel.RangeAreas;
         /**
          *
          * Returns a scoped collection of tables that overlap with any range in this RangeAreas object.
@@ -4595,10 +4595,10 @@ export declare namespace Excel {
          * 
          *
          * @param range - Range to bind the binding to. May be an Excel Range object, or a string. If string, must contain the full address, including the sheet name
-         * @param bindingTypeStringString - Type of binding. See Excel.BindingType.
+         * @param bindingTypeString - Type of binding. See Excel.BindingType.
          * @param id - Name of binding.
          */
-        add(range: Range | string, bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;
+        add(range: Range | string, bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;
         /**
          *
          * Add a new binding based on a named item in the workbook.
@@ -4619,10 +4619,10 @@ export declare namespace Excel {
          * 
          *
          * @param name - Name from which to create binding.
-         * @param bindingTypeStringString - Type of binding. See Excel.BindingType.
+         * @param bindingTypeString - Type of binding. See Excel.BindingType.
          * @param id - Name of binding.
          */
-        addFromNamedItem(name: string, bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;
+        addFromNamedItem(name: string, bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;
         /**
          *
          * Add a new binding based on the current selection.
@@ -4641,10 +4641,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param bindingTypeStringString - Type of binding. See Excel.BindingType.
+         * @param bindingTypeString - Type of binding. See Excel.BindingType.
          * @param id - Name of binding.
          */
-        addFromSelection(bindingTypeStringString: "Range" | "Table" | "Text", id: string): Excel.Binding;
+        addFromSelection(bindingTypeString: "Range" | "Table" | "Text", id: string): Excel.Binding;
         /**
          *
          * Gets the number of bindings in the collection.
@@ -6315,9 +6315,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param indexStringString - Index value of the border object to be retrieved. See Excel.BorderIndex for details.
+         * @param indexString - Index value of the border object to be retrieved. See Excel.BorderIndex for details.
          */
-        getItem(indexStringString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight" | "InsideVertical" | "InsideHorizontal" | "DiagonalDown" | "DiagonalUp"): Excel.RangeBorder;
+        getItem(indexString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight" | "InsideVertical" | "InsideHorizontal" | "DiagonalDown" | "DiagonalUp"): Excel.RangeBorder;
         /**
          *
          * Gets a border object using its index.
@@ -6513,11 +6513,11 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param typeStringString - Represents the type of a chart. See Excel.ChartType for details.
+         * @param typeString - Represents the type of a chart. See Excel.ChartType for details.
          * @param sourceData - The Range object corresponding to the source data.
          * @param seriesBy - Optional. Specifies the way columns or rows are used as data series on the chart. See Excel.ChartSeriesBy for details.
          */
-        add(typeStringString: "Invalid" | "ColumnClustered" | "ColumnStacked" | "ColumnStacked100" | "3DColumnClustered" | "3DColumnStacked" | "3DColumnStacked100" | "BarClustered" | "BarStacked" | "BarStacked100" | "3DBarClustered" | "3DBarStacked" | "3DBarStacked100" | "LineStacked" | "LineStacked100" | "LineMarkers" | "LineMarkersStacked" | "LineMarkersStacked100" | "PieOfPie" | "PieExploded" | "3DPieExploded" | "BarOfPie" | "XYScatterSmooth" | "XYScatterSmoothNoMarkers" | "XYScatterLines" | "XYScatterLinesNoMarkers" | "AreaStacked" | "AreaStacked100" | "3DAreaStacked" | "3DAreaStacked100" | "DoughnutExploded" | "RadarMarkers" | "RadarFilled" | "Surface" | "SurfaceWireframe" | "SurfaceTopView" | "SurfaceTopViewWireframe" | "Bubble" | "Bubble3DEffect" | "StockHLC" | "StockOHLC" | "StockVHLC" | "StockVOHLC" | "CylinderColClustered" | "CylinderColStacked" | "CylinderColStacked100" | "CylinderBarClustered" | "CylinderBarStacked" | "CylinderBarStacked100" | "CylinderCol" | "ConeColClustered" | "ConeColStacked" | "ConeColStacked100" | "ConeBarClustered" | "ConeBarStacked" | "ConeBarStacked100" | "ConeCol" | "PyramidColClustered" | "PyramidColStacked" | "PyramidColStacked100" | "PyramidBarClustered" | "PyramidBarStacked" | "PyramidBarStacked100" | "PyramidCol" | "3DColumn" | "Line" | "3DLine" | "3DPie" | "Pie" | "XYScatter" | "3DArea" | "Area" | "Doughnut" | "Radar" | "Histogram" | "Boxwhisker" | "Pareto" | "RegionMap" | "Treemap" | "Waterfall" | "Sunburst" | "Funnel", sourceData: Range, seriesBy?: "Auto" | "Columns" | "Rows"): Excel.Chart;
+        add(typeString: "Invalid" | "ColumnClustered" | "ColumnStacked" | "ColumnStacked100" | "3DColumnClustered" | "3DColumnStacked" | "3DColumnStacked100" | "BarClustered" | "BarStacked" | "BarStacked100" | "3DBarClustered" | "3DBarStacked" | "3DBarStacked100" | "LineStacked" | "LineStacked100" | "LineMarkers" | "LineMarkersStacked" | "LineMarkersStacked100" | "PieOfPie" | "PieExploded" | "3DPieExploded" | "BarOfPie" | "XYScatterSmooth" | "XYScatterSmoothNoMarkers" | "XYScatterLines" | "XYScatterLinesNoMarkers" | "AreaStacked" | "AreaStacked100" | "3DAreaStacked" | "3DAreaStacked100" | "DoughnutExploded" | "RadarMarkers" | "RadarFilled" | "Surface" | "SurfaceWireframe" | "SurfaceTopView" | "SurfaceTopViewWireframe" | "Bubble" | "Bubble3DEffect" | "StockHLC" | "StockOHLC" | "StockVHLC" | "StockVOHLC" | "CylinderColClustered" | "CylinderColStacked" | "CylinderColStacked100" | "CylinderBarClustered" | "CylinderBarStacked" | "CylinderBarStacked100" | "CylinderCol" | "ConeColClustered" | "ConeColStacked" | "ConeColStacked100" | "ConeBarClustered" | "ConeBarStacked" | "ConeBarStacked100" | "ConeCol" | "PyramidColClustered" | "PyramidColStacked" | "PyramidColStacked100" | "PyramidBarClustered" | "PyramidBarStacked" | "PyramidBarStacked100" | "PyramidCol" | "3DColumn" | "Line" | "3DLine" | "3DPie" | "Pie" | "XYScatter" | "3DArea" | "Area" | "Doughnut" | "Radar" | "Histogram" | "Boxwhisker" | "Pareto" | "RegionMap" | "Treemap" | "Waterfall" | "Sunburst" | "Funnel", sourceData: Range, seriesBy?: "Auto" | "Columns" | "Rows"): Excel.Chart;
         /**
          *
          * Returns the number of charts in the worksheet.
@@ -6808,9 +6808,9 @@ export declare namespace Excel {
          *
          * @param height - (Optional) The desired height of the resulting image.
          * @param width - (Optional) The desired width of the resulting image.
-         * @param fittingModeStringString - (Optional) The method used to scale the chart to the specified to the specified dimensions (if both height and width are set).
+         * @param fittingModeString - (Optional) The method used to scale the chart to the specified to the specified dimensions (if both height and width are set).
          */
-        getImage(width?: number, height?: number, fittingModeStringString?: "Fit" | "FitAndCenter" | "Fill"): ClientResult<string>;
+        getImage(width?: number, height?: number, fittingModeString?: "Fit" | "FitAndCenter" | "Fill"): ClientResult<string>;
         /**
          *
          * Resets the source data for the chart.
@@ -6828,9 +6828,9 @@ export declare namespace Excel {
          * 
          *
          * @param sourceData - The range object corresponding to the source data.
-         * @param seriesByStringString - Specifies the way columns or rows are used as data series on the chart. Can be one of the following: Auto (default), Rows, and Columns. See Excel.ChartSeriesBy for details.
+         * @param seriesByString - Specifies the way columns or rows are used as data series on the chart. Can be one of the following: Auto (default), Rows, and Columns. See Excel.ChartSeriesBy for details.
          */
-        setData(sourceData: Range, seriesByStringString?: "Auto" | "Columns" | "Rows"): void;
+        setData(sourceData: Range, seriesByString?: "Auto" | "Columns" | "Rows"): void;
         /**
          *
          * Positions the chart relative to cells on the worksheet.
@@ -7859,10 +7859,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param typeStringString - Specifies the axis type. See Excel.ChartAxisType for details.
+         * @param typeString - Specifies the axis type. See Excel.ChartAxisType for details.
          * @param group - Optional. Specifies the axis group. See Excel.ChartAxisGroup for details.
          */
-        getItem(typeStringString: "Invalid" | "Category" | "Value" | "Series", group?: "Primary" | "Secondary"): Excel.ChartAxis;
+        getItem(typeString: "Invalid" | "Category" | "Value" | "Series", group?: "Primary" | "Secondary"): Excel.ChartAxis;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -10474,9 +10474,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param typeStringString - Specifies the trendline type. The default value is "Linear". See Excel.ChartTrendline for details.
+         * @param typeString - Specifies the trendline type. The default value is "Linear". See Excel.ChartTrendline for details.
          */
-        add(typeStringString?: "Linear" | "Exponential" | "Logarithmic" | "MovingAverage" | "Polynomial" | "Power"): Excel.ChartTrendline;
+        add(typeString?: "Linear" | "Exponential" | "Logarithmic" | "MovingAverage" | "Polynomial" | "Power"): Excel.ChartTrendline;
         /**
          *
          * Returns the number of trendlines in the collection.
@@ -11003,10 +11003,10 @@ export declare namespace Excel {
          * @param fields - The list of conditions to sort on.
          * @param matchCase - Optional. Whether to have the casing impact string ordering.
          * @param hasHeaders - Optional. Whether the range has a header.
-         * @param orientationStringString - Optional. Whether the operation is sorting rows or columns.
+         * @param orientationString - Optional. Whether the operation is sorting rows or columns.
          * @param method - Optional. The ordering method used for Chinese characters.
          */
-        apply(fields: Excel.SortField[], matchCase?: boolean, hasHeaders?: boolean, orientationStringString?: "Rows" | "Columns", method?: "PinYin" | "StrokeCount"): void;
+        apply(fields: Excel.SortField[], matchCase?: boolean, hasHeaders?: boolean, orientationString?: "Rows" | "Columns", method?: "PinYin" | "StrokeCount"): void;
         /**
         * Overrides the JavaScript `toJSON()` method in order to provide more useful output when an API object is passed to `JSON.stringify()`. (`JSON.stringify`, in turn, calls the `toJSON` method of the object that is passed to it.)
         * Whereas the original Excel.RangeSort object is an API object, the `toJSON` method returns a plain JavaScript object (typed as `Excel.Interfaces.RangeSortData`) that contains shallow copies of any loaded child properties from the original object.
@@ -11064,9 +11064,9 @@ export declare namespace Excel {
          *
          * @param fields - The list of conditions to sort on.
          * @param matchCase - Optional. Whether to have the casing impact string ordering.
-         * @param methodStringString - Optional. The ordering method used for Chinese characters.
+         * @param methodString - Optional. The ordering method used for Chinese characters.
          */
-        apply(fields: Excel.SortField[], matchCase?: boolean, methodStringString?: "PinYin" | "StrokeCount"): void;
+        apply(fields: Excel.SortField[], matchCase?: boolean, methodString?: "PinYin" | "StrokeCount"): void;
         /**
          *
          * Clears the sorting that is currently on the table. While this doesn't modify the table's ordering, it clears the state of the header buttons.
@@ -11236,9 +11236,9 @@ export declare namespace Excel {
          *
          * @param criteria1 - The first criteria string.
          * @param criteria2 - Optional. The second criteria string.
-         * @param operStringString - Optional. The operator that describes how the two criteria are joined.
+         * @param operString - Optional. The operator that describes how the two criteria are joined.
          */
-        applyCustomFilter(criteria1: string, criteria2?: string, operStringString?: "And" | "Or"): void;
+        applyCustomFilter(criteria1: string, criteria2?: string, operString?: "And" | "Or"): void;
         /**
          *
          * Apply a "Dynamic" filter to the column.
@@ -11254,9 +11254,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param criteriaStringString - The dynamic criteria to apply.
+         * @param criteriaString - The dynamic criteria to apply.
          */
-        applyDynamicFilter(criteriaStringString: "Unknown" | "AboveAverage" | "AllDatesInPeriodApril" | "AllDatesInPeriodAugust" | "AllDatesInPeriodDecember" | "AllDatesInPeriodFebruray" | "AllDatesInPeriodJanuary" | "AllDatesInPeriodJuly" | "AllDatesInPeriodJune" | "AllDatesInPeriodMarch" | "AllDatesInPeriodMay" | "AllDatesInPeriodNovember" | "AllDatesInPeriodOctober" | "AllDatesInPeriodQuarter1" | "AllDatesInPeriodQuarter2" | "AllDatesInPeriodQuarter3" | "AllDatesInPeriodQuarter4" | "AllDatesInPeriodSeptember" | "BelowAverage" | "LastMonth" | "LastQuarter" | "LastWeek" | "LastYear" | "NextMonth" | "NextQuarter" | "NextWeek" | "NextYear" | "ThisMonth" | "ThisQuarter" | "ThisWeek" | "ThisYear" | "Today" | "Tomorrow" | "YearToDate" | "Yesterday"): void;
+        applyDynamicFilter(criteriaString: "Unknown" | "AboveAverage" | "AllDatesInPeriodApril" | "AllDatesInPeriodAugust" | "AllDatesInPeriodDecember" | "AllDatesInPeriodFebruray" | "AllDatesInPeriodJanuary" | "AllDatesInPeriodJuly" | "AllDatesInPeriodJune" | "AllDatesInPeriodMarch" | "AllDatesInPeriodMay" | "AllDatesInPeriodNovember" | "AllDatesInPeriodOctober" | "AllDatesInPeriodQuarter1" | "AllDatesInPeriodQuarter2" | "AllDatesInPeriodQuarter3" | "AllDatesInPeriodQuarter4" | "AllDatesInPeriodSeptember" | "BelowAverage" | "LastMonth" | "LastQuarter" | "LastWeek" | "LastYear" | "NextMonth" | "NextQuarter" | "NextWeek" | "NextYear" | "ThisMonth" | "ThisQuarter" | "ThisWeek" | "ThisYear" | "Today" | "Tomorrow" | "YearToDate" | "Yesterday"): void;
         /**
          *
          * Apply a "Font Color" filter to the column for the given color.
@@ -12131,11 +12131,11 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param axisStringString - The axis from which to get the PivotItems. Must be either "row" or "column."
+         * @param axisString - The axis from which to get the PivotItems. Must be either "row" or "column."
          * @param cell - A single cell within the PivotTable's data body.
          * @returns A collection of PivotItems that are used to calculate the values in the specified row.
          */
-        getPivotItems(axisStringString: "Unknown" | "Row" | "Column" | "Data" | "Filter", cell: Range | string): ClientResult<Excel.PivotItem[]>;
+        getPivotItems(axisString: "Unknown" | "Row" | "Column" | "Data" | "Filter", cell: Range | string): ClientResult<Excel.PivotItem[]>;
         /**
          *
          * Returns the range the PivotTable exists on, excluding the filter area.
@@ -12167,9 +12167,9 @@ export declare namespace Excel {
          * 
          *
          * @param cell - A single cell to use get the criteria from for applying the autosort.
-         * @param sortByStringString - The direction of the sort.
+         * @param sortByString - The direction of the sort.
          */
-        setAutoSortOnCell(cell: Range | string, sortByStringString: "Ascending" | "Descending"): void;
+        setAutoSortOnCell(cell: Range | string, sortByString: "Ascending" | "Descending"): void;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -13010,14 +13010,14 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param sortByStringString - Represents whether the sorting is done in an ascending or descending order.
+         * @param sortByString - Represents whether the sorting is done in an ascending or descending order.
          * @param valuesHierarchy - Specifies the values hierarchy on the data axis to be used for sorting.
          * @param pivotItemScope - The items that should be used for the scope of the sorting. These will be the
             items that make up the row or column that you want to sort on. If a string is used instead of a PivotItem,
             the string represents the ID of the PivotItem. If there are no items other than data hierarchy on the axis
             you want to sort on, this can be empty.
          */
-        sortByValues(sortByStringString: "Ascending" | "Descending", valuesHierarchy: Excel.DataPivotHierarchy, pivotItemScope?: Array<PivotItem | string>): void;
+        sortByValues(sortByString: "Ascending" | "Descending", valuesHierarchy: Excel.DataPivotHierarchy, pivotItemScope?: Array<PivotItem | string>): void;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *
@@ -13788,9 +13788,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param typeStringString - The type of conditional format being added. See Excel.ConditionalFormatType for details.
+         * @param typeString - The type of conditional format being added. See Excel.ConditionalFormatType for details.
          */
-        add(typeStringString: "Custom" | "DataBar" | "ColorScale" | "IconSet" | "TopBottom" | "PresetCriteria" | "ContainsText" | "CellValue"): Excel.ConditionalFormat;
+        add(typeString: "Custom" | "DataBar" | "ColorScale" | "IconSet" | "TopBottom" | "PresetCriteria" | "ContainsText" | "CellValue"): Excel.ConditionalFormat;
         /**
          *
          * Clears all conditional formats active on the current specified range.
@@ -15441,9 +15441,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param indexStringString - Index value of the border object to be retrieved. See Excel.ConditionalRangeBorderIndex for details.
+         * @param indexString - Index value of the border object to be retrieved. See Excel.ConditionalRangeBorderIndex for details.
          */
-        getItem(indexStringString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"): Excel.ConditionalRangeBorder;
+        getItem(indexString: "EdgeTop" | "EdgeBottom" | "EdgeLeft" | "EdgeRight"): Excel.ConditionalRangeBorder;
         /**
          *
          * Gets a border object using its index.
@@ -16671,10 +16671,10 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param unitStringString - Measurement unit for the margins provided.
+         * @param unitString - Measurement unit for the margins provided.
          * @param marginOptions - Margin values to set, margins not provided will remain unchanged.
          */
-        setPrintMargins(unitStringString: "Points" | "Inches" | "Centimeters", marginOptions: Excel.PageLayoutMarginOptions): void;
+        setPrintMargins(unitString: "Points" | "Inches" | "Centimeters", marginOptions: Excel.PageLayoutMarginOptions): void;
         /**
          *
          * Sets the columns that contain the cells to be repeated at the left of each page of the worksheet for printing.
@@ -17262,9 +17262,9 @@ export declare namespace Excel {
          *
          * @param cellAddress - The cell to which the comment is added. This can be a Range object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          * @param content - The comment's content. This can be either a string or CommentRichContent object. Strings are used for plain text. CommentRichContent objects allow for other comment features, such as mentions. 
-         * @param contentTypeStringString - Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
+         * @param contentTypeString - Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
          */
-        add(cellAddress: Range | string, content: CommentRichContent | string, contentTypeStringString?: "Plain" | "Mention"): Excel.Comment;
+        add(cellAddress: Range | string, content: CommentRichContent | string, contentTypeString?: "Plain" | "Mention"): Excel.Comment;
         /**
          *
          * Gets the number of comments in the collection.
@@ -17489,9 +17489,9 @@ export declare namespace Excel {
          * 
          *
          * @param content - The comment's content. This can be either a string or Interface CommentRichContent (e.g. for comments with mentions). 
-         * @param contentTypeStringString - Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
+         * @param contentTypeString - Optional. The type of content contained within the comment. The default value is enum `ContentType.Plain`. 
          */
-        add(content: CommentRichContent | string, contentTypeStringString?: "Plain" | "Mention"): Excel.CommentReply;
+        add(content: CommentRichContent | string, contentTypeString?: "Plain" | "Mention"): Excel.CommentReply;
         /**
          *
          * Gets the number of comment replies in the collection.
@@ -17696,9 +17696,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param geometricShapeTypeStringString - Represents the type of the geometric shape. See Excel.GeometricShapeType for details.
+         * @param geometricShapeTypeString - Represents the type of the geometric shape. See Excel.GeometricShapeType for details.
          */
-        addGeometricShape(geometricShapeTypeStringString: "LineInverse" | "Triangle" | "RightTriangle" | "Rectangle" | "Diamond" | "Parallelogram" | "Trapezoid" | "NonIsoscelesTrapezoid" | "Pentagon" | "Hexagon" | "Heptagon" | "Octagon" | "Decagon" | "Dodecagon" | "Star4" | "Star5" | "Star6" | "Star7" | "Star8" | "Star10" | "Star12" | "Star16" | "Star24" | "Star32" | "RoundRectangle" | "Round1Rectangle" | "Round2SameRectangle" | "Round2DiagonalRectangle" | "SnipRoundRectangle" | "Snip1Rectangle" | "Snip2SameRectangle" | "Snip2DiagonalRectangle" | "Plaque" | "Ellipse" | "Teardrop" | "HomePlate" | "Chevron" | "PieWedge" | "Pie" | "BlockArc" | "Donut" | "NoSmoking" | "RightArrow" | "LeftArrow" | "UpArrow" | "DownArrow" | "StripedRightArrow" | "NotchedRightArrow" | "BentUpArrow" | "LeftRightArrow" | "UpDownArrow" | "LeftUpArrow" | "LeftRightUpArrow" | "QuadArrow" | "LeftArrowCallout" | "RightArrowCallout" | "UpArrowCallout" | "DownArrowCallout" | "LeftRightArrowCallout" | "UpDownArrowCallout" | "QuadArrowCallout" | "BentArrow" | "UturnArrow" | "CircularArrow" | "LeftCircularArrow" | "LeftRightCircularArrow" | "CurvedRightArrow" | "CurvedLeftArrow" | "CurvedUpArrow" | "CurvedDownArrow" | "SwooshArrow" | "Cube" | "Can" | "LightningBolt" | "Heart" | "Sun" | "Moon" | "SmileyFace" | "IrregularSeal1" | "IrregularSeal2" | "FoldedCorner" | "Bevel" | "Frame" | "HalfFrame" | "Corner" | "DiagonalStripe" | "Chord" | "Arc" | "LeftBracket" | "RightBracket" | "LeftBrace" | "RightBrace" | "BracketPair" | "BracePair" | "Callout1" | "Callout2" | "Callout3" | "AccentCallout1" | "AccentCallout2" | "AccentCallout3" | "BorderCallout1" | "BorderCallout2" | "BorderCallout3" | "AccentBorderCallout1" | "AccentBorderCallout2" | "AccentBorderCallout3" | "WedgeRectCallout" | "WedgeRRectCallout" | "WedgeEllipseCallout" | "CloudCallout" | "Cloud" | "Ribbon" | "Ribbon2" | "EllipseRibbon" | "EllipseRibbon2" | "LeftRightRibbon" | "VerticalScroll" | "HorizontalScroll" | "Wave" | "DoubleWave" | "Plus" | "FlowChartProcess" | "FlowChartDecision" | "FlowChartInputOutput" | "FlowChartPredefinedProcess" | "FlowChartInternalStorage" | "FlowChartDocument" | "FlowChartMultidocument" | "FlowChartTerminator" | "FlowChartPreparation" | "FlowChartManualInput" | "FlowChartManualOperation" | "FlowChartConnector" | "FlowChartPunchedCard" | "FlowChartPunchedTape" | "FlowChartSummingJunction" | "FlowChartOr" | "FlowChartCollate" | "FlowChartSort" | "FlowChartExtract" | "FlowChartMerge" | "FlowChartOfflineStorage" | "FlowChartOnlineStorage" | "FlowChartMagneticTape" | "FlowChartMagneticDisk" | "FlowChartMagneticDrum" | "FlowChartDisplay" | "FlowChartDelay" | "FlowChartAlternateProcess" | "FlowChartOffpageConnector" | "ActionButtonBlank" | "ActionButtonHome" | "ActionButtonHelp" | "ActionButtonInformation" | "ActionButtonForwardNext" | "ActionButtonBackPrevious" | "ActionButtonEnd" | "ActionButtonBeginning" | "ActionButtonReturn" | "ActionButtonDocument" | "ActionButtonSound" | "ActionButtonMovie" | "Gear6" | "Gear9" | "Funnel" | "MathPlus" | "MathMinus" | "MathMultiply" | "MathDivide" | "MathEqual" | "MathNotEqual" | "CornerTabs" | "SquareTabs" | "PlaqueTabs" | "ChartX" | "ChartStar" | "ChartPlus"): Excel.Shape;
+        addGeometricShape(geometricShapeTypeString: "LineInverse" | "Triangle" | "RightTriangle" | "Rectangle" | "Diamond" | "Parallelogram" | "Trapezoid" | "NonIsoscelesTrapezoid" | "Pentagon" | "Hexagon" | "Heptagon" | "Octagon" | "Decagon" | "Dodecagon" | "Star4" | "Star5" | "Star6" | "Star7" | "Star8" | "Star10" | "Star12" | "Star16" | "Star24" | "Star32" | "RoundRectangle" | "Round1Rectangle" | "Round2SameRectangle" | "Round2DiagonalRectangle" | "SnipRoundRectangle" | "Snip1Rectangle" | "Snip2SameRectangle" | "Snip2DiagonalRectangle" | "Plaque" | "Ellipse" | "Teardrop" | "HomePlate" | "Chevron" | "PieWedge" | "Pie" | "BlockArc" | "Donut" | "NoSmoking" | "RightArrow" | "LeftArrow" | "UpArrow" | "DownArrow" | "StripedRightArrow" | "NotchedRightArrow" | "BentUpArrow" | "LeftRightArrow" | "UpDownArrow" | "LeftUpArrow" | "LeftRightUpArrow" | "QuadArrow" | "LeftArrowCallout" | "RightArrowCallout" | "UpArrowCallout" | "DownArrowCallout" | "LeftRightArrowCallout" | "UpDownArrowCallout" | "QuadArrowCallout" | "BentArrow" | "UturnArrow" | "CircularArrow" | "LeftCircularArrow" | "LeftRightCircularArrow" | "CurvedRightArrow" | "CurvedLeftArrow" | "CurvedUpArrow" | "CurvedDownArrow" | "SwooshArrow" | "Cube" | "Can" | "LightningBolt" | "Heart" | "Sun" | "Moon" | "SmileyFace" | "IrregularSeal1" | "IrregularSeal2" | "FoldedCorner" | "Bevel" | "Frame" | "HalfFrame" | "Corner" | "DiagonalStripe" | "Chord" | "Arc" | "LeftBracket" | "RightBracket" | "LeftBrace" | "RightBrace" | "BracketPair" | "BracePair" | "Callout1" | "Callout2" | "Callout3" | "AccentCallout1" | "AccentCallout2" | "AccentCallout3" | "BorderCallout1" | "BorderCallout2" | "BorderCallout3" | "AccentBorderCallout1" | "AccentBorderCallout2" | "AccentBorderCallout3" | "WedgeRectCallout" | "WedgeRRectCallout" | "WedgeEllipseCallout" | "CloudCallout" | "Cloud" | "Ribbon" | "Ribbon2" | "EllipseRibbon" | "EllipseRibbon2" | "LeftRightRibbon" | "VerticalScroll" | "HorizontalScroll" | "Wave" | "DoubleWave" | "Plus" | "FlowChartProcess" | "FlowChartDecision" | "FlowChartInputOutput" | "FlowChartPredefinedProcess" | "FlowChartInternalStorage" | "FlowChartDocument" | "FlowChartMultidocument" | "FlowChartTerminator" | "FlowChartPreparation" | "FlowChartManualInput" | "FlowChartManualOperation" | "FlowChartConnector" | "FlowChartPunchedCard" | "FlowChartPunchedTape" | "FlowChartSummingJunction" | "FlowChartOr" | "FlowChartCollate" | "FlowChartSort" | "FlowChartExtract" | "FlowChartMerge" | "FlowChartOfflineStorage" | "FlowChartOnlineStorage" | "FlowChartMagneticTape" | "FlowChartMagneticDisk" | "FlowChartMagneticDrum" | "FlowChartDisplay" | "FlowChartDelay" | "FlowChartAlternateProcess" | "FlowChartOffpageConnector" | "ActionButtonBlank" | "ActionButtonHome" | "ActionButtonHelp" | "ActionButtonInformation" | "ActionButtonForwardNext" | "ActionButtonBackPrevious" | "ActionButtonEnd" | "ActionButtonBeginning" | "ActionButtonReturn" | "ActionButtonDocument" | "ActionButtonSound" | "ActionButtonMovie" | "Gear6" | "Gear9" | "Funnel" | "MathPlus" | "MathMinus" | "MathMultiply" | "MathDivide" | "MathEqual" | "MathNotEqual" | "CornerTabs" | "SquareTabs" | "PlaqueTabs" | "ChartX" | "ChartStar" | "ChartPlus"): Excel.Shape;
         /**
          *
          * Groups a subset of shapes in this collection's worksheet. Returns a Shape object that represents the new group of shapes.
@@ -17740,9 +17740,9 @@ export declare namespace Excel {
          * @param startTop - The distance, in points, from the start of the line to the top of the worksheet.
          * @param endLeft - The distance, in points, from the end of the line to the left of the worksheet.
          * @param endTop - The distance, in points, from the end of the line to the top of the worksheet.
-         * @param connectorTypeStringString - Represents the connector type. See Excel.ConnectorType for details.
+         * @param connectorTypeString - Represents the connector type. See Excel.ConnectorType for details.
          */
-        addLine(startLeft: number, startTop: number, endLeft: number, endTop: number, connectorTypeStringString?: "Straight" | "Elbow" | "Curve"): Excel.Shape;
+        addLine(startLeft: number, startTop: number, endLeft: number, endTop: number, connectorTypeString?: "Straight" | "Elbow" | "Curve"): Excel.Shape;
         /**
          *
          * Adds a text box to the worksheet with the provided text as the content. Returns a Shape object that represents the new text box.
@@ -18036,9 +18036,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param formatStringString - Specifies the format of the image.
+         * @param formatString - Specifies the format of the image.
          */
-        getAsImage(formatStringString: "UNKNOWN" | "BMP" | "JPEG" | "GIF" | "PNG" | "SVG"): ClientResult<string>;
+        getAsImage(formatString: "UNKNOWN" | "BMP" | "JPEG" | "GIF" | "PNG" | "SVG"): ClientResult<string>;
         /**
          *
          * Moves the shape horizontally by the specified number of points.
@@ -18085,10 +18085,10 @@ export declare namespace Excel {
          * 
          *
          * @param scaleFactor - Specifies the ratio between the height of the shape after you resize it and the current or original height.
-         * @param scaleTypeStringString - Specifies whether the shape is scaled relative to its original or current size. The original size scaling option only works for images.
+         * @param scaleTypeString - Specifies whether the shape is scaled relative to its original or current size. The original size scaling option only works for images.
          * @param scaleFrom - Optional. Specifies which part of the shape retains its position when the shape is scaled. If omitted, it represents the shape's upper left corner retains its position.
          */
-        scaleHeight(scaleFactor: number, scaleTypeStringString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
+        scaleHeight(scaleFactor: number, scaleTypeString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
         /**
          *
          * Scales the width of the shape by a specified factor. For images, you can indicate whether you want to scale the shape relative to the original or the current size. Shapes other than pictures are always scaled relative to their current width.
@@ -18107,10 +18107,10 @@ export declare namespace Excel {
          * 
          *
          * @param scaleFactor - Specifies the ratio between the width of the shape after you resize it and the current or original width.
-         * @param scaleTypeStringString - Specifies whether the shape is scaled relative to its original or current size. The original size scaling option only works for images.
+         * @param scaleTypeString - Specifies whether the shape is scaled relative to its original or current size. The original size scaling option only works for images.
          * @param scaleFrom - Optional. Specifies which part of the shape retains its position when the shape is scaled. If omitted, it represents the shape's upper left corner retains its position.
          */
-        scaleWidth(scaleFactor: number, scaleTypeStringString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
+        scaleWidth(scaleFactor: number, scaleTypeString: "CurrentSize" | "OriginalSize", scaleFrom?: "ScaleFromTopLeft" | "ScaleFromMiddle" | "ScaleFromBottomRight"): void;
         /**
          *
          * Moves the specified shape up or down the collection's z-order, which shifts it in front of or behind other shapes.
@@ -18126,9 +18126,9 @@ export declare namespace Excel {
          *
          * 
          *
-         * @param positionStringString - Where to move the shape in the z-order stack relative to the other shapes. See Excel.ShapeZOrder for details.
+         * @param positionString - Where to move the shape in the z-order stack relative to the other shapes. See Excel.ShapeZOrder for details.
          */
-        setZOrder(positionStringString: "BringToFront" | "BringForward" | "SendToBack" | "SendBackward"): void;
+        setZOrder(positionString: "BringToFront" | "BringForward" | "SendToBack" | "SendBackward"): void;
         /**
          * Queues up a command to load the specified properties of the object. You must call `context.sync()` before reading the properties.
          *

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -10,7 +10,7 @@ tryCatch(async () => {
     // Display prompt
     // ----
     console.log('\n\n');
-    // TODO: Add CDN edipoint link
+    // TODO: Add CDN endpoint link
     // const urlToCopyOfficeJsFrom = await promptFromList({
     //     message: `What is the source of the Office-js TypeScript definition file that should be used to generate the Excel Script docs?`,
     //     choices: [
@@ -28,7 +28,7 @@ tryCatch(async () => {
     let releaseDefinitions = cleanUpDts(localReleaseDtsPath);
 
     console.log("\ncreate file: excel.d.ts (preview)");
-    fsx.writeFileSync('../api-extractor-inputs-excel/excel.d.ts', handleLiteralParameterOverloads(releaseDefinitions));
+    fsx.writeFileSync('../api-extractor-inputs-excel/excel.d.ts', releaseDefinitions);
 
     // TODO: Deal with Script Lab snippets
     // ----
@@ -110,28 +110,29 @@ function applyRegularExpressions (definitionsIn) {
         .replace(/(\s*)(@param)(\s+)(\w+)(\s+)([^\-])/g, `$1$2$3$4$5- $6`);
 }
 
-function handleLiteralParameterOverloads(dtsString: string): string {
-    // rename parameters for string literal overloads
-    const matches = dtsString.match(/([a-zA-Z]+)\??: (\"[a-zA-Z]*\").*:/g);
-    let matchIndex = 0;
-    matches.forEach((match) => {
-        let parameterName = match.substring(0, match.indexOf(": "));
-        matchIndex = dtsString.indexOf(match, matchIndex);
-        parameterName = parameterName.indexOf("?") >= 0 ? parameterName.substring(0, parameterName.length - 1) : parameterName;
-        const parameterString = "@param " + parameterName + " ";
-        const index = dtsString.lastIndexOf(parameterString, matchIndex);
-        if (index < 0) {
-            console.warn("Missing @param for literal parameter: " + match);
-        } else {
-        dtsString = dtsString.substring(0, index)
-         + "@param " + parameterName + "String "
-         + dtsString.substring(index + parameterString.length);
-         matchIndex += match.length;
-        }
-    });
+// TODO: Use once d.ts file is pulled from CDN
+// function handleLiteralParameterOverloads(dtsString: string): string {
+//     // rename parameters for string literal overloads
+//     const matches = dtsString.match(/([a-zA-Z]+)\??: (\"[a-zA-Z]*\").*:/g);
+//     let matchIndex = 0;
+//     matches.forEach((match) => {
+//         let parameterName = match.substring(0, match.indexOf(": "));
+//         matchIndex = dtsString.indexOf(match, matchIndex);
+//         parameterName = parameterName.indexOf("?") >= 0 ? parameterName.substring(0, parameterName.length - 1) : parameterName;
+//         const parameterString = "@param " + parameterName + " ";
+//         const index = dtsString.lastIndexOf(parameterString, matchIndex);
+//         if (index < 0) {
+//             console.warn("Missing @param for literal parameter: " + match);
+//         } else {
+//         dtsString = dtsString.substring(0, index)
+//          + "@param " + parameterName + "String "
+//          + dtsString.substring(index + parameterString.length);
+//          matchIndex += match.length;
+//         }
+//     });
 
-    return dtsString.replace(/([a-zA-Z]+)(\??: \"[a-zA-Z]*\".*:)/g, "$1String$2");
-}
+//     return dtsString.replace(/([a-zA-Z]+)(\??: \"[a-zA-Z]*\".*:)/g, "$1String$2");
+// }
 
 async function tryCatch(call: () => Promise<void>) {
     try {


### PR DESCRIPTION
Because we're using a version of the d.ts that already has the literal parameter overloads renamed, the preprocessor was adding an unnecessary "String" suffix to some parameter names.