### PR TITLE
[excel] Adding samples for prominent enum pages

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttype.yml
@@ -4,7 +4,29 @@ uid: 'ExcelScript!ExcelScript.ChartType:enum'
 package: ExcelScript!
 fullName: ExcelScript.ChartType
 summary: ''
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This sample creates a column-clustered chart based on the current worksheet's data.
+   */
+  function main(workbook: ExcelScript.Workbook) {
+    // Get the current worksheet.
+    let selectedSheet = workbook.getActiveWorksheet();
+
+    // Get the data range.
+    let range = selectedSheet.getUsedRange();
+
+    // Insert a chart using the data on the current worksheet.
+    let chart = selectedSheet.addChart(ExcelScript.ChartType.columnClustered, range);
+
+    // Name the chart for easy access in other scripts.
+    chart.setName("ColumnChart");
+  }
+  ```
 isPreview: false
 isDeprecated: false
 fields:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.insertshiftdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.insertshiftdirection.yml
@@ -4,7 +4,30 @@ uid: 'ExcelScript!ExcelScript.InsertShiftDirection:enum'
 package: ExcelScript!
 fullName: ExcelScript.InsertShiftDirection
 summary: ''
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script inserts headers at the top of the worksheet.
+   */
+  function main(workbook: ExcelScript.Workbook)
+  {
+    let currentSheet = workbook.getActiveWorksheet();
+
+    // Create headers for 3 columns.
+    let myHeaders = [["NAME", "ID", "ROLE"]];
+
+    // Add a blank first row and push existing data down a row.
+    let firstRow = currentSheet.getRange("1:1");
+    firstRow.insert(ExcelScript.InsertShiftDirection.down);
+
+    // Add the headers.
+    currentSheet.getRange("A1:C1").setValues(myHeaders);
+  }
+  ```
 isPreview: false
 isDeprecated: false
 fields:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatcategory.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatcategory.yml
@@ -4,7 +4,33 @@ uid: 'ExcelScript!ExcelScript.NumberFormatCategory:enum'
 package: ExcelScript!
 fullName: ExcelScript.NumberFormatCategory
 summary: Represents a category of number formats.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script finds cells in a table column that are not formatted as currency
+   * and sets the fill color to red.
+   */
+  function main(workbook: ExcelScript.Workbook) {
+    // Get the "Cost" column from the "Expenses" table.
+    const table = workbook.getTable("Expenses");
+    const costColumn = table.getColumnByName("Cost");
+    const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+    // Get the number for categories for the column's range.
+    const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+    // If any cell in the column doesn't have a currency format, make the cell red.
+    numberFormatCategories.forEach((category, index) =>{
+      if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+        costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+      }
+    }); 
+  }
+  ```
 isPreview: false
 isDeprecated: false
 fields:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.protectionselectionmode.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.protectionselectionmode.yml
@@ -4,7 +4,29 @@ uid: 'ExcelScript!ExcelScript.ProtectionSelectionMode:enum'
 package: ExcelScript!
 fullName: ExcelScript.ProtectionSelectionMode
 summary: ''
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script protects cells from being selected on the current worksheet.
+   */
+  function main(workbook: ExcelScript.Workbook) {
+    // Get the protection settings for the current worksheet.
+    const currentSheet = workbook.getActiveWorksheet();
+    const sheetProtection = currentSheet.getProtection();
+
+    // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+    let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+      selectionMode: ExcelScript.ProtectionSelectionMode.none
+    }
+
+    // Apply the given protection options.
+    sheetProtection.protect(protectionOptions);
+  }
+  ```
 isPreview: false
 isDeprecated: false
 fields:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -1308,7 +1308,33 @@ methods:
       content: 'getNumberFormatCategories(): NumberFormatCategory[][];'
       return:
         type: '<xref uid="ExcelScript!ExcelScript.NumberFormatCategory:enum" />[][]'
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script finds cells in a table column that are not formatted as currency
+           * and sets the fill color to red.
+           */
+          function main(workbook: ExcelScript.Workbook) {
+            // Get the "Cost" column from the "Expenses" table.
+            const table = workbook.getTable("Expenses");
+            const costColumn = table.getColumnByName("Cost");
+            const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+            // Get the number for categories for the column's range.
+            const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+            // If any cell in the column doesn't have a currency format, make the cell red.
+            numberFormatCategories.forEach((category, index) =>{
+              if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+                costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+              }
+            }); 
+          }
+          ```
   - name: getNumberFormatCategory()
     uid: 'ExcelScript!ExcelScript.Range#getNumberFormatCategory:member(1)'
     package: ExcelScript!

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
@@ -1268,7 +1268,29 @@ methods:
       content: 'getProtection(): WorksheetProtection;'
       return:
         type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtection:interface" />'
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script protects cells from being selected on the current worksheet.
+           */
+          function main(workbook: ExcelScript.Workbook) {
+            // Get the protection settings for the current worksheet.
+            const currentSheet = workbook.getActiveWorksheet();
+            const sheetProtection = currentSheet.getProtection();
+
+            // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+            let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+              selectionMode: ExcelScript.ProtectionSelectionMode.none
+            }
+
+            // Apply the given protection options.
+            sheetProtection.protect(protectionOptions);
+          }
+          ```
   - name: getRange(address)
     uid: 'ExcelScript!ExcelScript.Worksheet#getRange:member(1)'
     package: ExcelScript!

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotection.yml
@@ -54,7 +54,29 @@ methods:
           type: string
       return:
         type: void
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script protects cells from being selected on the current worksheet.
+           */
+          function main(workbook: ExcelScript.Workbook) {
+            // Get the protection settings for the current worksheet.
+            const currentSheet = workbook.getActiveWorksheet();
+            const sheetProtection = currentSheet.getProtection();
+
+            // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+            let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+              selectionMode: ExcelScript.ProtectionSelectionMode.none
+            }
+
+            // Apply the given protection options.
+            sheetProtection.protect(protectionOptions);
+          }
+          ```
   - name: unprotect(password)
     uid: 'ExcelScript!ExcelScript.WorksheetProtection#unprotect:member(1)'
     package: ExcelScript!

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotectionoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotectionoptions.yml
@@ -4,7 +4,29 @@ uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions:interface'
 package: ExcelScript!
 fullName: ExcelScript.WorksheetProtectionOptions
 summary: Represents the options in sheet protection.
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script protects cells from being selected on the current worksheet.
+   */
+  function main(workbook: ExcelScript.Workbook) {
+    // Get the protection settings for the current worksheet.
+    const currentSheet = workbook.getActiveWorksheet();
+    const sheetProtection = currentSheet.getProtection();
+
+    // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+    let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+      selectionMode: ExcelScript.ProtectionSelectionMode.none
+    }
+
+    // Apply the given protection options.
+    sheetProtection.protect(protectionOptions);
+  }
+  ```
 isPreview: false
 isDeprecated: false
 type: interface

--- a/docs/sample-scripts/excel-scripts.yaml
+++ b/docs/sample-scripts/excel-scripts.yaml
@@ -108,57 +108,6 @@
       format.getFill().setColor("yellow");
       format.getFont().setItalic(true);
     }
-'ExcelScript.Chart#setName:member(1)':
-  - |-
-    /**
-     * This sample creates a column-clustered chart based on the current worksheet's data.
-     */
-    function main(workbook: ExcelScript.Workbook) {
-      // Get the current worksheet.
-      let selectedSheet = workbook.getActiveWorksheet();
-
-      // Get the data range.
-      let range = selectedSheet.getUsedRange();
-
-      // Insert a chart using the data on the current worksheet.
-      let chart = selectedSheet.addChart(ExcelScript.ChartType.columnClustered, range);
-
-      // Name the chart for easy access in other scripts.
-      chart.setName("ColumnChart");
-    }
-'ExcelScript.Chart#setPosition:member(1)':
-  - |-
-    /**
-     * This sample moves an existing chart to a specific place on the worksheet.
-     */
-    function main(workbook: ExcelScript.Workbook) {
-      // Get the current worksheet.
-      let selectedSheet = workbook.getActiveWorksheet();
-      
-      // Get an existing chart named "ColumnChart".
-      let chart = selectedSheet.getChart("ColumnChart");
-
-      // Place the chart over the range "F1:L13".
-      chart.setPosition("F1", "L13");
-    }
-'ExcelScript.ChartSeries#getName:member(1)':
-  - |-
-    /**
-     * This sample logs the names of each of the chart series in a chart named "ColumnClusteredChart".
-     */
-    function main(workbook: ExcelScript.Workbook) {
-      // Get the current worksheet.
-      let selectedSheet = workbook.getActiveWorksheet();
-
-      // Get an existing chart named "ColumnClusteredChart".
-      let chart = selectedSheet.getChart("ColumnClusteredChart");
-
-      // Log the name of each chart series in the chart.
-      let seriesList = chart.getSeries();
-      seriesList.forEach((series) => {
-        console.log(series.getName());
-      });
-    }
 'ExcelScript.Chart#getPlotBy:member(1)':
   - |-
     /**
@@ -199,6 +148,24 @@
         series.setOverlap(25);
       });
     }
+'ExcelScript.Chart#setName:member(1)':
+  - |-
+    /**
+     * This sample creates a column-clustered chart based on the current worksheet's data.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get the data range.
+      let range = selectedSheet.getUsedRange();
+
+      // Insert a chart using the data on the current worksheet.
+      let chart = selectedSheet.addChart(ExcelScript.ChartType.columnClustered, range);
+
+      // Name the chart for easy access in other scripts.
+      chart.setName("ColumnChart");
+    }
 'ExcelScript.Chart#setPlotBy:member(1)':
  - |-
     /**
@@ -219,6 +186,21 @@
         // If the chart is grouped by rows, switch it to columns.
         columnClusteredChart.setPlotBy(ExcelScript.ChartPlotBy.columns);
       }
+    }
+'ExcelScript.Chart#setPosition:member(1)':
+  - |-
+    /**
+     * This sample moves an existing chart to a specific place on the worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+      
+      // Get an existing chart named "ColumnChart".
+      let chart = selectedSheet.getChart("ColumnChart");
+
+      // Place the chart over the range "F1:L13".
+      chart.setPosition("F1", "L13");
     }
 'ExcelScript.ChartPlotBy:enum':
   - |-
@@ -241,6 +223,24 @@
         columnClusteredChart.setPlotBy(ExcelScript.ChartPlotBy.columns);
       }
     }
+'ExcelScript.ChartSeries#getName:member(1)':
+  - |-
+    /**
+     * This sample logs the names of each of the chart series in a chart named "ColumnClusteredChart".
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get an existing chart named "ColumnClusteredChart".
+      let chart = selectedSheet.getChart("ColumnClusteredChart");
+
+      // Log the name of each chart series in the chart.
+      let seriesList = chart.getSeries();
+      seriesList.forEach((series) => {
+        console.log(series.getName());
+      });
+    }
 'ExcelScript.ChartSeries#setOverlap:member(1)':
   - |-
     /**
@@ -259,6 +259,24 @@
         // An overlap of 25 means the columns have 25% of their length overlapping with the adjacent columns in the same category.
         series.setOverlap(25);
       });
+    }
+'ExcelScript.ChartType:enum':
+  - |-
+    /**
+     * This sample creates a column-clustered chart based on the current worksheet's data.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get the data range.
+      let range = selectedSheet.getUsedRange();
+
+      // Insert a chart using the data on the current worksheet.
+      let chart = selectedSheet.addChart(ExcelScript.ChartType.columnClustered, range);
+
+      // Name the chart for easy access in other scripts.
+      chart.setName("ColumnChart");
     }
 'ExcelScript.ClearApplyTo:enum':
   - |-
@@ -850,6 +868,25 @@
       // Copy the image to another worksheet.
       image.getShape().copyTo("SecondSheet");
     }
+'ExcelScript.InsertShiftDirection:enum':
+  - |-
+    /**
+     * This script inserts headers at the top of the worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      let currentSheet = workbook.getActiveWorksheet();
+
+      // Create headers for 3 columns.
+      let myHeaders = [["NAME", "ID", "ROLE"]];
+
+      // Add a blank first row and push existing data down a row.
+      let firstRow = currentSheet.getRange("1:1");
+      firstRow.insert(ExcelScript.InsertShiftDirection.down);
+
+      // Add the headers.
+      currentSheet.getRange("A1:C1").setValues(myHeaders);
+    }
 'ExcelScript.KeyboardDirection:enum':
   - |-
     /**
@@ -868,6 +905,28 @@
 
       // Set the font to bold in that range.
       firstColumn.getFormat().getFont().setBold(true);
+    }
+'ExcelScript.NumberFormatCategory:enum':
+  - |-
+    /**
+     * This script finds cells in a table column that are not formatted as currency
+     * and sets the fill color to red.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the "Cost" column from the "Expenses" table.
+      const table = workbook.getTable("Expenses");
+      const costColumn = table.getColumnByName("Cost");
+      const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+      // Get the number for categories for the column's range.
+      const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+      // If any cell in the column doesn't have a currency format, make the cell red.
+      numberFormatCategories.forEach((category, index) =>{
+        if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+          costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+        }
+      }); 
     }
 'ExcelScript.PivotField#applyFilter:member(1)':
   - |-
@@ -1197,6 +1256,24 @@
       rowHierarchy.getPivotField(rowHierarchy.getName()).applyFilter({
         valueFilter: filter
       });
+    }
+'ExcelScript.ProtectionSelectionMode:enum':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
     }
 'ExcelScript.Range:interface':
   - |-
@@ -1561,6 +1638,28 @@
       }
 
       console.log(`Done. Cleared hyperlinks from ${clearedCount} cells`);
+    }
+'ExcelScript.Range#getNumberFormatCategories:member(1)':
+  - |-
+    /**
+     * This script finds cells in a table column that are not formatted as currency
+     * and sets the fill color to red.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the "Cost" column from the "Expenses" table.
+      const table = workbook.getTable("Expenses");
+      const costColumn = table.getColumnByName("Cost");
+      const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+      // Get the number for categories for the column's range.
+      const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+      // If any cell in the column doesn't have a currency format, make the cell red.
+      numberFormatCategories.forEach((category, index) =>{
+        if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+          costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+        }
+      }); 
     }
 'ExcelScript.Range#getOffsetRange:member(1)':
   - |-
@@ -3011,6 +3110,24 @@
         // Log the array of worksheet names.
         console.log(worksheetNames);
     }
+'ExcelScript.Worksheet#getProtection:member(1)':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
+    }
 'ExcelScript.Worksheet#getRange:member(1)':
   - |-
     /**
@@ -3095,4 +3212,40 @@
       // Name the worksheet using the current date.
       let date = new Date(Date.now());
       newSheet.setName(`${date.toDateString()}`);
+    }
+'ExcelScript.WorksheetProtection#protect:member(1)':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
+    }
+'ExcelScript.WorksheetProtectionOptions:interface':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
     }

--- a/generate-docs/json/excel/snippets.yaml
+++ b/generate-docs/json/excel/snippets.yaml
@@ -260,6 +260,24 @@
         series.setOverlap(25);
       });
     }
+'ExcelScript.ChartType:enum':
+  - |-
+    /**
+     * This sample creates a column-clustered chart based on the current worksheet's data.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the current worksheet.
+      let selectedSheet = workbook.getActiveWorksheet();
+
+      // Get the data range.
+      let range = selectedSheet.getUsedRange();
+
+      // Insert a chart using the data on the current worksheet.
+      let chart = selectedSheet.addChart(ExcelScript.ChartType.columnClustered, range);
+
+      // Name the chart for easy access in other scripts.
+      chart.setName("ColumnChart");
+    }
 'ExcelScript.ClearApplyTo:enum':
   - |-
     /**
@@ -850,6 +868,25 @@
       // Copy the image to another worksheet.
       image.getShape().copyTo("SecondSheet");
     }
+'ExcelScript.InsertShiftDirection:enum':
+  - |-
+    /**
+     * This script inserts headers at the top of the worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook)
+    {
+      let currentSheet = workbook.getActiveWorksheet();
+
+      // Create headers for 3 columns.
+      let myHeaders = [["NAME", "ID", "ROLE"]];
+
+      // Add a blank first row and push existing data down a row.
+      let firstRow = currentSheet.getRange("1:1");
+      firstRow.insert(ExcelScript.InsertShiftDirection.down);
+
+      // Add the headers.
+      currentSheet.getRange("A1:C1").setValues(myHeaders);
+    }
 'ExcelScript.KeyboardDirection:enum':
   - |-
     /**
@@ -868,6 +905,28 @@
 
       // Set the font to bold in that range.
       firstColumn.getFormat().getFont().setBold(true);
+    }
+'ExcelScript.NumberFormatCategory:enum':
+  - |-
+    /**
+     * This script finds cells in a table column that are not formatted as currency
+     * and sets the fill color to red.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the "Cost" column from the "Expenses" table.
+      const table = workbook.getTable("Expenses");
+      const costColumn = table.getColumnByName("Cost");
+      const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+      // Get the number for categories for the column's range.
+      const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+      // If any cell in the column doesn't have a currency format, make the cell red.
+      numberFormatCategories.forEach((category, index) =>{
+        if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+          costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+        }
+      }); 
     }
 'ExcelScript.PivotField#applyFilter:member(1)':
   - |-
@@ -1197,6 +1256,24 @@
       rowHierarchy.getPivotField(rowHierarchy.getName()).applyFilter({
         valueFilter: filter
       });
+    }
+'ExcelScript.ProtectionSelectionMode:enum':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
     }
 'ExcelScript.Range#addConditionalFormat:member(1)':
   - |-
@@ -1547,6 +1624,28 @@
       }
 
       console.log(`Done. Cleared hyperlinks from ${clearedCount} cells`);
+    }
+'ExcelScript.Range#getNumberFormatCategories:member(1)':
+  - |-
+    /**
+     * This script finds cells in a table column that are not formatted as currency
+     * and sets the fill color to red.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the "Cost" column from the "Expenses" table.
+      const table = workbook.getTable("Expenses");
+      const costColumn = table.getColumnByName("Cost");
+      const costColumnRange = costColumn.getRangeBetweenHeaderAndTotal();
+
+      // Get the number for categories for the column's range.
+      const numberFormatCategories = costColumnRange.getNumberFormatCategories();
+
+      // If any cell in the column doesn't have a currency format, make the cell red.
+      numberFormatCategories.forEach((category, index) =>{
+        if (category[0] != ExcelScript.NumberFormatCategory.currency) {
+          costColumnRange.getCell(index, 0).getFormat().getFill().setColor("red");
+        }
+      }); 
     }
 'ExcelScript.Range#getOffsetRange:member(1)':
   - |-
@@ -3003,6 +3102,24 @@
         // Log the array of worksheet names.
         console.log(worksheetNames);
     }
+'ExcelScript.Worksheet#getProtection:member(1)':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
+    }
 'ExcelScript.Worksheet#getRange:member(1)':
   - |-
     /**
@@ -3096,4 +3213,40 @@
       // Name the worksheet using the current date.
       let date = new Date(Date.now());
       newSheet.setName(`${date.toDateString()}`);
+    }
+'ExcelScript.WorksheetProtection#protect:member(1)':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
+    }
+'ExcelScript.WorksheetProtectionOptions:interface':
+  - |-
+    /**
+     * This script protects cells from being selected on the current worksheet.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the protection settings for the current worksheet.
+      const currentSheet = workbook.getActiveWorksheet();
+      const sheetProtection = currentSheet.getProtection();
+
+      // Create a new WorksheetProtectionOptions object with the selectionMode property set to `none`.
+      let protectionOptions : ExcelScript.WorksheetProtectionOptions = {
+        selectionMode: ExcelScript.ProtectionSelectionMode.none
+      }
+
+      // Apply the given protection options.
+      sheetProtection.protect(protectionOptions);
     }

--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -941,7 +941,7 @@ ExcelScript.ChartTrendlineType,logarithmic,EnumField,Missing,false
 ExcelScript.ChartTrendlineType,movingAverage,EnumField,Missing,false
 ExcelScript.ChartTrendlineType,polynomial,EnumField,Missing,false
 ExcelScript.ChartTrendlineType,power,EnumField,Missing,false
-ExcelScript.ChartType,N/A,Enum,Missing,false
+ExcelScript.ChartType,N/A,Enum,Missing,true
 ExcelScript.ChartType,area,EnumField,Missing,false
 ExcelScript.ChartType,areaStacked,EnumField,Missing,false
 ExcelScript.ChartType,areaStacked100,EnumField,Missing,false
@@ -1857,7 +1857,7 @@ ExcelScript.ImageFittingMode,N/A,Enum,Missing,false
 ExcelScript.ImageFittingMode,fill,EnumField,Missing,false
 ExcelScript.ImageFittingMode,fit,EnumField,Missing,false
 ExcelScript.ImageFittingMode,fitAndCenter,EnumField,Missing,false
-ExcelScript.InsertShiftDirection,N/A,Enum,Missing,false
+ExcelScript.InsertShiftDirection,N/A,Enum,Missing,true
 ExcelScript.InsertShiftDirection,down,EnumField,Missing,false
 ExcelScript.InsertShiftDirection,right,EnumField,Missing,false
 ExcelScript.IterativeCalculation,N/A,Class,Poor,false
@@ -1957,7 +1957,7 @@ ExcelScript.NamedSheetView,delete(),Method,Poor,false
 ExcelScript.NamedSheetView,duplicate(name),Method,Poor,false
 ExcelScript.NamedSheetView,getName(),Method,Poor,false
 ExcelScript.NamedSheetView,setName(name),Method,Poor,false
-ExcelScript.NumberFormatCategory,N/A,Enum,Poor,false
+ExcelScript.NumberFormatCategory,N/A,Enum,Poor,true
 ExcelScript.NumberFormatCategory,accounting,EnumField,Fine,false
 ExcelScript.NumberFormatCategory,currency,EnumField,Good,false
 ExcelScript.NumberFormatCategory,custom,EnumField,Fine,false
@@ -2301,7 +2301,7 @@ ExcelScript.PrintMarginUnit,points,EnumField,Good,false
 ExcelScript.PrintOrder,N/A,Enum,Missing,false
 ExcelScript.PrintOrder,downThenOver,EnumField,Fine,false
 ExcelScript.PrintOrder,overThenDown,EnumField,Fine,false
-ExcelScript.ProtectionSelectionMode,N/A,Enum,Missing,false
+ExcelScript.ProtectionSelectionMode,N/A,Enum,Missing,true
 ExcelScript.ProtectionSelectionMode,none,EnumField,Poor,false
 ExcelScript.ProtectionSelectionMode,normal,EnumField,Poor,false
 ExcelScript.ProtectionSelectionMode,unlocked,EnumField,Fine,false
@@ -2358,7 +2358,7 @@ ExcelScript.Range,getLinkedDataTypeState(),Method,Poor,false
 ExcelScript.Range,getLinkedDataTypeStates(),Method,Poor,false
 ExcelScript.Range,getMergedAreas(),Method,Poor,false
 ExcelScript.Range,getNumberFormat(),Method,Poor,false
-ExcelScript.Range,getNumberFormatCategories(),Method,Poor,false
+ExcelScript.Range,getNumberFormatCategories(),Method,Poor,true
 ExcelScript.Range,getNumberFormatCategory(),Method,Poor,false
 ExcelScript.Range,getNumberFormatLocal(),Method,Poor,false
 ExcelScript.Range,getNumberFormats(),Method,Poor,false
@@ -3200,7 +3200,7 @@ ExcelScript.Worksheet,getPivotTable(name),Method,Poor,false
 ExcelScript.Worksheet,getPivotTables(),Method,Poor,false
 ExcelScript.Worksheet,getPosition(),Method,Poor,false
 ExcelScript.Worksheet,getPrevious(visibleOnly),Method,Poor,false
-ExcelScript.Worksheet,getProtection(),Method,Poor,false
+ExcelScript.Worksheet,getProtection(),Method,Poor,true
 ExcelScript.Worksheet,getRange(address),Method,Fine,true
 ExcelScript.Worksheet,getRangeByIndexes(startRow,Method,Poor,false
 ExcelScript.Worksheet,getRanges(address),Method,Poor,false
@@ -3252,9 +3252,9 @@ ExcelScript.WorksheetPositionType,none,EnumField,Missing,false
 ExcelScript.WorksheetProtection,N/A,Class,Poor,false
 ExcelScript.WorksheetProtection,getOptions(),Method,Poor,false
 ExcelScript.WorksheetProtection,getProtected(),Method,Poor,false
-ExcelScript.WorksheetProtection,protect(options,Method,Poor,false
+ExcelScript.WorksheetProtection,protect(options,Method,Poor,true
 ExcelScript.WorksheetProtection,unprotect(password),Method,Poor,false
-ExcelScript.WorksheetProtectionOptions,N/A,Class,Poor,false
+ExcelScript.WorksheetProtectionOptions,N/A,Class,Poor,true
 ExcelScript.WorksheetProtectionOptions,allowAutoFilter,Property,Fine,false
 ExcelScript.WorksheetProtectionOptions,allowDeleteColumns,Property,Poor,false
 ExcelScript.WorksheetProtectionOptions,allowDeleteRows,Property,Poor,false


### PR DESCRIPTION
This PR adds samples for the NumberFormatCategory and ProtectionSelectionMode enums. It also maps existing samples to the InsertShiftDirection, KeyboardDirection, FilterOperator, and ChartType enum pages.

One other minor thing, a couple of the Chart samples were not alphabetized, so this PR addresses that.