### PR TITLE
[tooling] Declaring samples as TypeScript

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.commentrichcontent.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.commentrichcontent.yml
@@ -42,7 +42,7 @@ properties:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample finds overdue work items in a table and 
            * lets their owners know with a comment that uses an @mention.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.deleteshiftdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.deleteshiftdirection.yml
@@ -9,7 +9,7 @@ remarks: |-
 
   #### Examples
 
-  ```javascript
+  ```TypeScript
   /**
    * This sample creates a sample range, then deletes
    * "A1" using different DeleteShiftDirection values.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayout.yml
@@ -39,7 +39,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample finds the first PivotTable in the workbook and logs the values in the "Grand Total" cells.
            */

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -30,7 +30,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample applies conditional formatting to the currently used range in the worksheet. 
            * The conditional formatting is a green fill for the top 10% of values.
@@ -116,7 +116,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script removes all the formatting from the selected range.
            */
@@ -214,7 +214,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample creates a sample range, then deletes
            * "A1" using different DeleteShiftDirection values.
@@ -426,7 +426,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample provides the count of negative numbers that are present
            * in the used range of the current worksheet.
@@ -569,7 +569,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script creates a drop-down selection list for a cell. It uses the existing values of the selected range as the choices for the list.
            */
@@ -709,7 +709,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /*
            * This script sets a cell's formula, 
            * then displays how Excel stores the cell's formula and value separately.
@@ -1114,7 +1114,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script gets adjacent cells using relative references.
            * Note that if the active cell is on the top row, part of the script fails, 
@@ -1236,7 +1236,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script copies the formatting in the active cell to the neighboring cells.
            * Note that this script only works when the active cell isn't on an edge of the worksheet.
@@ -1292,7 +1292,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample provides the count of negative numbers that are present
            * in the used range of the current worksheet.
@@ -1451,7 +1451,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample gets all the blank cells in the current worksheet's used range. It then highlights all those cells with a yellow background.
            */
@@ -1614,7 +1614,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample reads the value of A1 and prints it to the console.
            */
@@ -1927,7 +1927,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /*
            * This script sets a cell's formula, 
            * then displays how Excel stores the cell's formula and value separately.
@@ -2061,7 +2061,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /** 
            * This script inserts a hyperlink to the first cell of the last worksheet in the workbook.
            */
@@ -2246,7 +2246,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample inserts some pre-loaded data into a range.
            * It also shows how to get a range that fits the data.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shape.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shape.yml
@@ -201,7 +201,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
           * This script transfers an image from one worksheet to another.
           */

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.tablesort.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.tablesort.yml
@@ -41,7 +41,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample creates a table from the current worksheet's used range, then sorts it based on the first column.
            */

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomconditionalformat.yml
@@ -56,7 +56,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample applies conditional formatting to the currently used range in the worksheet. 
            * The conditional formatting is a green fill for the top 10% of values.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
@@ -460,7 +460,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script logs the value of the current active cell. 
            * If multiple cells are selected, the top-leftmost cell will be logged.
@@ -1249,7 +1249,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script logs the names of all the worksheets in the workbook.
            */

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
@@ -380,7 +380,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample creates a table from the current worksheet's used range, then sorts it based on the first column.
            */
@@ -525,7 +525,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * The following scripts removes the first worksheet in the workbook.
            */
@@ -824,7 +824,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample gets all the worksheet names in the workbook.
            * It then logs those names to the console.
@@ -1038,7 +1038,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This sample reads the value of A1 and prints it to the console.
            */
@@ -1538,7 +1538,7 @@ methods:
 
           #### Examples
 
-          ```javascript
+          ```TypeScript
           /**
            * This script sets the tab color of every worksheet in the workbook to red.
            */

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -497,9 +497,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "make-error": {
       "version": "1.3.6",

--- a/generate-docs/scripts/package.json
+++ b/generate-docs/scripts/package.json
@@ -25,6 +25,6 @@
     "inquirer": "^7.0.0",
     "isomorphic-fetch": "^3.0.0",
     "js-yaml": "3.13.1",
-    "lodash": "4.17.19"
+    "lodash": "^4.17.21"
   }
 }

--- a/generate-docs/scripts/postprocessor.ts
+++ b/generate-docs/scripts/postprocessor.ts
@@ -65,6 +65,26 @@ tryCatch(async () => {
             );
     });
 
+    // correct the language from javascript to TypeScript
+    fsx.readdirSync(docsDestination)
+        .filter(topLevel => topLevel.indexOf(".") < 0)
+        .forEach(topLevel => { // contents of docs-ref-autogen
+            let hostFolder = docsDestination + '/' + topLevel;
+            fsx.readdirSync(hostFolder)
+                .filter(subfilename => subfilename.indexOf(".") < 0)
+                .forEach(subfilename => { // contents of docs-ref-autogen/<host>
+                    let scriptFolder = hostFolder + '/' + subfilename;
+                    fsx.readdirSync(scriptFolder)
+                        .filter(interfaceYml => interfaceYml.indexOf(".yml") >= 0)
+                        .forEach(interfaceYml => { // contents of docs-ref-autogen/<host>/<host>script
+                        fsx.writeFileSync(
+                            scriptFolder + '/' + interfaceYml,
+                            fsx.readFileSync(scriptFolder + '/' + interfaceYml).toString().replace(/```(javascript)/g, "```TypeScript")
+                        );
+                    });
+                });
+        });
+
     // fix all the individual TOC files
     console.log("Writing TOC for Office Scripts");
     let versionPath = path.resolve(`${docsDestination}/excel`);


### PR DESCRIPTION
The API Documenter uses a very simple to see if a sample is TypeScript or JavaScript: it looks for an `await` statement. Because Office Scripts code is synchronous, `await` statements are not present. However, the language choice in Office Scripts is explicitly TypeScript, and never JavaScript.

This PR makes the postprocessor manually change the JavaScript declarations before code blocks to TypeScript declarations.