### PR TITLE
[tools] (coverage tester) Fix content coverage tool to catch other places examples are inserted

### DIFF
--- a/generate-docs/tools/coverage-tester.ts
+++ b/generate-docs/tools/coverage-tester.ts
@@ -193,7 +193,10 @@ function rateClassDescription(classYml: ApiYaml) : CoverageRating {
 
 function rateFieldDescription(fieldYml: ApiPropertyYaml | ApiMethodYaml) : CoverageRating {
     let rating : CoverageRating;
-    let indexOfExample = fieldYml.syntax.return.description?.indexOf("#### Examples");
+    let indexOfExample = Math.max(
+        fieldYml.remarks?.indexOf("#### Examples"), 
+        fieldYml.syntax.return.description?.indexOf("#### Examples")
+    );
     
     if (indexOfExample > 0) {
         rating = {


### PR DESCRIPTION
Same fix as: https://github.com/OfficeDev/office-js-docs-reference/pull/1029

There are no changes to the .csv because Office Scripts only uses methods.