### PR TITLE
[samples] (Range) Adding relative positioning samples

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
@@ -4,7 +4,30 @@ uid: 'ExcelScript!ExcelScript.KeyboardDirection:enum'
 package: ExcelScript!
 fullName: ExcelScript.KeyboardDirection
 summary: ''
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script makes the the font bold on all the contiguous cells between 
+   * A1 and the bottom of the used range of the first column.
+   */
+  function main(workbook: ExcelScript.Workbook)
+  {
+    // Get the current worksheet.
+    let selectedSheet = workbook.getActiveWorksheet();
+
+    // Get every cell that's used between A1 and the end of the column.
+    // This recreates the Ctrl+Shift+Down arrow key behavior.
+    let firstCell = selectedSheet.getRange("A1")
+    let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+    // Set the font to bold in that range.
+    firstColumn.getFormat().getFont().setBold(true);
+  }
+  ```
 isPreview: false
 isDeprecated: false
 fields:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
@@ -11,7 +11,7 @@ remarks: |-
 
   ```TypeScript
   /**
-   * This script makes the the font bold on all the contiguous cells between 
+   * This script makes the font bold on all the contiguous cells between 
    * A1 and the bottom of the used range of the first column.
    */
   function main(workbook: ExcelScript.Workbook)
@@ -21,7 +21,7 @@ remarks: |-
 
     // Get every cell that's used between A1 and the end of the column.
     // This recreates the Ctrl+Shift+Down arrow key behavior.
-    let firstCell = selectedSheet.getRange("A1")
+    let firstCell = selectedSheet.getRange("A1");
     let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
     // Set the font to bold in that range.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -863,7 +863,7 @@ methods:
 
           ```TypeScript
           /**
-           * This script makes the the font bold on all the contiguous cells between 
+           * This script makes the font bold on all the contiguous cells between 
            * A1 and the bottom of the used range of the first column.
            */
           function main(workbook: ExcelScript.Workbook)
@@ -873,7 +873,7 @@ methods:
 
             // Get every cell that's used between A1 and the end of the column.
             // This recreates the Ctrl+Shift+Down arrow key behavior.
-            let firstCell = selectedSheet.getRange("A1")
+            let firstCell = selectedSheet.getRange("A1");
             let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
             // Set the font to bold in that range.
@@ -1503,8 +1503,8 @@ methods:
 
             // Get the last used cell at the end of the column.
             // This recreates the Ctrl+Down arrow key behavior.
-            let firstCell = selectedSheet.getRange("A1")
-            let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+            let firstCell = selectedSheet.getRange("A1");
+            let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down);
             let cellAfter = firstColumn.getOffsetRange(1, 0);
 
             // Set the value of the cell after the current end of the used column to "Total".

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -856,7 +856,30 @@ methods:
                     
       return:
         type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script makes the the font bold on all the contiguous cells between 
+           * A1 and the bottom of the used range of the first column.
+           */
+          function main(workbook: ExcelScript.Workbook)
+          {
+            // Get the current worksheet.
+            let selectedSheet = workbook.getActiveWorksheet();
+
+            // Get every cell that's used between A1 and the end of the column.
+            // This recreates the Ctrl+Shift+Down arrow key behavior.
+            let firstCell = selectedSheet.getRange("A1")
+            let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+            // Set the font to bold in that range.
+            firstColumn.getFormat().getFont().setBold(true);
+          }
+          ```
   - name: getFormat()
     uid: 'ExcelScript!ExcelScript.Range#getFormat:member(1)'
     package: ExcelScript!
@@ -1464,7 +1487,30 @@ methods:
                     
       return:
         type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script adds the value "Total" after the end of the first column.
+           */
+          function main(workbook: ExcelScript.Workbook)
+          {
+            // Get the current worksheet.
+            let selectedSheet = workbook.getActiveWorksheet();
+
+            // Get the last used cell at the end of the column.
+            // This recreates the Ctrl+Down arrow key behavior.
+            let firstCell = selectedSheet.getRange("A1")
+            let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+            let cellAfter = firstColumn.getOffsetRange(1, 0);
+
+            // Set the value of the cell after the current end of the used column to "Total".
+            cellAfter.setValue("Total");
+          }
+          ```
   - name: 'getResizedRange(deltaRows, deltaColumns)'
     uid: 'ExcelScript!ExcelScript.Range#getResizedRange:member(1)'
     package: ExcelScript!

--- a/docs/sample-scripts/excel-scripts.yaml
+++ b/docs/sample-scripts/excel-scripts.yaml
@@ -311,7 +311,7 @@
 'ExcelScript.KeyboardDirection:enum':
   - |-
     /**
-     * This script makes the the font bold on all the contiguous cells between 
+     * This script makes the font bold on all the contiguous cells between 
      * A1 and the bottom of the used range of the first column.
      */
     function main(workbook: ExcelScript.Workbook)
@@ -321,7 +321,7 @@
 
       // Get every cell that's used between A1 and the end of the column.
       // This recreates the Ctrl+Shift+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
+      let firstCell = selectedSheet.getRange("A1");
       let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
       // Set the font to bold in that range.
@@ -627,7 +627,7 @@
 'ExcelScript.Range#getExtendedRange:member(1)':
   - |-
     /**
-     * This script makes the the font bold on all the contiguous cells between 
+     * This script makes the font bold on all the contiguous cells between 
      * A1 and the bottom of the used range of the first column.
      */
     function main(workbook: ExcelScript.Workbook)
@@ -637,7 +637,7 @@
 
       // Get every cell that's used between A1 and the end of the column.
       // This recreates the Ctrl+Shift+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
+      let firstCell = selectedSheet.getRange("A1");
       let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
       // Set the font to bold in that range.
@@ -754,8 +754,8 @@
 
       // Get the last used cell at the end of the column.
       // This recreates the Ctrl+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
-      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+      let firstCell = selectedSheet.getRange("A1");
+      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down);
       let cellAfter = firstColumn.getOffsetRange(1, 0);
 
       // Set the value of the cell after the current end of the used column to "Total".

--- a/docs/sample-scripts/excel-scripts.yaml
+++ b/docs/sample-scripts/excel-scripts.yaml
@@ -308,6 +308,25 @@
       */
       console.log(currentSheet.getRange("A1:D4").getValues()); 
     }
+'ExcelScript.KeyboardDirection:enum':
+  - |-
+    /**
+     * This script makes the the font bold on all the contiguous cells between 
+     * A1 and the bottom of the used range of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get every cell that's used between A1 and the end of the column.
+      // This recreates the Ctrl+Shift+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+      // Set the font to bold in that range.
+      firstColumn.getFormat().getFont().setBold(true);
+    }
 'ExcelScript.PivotLayout#getBodyAndTotalRange:member(1)':
   - |-
     /**
@@ -605,6 +624,25 @@
           }
         });
     }
+'ExcelScript.Range#getExtendedRange:member(1)':
+  - |-
+    /**
+     * This script makes the the font bold on all the contiguous cells between 
+     * A1 and the bottom of the used range of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get every cell that's used between A1 and the end of the column.
+      // This recreates the Ctrl+Shift+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+      // Set the font to bold in that range.
+      firstColumn.getFormat().getFont().setBold(true);
+    }
 'ExcelScript.Range#getFormat:member(1)':
   - |-
     /**
@@ -703,6 +741,25 @@
       console.log(`The above cell's address is: ${aboveCell.getAddress()}`);
       aboveCell.getFormat().getFont().setColor("White");
       aboveCell.getFormat().getFill().setColor("Black");
+    }
+'ExcelScript.Range#getRangeEdge:member(1)':
+  - |-
+    /**
+     * This script adds the value "Total" after the end of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get the last used cell at the end of the column.
+      // This recreates the Ctrl+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+      let cellAfter = firstColumn.getOffsetRange(1, 0);
+
+      // Set the value of the cell after the current end of the used column to "Total".
+      cellAfter.setValue("Total");
     }
 'ExcelScript.Range#getResizedRange:member(1)':
   - |-

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -308,6 +308,25 @@
       */
       console.log(currentSheet.getRange("A1:D4").getValues()); 
     }
+'ExcelScript.KeyboardDirection:enum':
+  - |-
+    /**
+     * This script makes the the font bold on all the contiguous cells between 
+     * A1 and the bottom of the used range of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get every cell that's used between A1 and the end of the column.
+      // This recreates the Ctrl+Shift+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+      // Set the font to bold in that range.
+      firstColumn.getFormat().getFont().setBold(true);
+    }
 'ExcelScript.PivotLayout#getBodyAndTotalRange:member(1)':
   - |-
     /**
@@ -590,6 +609,25 @@
           }
         });
     }
+'ExcelScript.Range#getExtendedRange:member(1)':
+  - |-
+    /**
+     * This script makes the the font bold on all the contiguous cells between 
+     * A1 and the bottom of the used range of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get every cell that's used between A1 and the end of the column.
+      // This recreates the Ctrl+Shift+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
+
+      // Set the font to bold in that range.
+      firstColumn.getFormat().getFont().setBold(true);
+    }
 'ExcelScript.Range#getFormat:member(1)':
   - |-
     /**
@@ -689,6 +727,25 @@
       console.log(`The above cell's address is: ${aboveCell.getAddress()}`);
       aboveCell.getFormat().getFont().setColor("White");
       aboveCell.getFormat().getFill().setColor("Black");
+    }
+'ExcelScript.Range#getRangeEdge:member(1)':
+  - |-
+    /**
+     * This script adds the value "Total" after the end of the first column.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get the last used cell at the end of the column.
+      // This recreates the Ctrl+Down arrow key behavior.
+      let firstCell = selectedSheet.getRange("A1")
+      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+      let cellAfter = firstColumn.getOffsetRange(1, 0);
+
+      // Set the value of the cell after the current end of the used column to "Total".
+      cellAfter.setValue("Total");
     }
 'ExcelScript.Range#getResizedRange:member(1)':
   - |-

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -311,7 +311,7 @@
 'ExcelScript.KeyboardDirection:enum':
   - |-
     /**
-     * This script makes the the font bold on all the contiguous cells between 
+     * This script makes the font bold on all the contiguous cells between 
      * A1 and the bottom of the used range of the first column.
      */
     function main(workbook: ExcelScript.Workbook)
@@ -321,7 +321,7 @@
 
       // Get every cell that's used between A1 and the end of the column.
       // This recreates the Ctrl+Shift+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
+      let firstCell = selectedSheet.getRange("A1");
       let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
       // Set the font to bold in that range.
@@ -612,7 +612,7 @@
 'ExcelScript.Range#getExtendedRange:member(1)':
   - |-
     /**
-     * This script makes the the font bold on all the contiguous cells between 
+     * This script makes the font bold on all the contiguous cells between 
      * A1 and the bottom of the used range of the first column.
      */
     function main(workbook: ExcelScript.Workbook)
@@ -622,7 +622,7 @@
 
       // Get every cell that's used between A1 and the end of the column.
       // This recreates the Ctrl+Shift+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
+      let firstCell = selectedSheet.getRange("A1");
       let firstColumn = firstCell.getExtendedRange(ExcelScript.KeyboardDirection.down);
 
       // Set the font to bold in that range.
@@ -740,8 +740,8 @@
 
       // Get the last used cell at the end of the column.
       // This recreates the Ctrl+Down arrow key behavior.
-      let firstCell = selectedSheet.getRange("A1")
-      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down)
+      let firstCell = selectedSheet.getRange("A1");
+      let firstColumn = selectedSheet.getRange("A1").getRangeEdge(ExcelScript.KeyboardDirection.down);
       let cellAfter = firstColumn.getOffsetRange(1, 0);
 
       // Set the value of the cell after the current end of the used column to "Total".

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -2014,7 +2014,7 @@ ExcelScript.IterativeCalculation,getMaxIteration(),Method,Fine,false
 ExcelScript.IterativeCalculation,setEnabled(enabled),Method,Fine,false
 ExcelScript.IterativeCalculation,setMaxChange(maxChange),Method,Fine,false
 ExcelScript.IterativeCalculation,setMaxIteration(maxIteration),Method,Fine,false
-ExcelScript.KeyboardDirection,N/A,Class,Missing,false
+ExcelScript.KeyboardDirection,N/A,Class,Missing,true
 ExcelScript.KeyboardDirection,down,EnumField,Missing,false
 ExcelScript.KeyboardDirection,left,EnumField,Missing,false
 ExcelScript.KeyboardDirection,right,EnumField,Missing,false
@@ -2478,7 +2478,7 @@ ExcelScript.Range,getDataValidation(),Method,Poor,true
 ExcelScript.Range,getDirectPrecedents(),Method,Fine,false
 ExcelScript.Range,getEntireColumn(),Method,Fine,false
 ExcelScript.Range,getEntireRow(),Method,Fine,false
-ExcelScript.Range,getExtendedRange(direction,Method,Good,false
+ExcelScript.Range,getExtendedRange(direction,Method,Good,true
 ExcelScript.Range,getFormat(),Method,Fine,true
 ExcelScript.Range,getFormula(),Method,Good,true
 ExcelScript.Range,getFormulaLocal(),Method,Good,false
@@ -2510,7 +2510,7 @@ ExcelScript.Range,getNumberFormatsLocal(),Method,Good,false
 ExcelScript.Range,getOffsetRange(rowOffset,Method,Good,true
 ExcelScript.Range,getPivotTables(fullyContained),Method,Fine,false
 ExcelScript.Range,getPredefinedCellStyle(),Method,Good,false
-ExcelScript.Range,getRangeEdge(direction,Method,Good,false
+ExcelScript.Range,getRangeEdge(direction,Method,Good,true
 ExcelScript.Range,getResizedRange(deltaRows,Method,Fine,true
 ExcelScript.Range,getRow(row),Method,Poor,false
 ExcelScript.Range,getRowCount(),Method,Poor,true


### PR DESCRIPTION
Adding samples for `Range.getExtendedRange` and `Range.getRangeEdge`. This is based on the low content score for the `KeyboardDirection` page and recent experiments around the desire and need for relative positioning script actions.