### PR TITLE
[excel] (Range) Add note about Range.getImage issue

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -1131,7 +1131,7 @@ methods:
       **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell
       width to render on the same line without line wrapping. This makes the resulting image unreadable, since the text
       overflows across the entire row. As a workaround, make sure the data in the range fits in each of the cells as a
-      single-line.
+      singleline.
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -1128,8 +1128,10 @@ methods:
       Renders the range as a base64-encoded png image.
 
 
-      **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without
-      line wrapping and in smaller cells. This makes the resulting image unreadable.
+      **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell
+      width to render on the same line without line wrapping. This makes the resulting image unreadable, since the text
+      overflows across the entire row. As a workaround, make sure the data in the range fits in each of the cells as a
+      single-line.
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -1124,7 +1124,12 @@ methods:
     uid: 'ExcelScript!ExcelScript.Range#getImage:member(1)'
     package: ExcelScript!
     fullName: getImage()
-    summary: Renders the range as a base64-encoded png image.
+    summary: >-
+      Renders the range as a base64-encoded png image.
+
+
+      **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without
+      line wrapping and in smaller cells. This makes the resulting image unreadable.
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -1634,7 +1634,7 @@ export declare namespace ExcelScript {
          * 
          * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. 
          * This makes the resulting image unreadable, since the text overflows across the entire row. 
-         * As a workaround, make sure the data in the range fits in each of the cells as a single-line.
+         * As a workaround, make sure the data in the range fits in each of the cells as a singleline.
          */
         getImage(): string;
 

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -1631,6 +1631,8 @@ export declare namespace ExcelScript {
 
         /**
          * Renders the range as a base64-encoded png image.
+         * 
+         * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.
          */
         getImage(): string;
 

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -1632,7 +1632,9 @@ export declare namespace ExcelScript {
         /**
          * Renders the range as a base64-encoded png image.
          * 
-         * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.
+         * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. 
+         * This makes the resulting image unreadable, since the text overflows across the entire row. 
+         * As a workaround, make sure the data in the range fits in each of the cells as a single-line.
          */
         getImage(): string;
 

--- a/generate-docs/json/excel/ExcelScript.api.json
+++ b/generate-docs/json/excel/ExcelScript.api.json
@@ -60386,7 +60386,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "ExcelScript!ExcelScript.Range#getImage:member(1)",
-                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n */\n",
+                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n *\n * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel/ExcelScript.api.json
+++ b/generate-docs/json/excel/ExcelScript.api.json
@@ -60386,7 +60386,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "ExcelScript!ExcelScript.Range#getImage:member(1)",
-                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n *\n * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. This makes the resulting image unreadable, since the text overflows across the entire row. As a workaround, make sure the data in the range fits in each of the cells as a single-line.\n */\n",
+                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n *\n * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. This makes the resulting image unreadable, since the text overflows across the entire row. As a workaround, make sure the data in the range fits in each of the cells as a singleline.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/json/excel/ExcelScript.api.json
+++ b/generate-docs/json/excel/ExcelScript.api.json
@@ -60386,7 +60386,7 @@
                 {
                   "kind": "MethodSignature",
                   "canonicalReference": "ExcelScript!ExcelScript.Range#getImage:member(1)",
-                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n *\n * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.\n */\n",
+                  "docComment": "/**\n * Renders the range as a base64-encoded png image.\n *\n * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. This makes the resulting image unreadable, since the text overflows across the entire row. As a workaround, make sure the data in the range fits in each of the cells as a single-line.\n */\n",
                   "excerptTokens": [
                     {
                       "kind": "Content",

--- a/generate-docs/script-inputs/excel.d.ts
+++ b/generate-docs/script-inputs/excel.d.ts
@@ -1634,7 +1634,7 @@ declare namespace ExcelScript {
          * 
          * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. 
          * This makes the resulting image unreadable, since the text overflows across the entire row. 
-         * As a workaround, make sure the data in the range fits in each of the cells as a single-line.
+         * As a workaround, make sure the data in the range fits in each of the cells as a singleline.
          */
         getImage(): string;
 

--- a/generate-docs/script-inputs/excel.d.ts
+++ b/generate-docs/script-inputs/excel.d.ts
@@ -1632,7 +1632,9 @@ declare namespace ExcelScript {
         /**
          * Renders the range as a base64-encoded png image.
          * 
-         * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.
+         * **Note**: There is a known issue with `Range.getImage` that causes wrapped text or text that exceeds the cell width to render on the same line without line wrapping. 
+         * This makes the resulting image unreadable, since the text overflows across the entire row. 
+         * As a workaround, make sure the data in the range fits in each of the cells as a single-line.
          */
         getImage(): string;
 

--- a/generate-docs/script-inputs/excel.d.ts
+++ b/generate-docs/script-inputs/excel.d.ts
@@ -1631,6 +1631,8 @@ declare namespace ExcelScript {
 
         /**
          * Renders the range as a base64-encoded png image.
+         * 
+         * **Note**: There is a known issue with `Range.getImage` that causes longer or wrapped text string to render without line wrapping and in smaller cells. This makes the resulting image unreadable.
          */
         getImage(): string;
 

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -2346,7 +2346,7 @@ ExcelScript.Range,getHasSpill(),Method,Good,false
 ExcelScript.Range,getHeight(),Method,Fine,false
 ExcelScript.Range,getHidden(),Method,Good,false
 ExcelScript.Range,getHyperlink(),Method,Poor,true
-ExcelScript.Range,getImage(),Method,Poor,false
+ExcelScript.Range,getImage(),Method,Good,false
 ExcelScript.Range,getIntersection(anotherRange),Method,Good,false
 ExcelScript.Range,getIsEntireColumn(),Method,Poor,false
 ExcelScript.Range,getIsEntireRow(),Method,Poor,false


### PR DESCRIPTION
[Preview link](https://review.docs.microsoft.com/en-us/javascript/api/office-scripts/excelscript/excelscript.range?branch=AlexJ-RangeImageNote&view=office-scripts#getImage__)

Based on [this customer issue](https://docs.microsoft.com/en-us/answers/questions/547136/office-script-to-copy-table-image-copies-39wrong39.html).
