### PR TITLE
[tools] (coverage-tester) Update coverage tester to note deprecated APIs

### DIFF
--- a/generate-docs/tools/API Coverage Report.csv
+++ b/generate-docs/tools/API Coverage Report.csv
@@ -1,5 +1,5 @@
 Class,Field,Type,Description Rating,Has Example?
-ExcelScript.AggregationFunction,N/A,Enum,Poor,true
+ExcelScript.AggregationFunction,N/A,Enum,Fine,true
 ExcelScript.AggregationFunction,automatic,EnumField,Fine,false
 ExcelScript.AggregationFunction,average,EnumField,Fine,false
 ExcelScript.AggregationFunction,count,EnumField,Fine,false
@@ -10,7 +10,7 @@ ExcelScript.AggregationFunction,product,EnumField,Fine,false
 ExcelScript.AggregationFunction,standardDeviation,EnumField,Fine,false
 ExcelScript.AggregationFunction,standardDeviationP,EnumField,Fine,false
 ExcelScript.AggregationFunction,sum,EnumField,Fine,false
-ExcelScript.AggregationFunction,unknown,EnumField,Poor,false
+ExcelScript.AggregationFunction,unknown,EnumField,Fine,false
 ExcelScript.AggregationFunction,variance,EnumField,Fine,false
 ExcelScript.AggregationFunction,varianceP,EnumField,Fine,false
 ExcelScript.AllowEditRange,N/A,Class,Good,false
@@ -23,9 +23,9 @@ ExcelScript.AllowEditRange,setAddress(address),Method,Poor,false
 ExcelScript.AllowEditRange,setPassword(password),Method,Poor,false
 ExcelScript.AllowEditRange,setTitle(title),Method,Poor,false
 ExcelScript.AllowEditRangeOptions,N/A,Class,Fine,false
-ExcelScript.AllowEditRangeOptions,password,Property,Poor,false
-ExcelScript.Application,N/A,Class,Poor,false
-ExcelScript.Application,calculate(calculationType),Method,Poor,true
+ExcelScript.AllowEditRangeOptions,password,Property,Fine,false
+ExcelScript.Application,N/A,Class,Fine,false
+ExcelScript.Application,calculate(calculationType),Method,Fine,true
 ExcelScript.Application,getCalculationEngineVersion(),Method,Poor,false
 ExcelScript.Application,getCalculationMode(),Method,Poor,false
 ExcelScript.Application,getCalculationState(),Method,Fine,true
@@ -54,17 +54,17 @@ ExcelScript.AutoFillType,N/A,Enum,Fine,true
 ExcelScript.AutoFillType,fillCopy,EnumField,Fine,false
 ExcelScript.AutoFillType,fillDays,EnumField,Fine,false
 ExcelScript.AutoFillType,fillDefault,EnumField,Fine,false
-ExcelScript.AutoFillType,fillFormats,EnumField,Poor,false
+ExcelScript.AutoFillType,fillFormats,EnumField,Fine,false
 ExcelScript.AutoFillType,fillMonths,EnumField,Fine,false
 ExcelScript.AutoFillType,fillSeries,EnumField,Fine,false
-ExcelScript.AutoFillType,fillValues,EnumField,Poor,false
+ExcelScript.AutoFillType,fillValues,EnumField,Fine,false
 ExcelScript.AutoFillType,fillWeekdays,EnumField,Fine,false
 ExcelScript.AutoFillType,fillYears,EnumField,Fine,false
 ExcelScript.AutoFillType,flashFill,EnumField,Fine,false
 ExcelScript.AutoFillType,growthTrend,EnumField,Fine,false
 ExcelScript.AutoFillType,linearTrend,EnumField,Fine,false
 ExcelScript.AutoFilter,N/A,Class,Good,true
-ExcelScript.AutoFilter,apply(range,Method,Poor,true
+ExcelScript.AutoFilter,apply(range, columnIndex, criteria),Method,Poor,true
 ExcelScript.AutoFilter,clearColumnCriteria(columnIndex),Method,Poor,false
 ExcelScript.AutoFilter,clearCriteria(),Method,Poor,true
 ExcelScript.AutoFilter,getCriteria(),Method,Poor,false
@@ -73,10 +73,10 @@ ExcelScript.AutoFilter,getIsDataFiltered(),Method,Poor,false
 ExcelScript.AutoFilter,getRange(),Method,Poor,false
 ExcelScript.AutoFilter,reapply(),Method,Poor,false
 ExcelScript.AutoFilter,remove(),Method,Poor,false
-ExcelScript.BasicDataValidation,N/A,Class,Poor,true
+ExcelScript.BasicDataValidation,N/A,Class,Fine,true
 ExcelScript.BasicDataValidation,formula1,Property,Good,false
 ExcelScript.BasicDataValidation,formula2,Property,Good,false
-ExcelScript.BasicDataValidation,operator,Property,Poor,false
+ExcelScript.BasicDataValidation,operator,Property,Fine,false
 ExcelScript.Binding,N/A,Class,Fine,false
 ExcelScript.Binding,delete(),Method,Poor,false
 ExcelScript.Binding,getId(),Method,Poor,false
@@ -176,13 +176,13 @@ ExcelScript.CalculationType,N/A,Enum,Missing,true
 ExcelScript.CalculationType,full,EnumField,Fine,false
 ExcelScript.CalculationType,fullRebuild,EnumField,Fine,false
 ExcelScript.CalculationType,recalculate,EnumField,Fine,false
-ExcelScript.CellValueConditionalFormat,N/A,Class,Poor,true
+ExcelScript.CellValueConditionalFormat,N/A,Class,Fine,true
 ExcelScript.CellValueConditionalFormat,getFormat(),Method,Poor,false
 ExcelScript.CellValueConditionalFormat,getRule(),Method,Poor,false
 ExcelScript.CellValueConditionalFormat,setRule(rule),Method,Poor,false
-ExcelScript.Chart,N/A,Class,Poor,false
+ExcelScript.Chart,N/A,Class,Fine,false
 ExcelScript.Chart,activate(),Method,Poor,false
-ExcelScript.Chart,addChartSeries(name,Method,Fine,true
+ExcelScript.Chart,addChartSeries(name, index),Method,Fine,true
 ExcelScript.Chart,delete(),Method,Poor,false
 ExcelScript.Chart,getAxes(),Method,Poor,false
 ExcelScript.Chart,getCategoryLabelLevel(),Method,Poor,false
@@ -193,7 +193,7 @@ ExcelScript.Chart,getDisplayBlanksAs(),Method,Poor,false
 ExcelScript.Chart,getFormat(),Method,Poor,false
 ExcelScript.Chart,getHeight(),Method,Poor,false
 ExcelScript.Chart,getId(),Method,Poor,false
-ExcelScript.Chart,getImage(width,Method,Fine,true
+ExcelScript.Chart,getImage(width, height, fittingMode),Method,Good,true
 ExcelScript.Chart,getLeft(),Method,Poor,false
 ExcelScript.Chart,getLegend(),Method,Poor,false
 ExcelScript.Chart,getName(),Method,Poor,false
@@ -212,21 +212,21 @@ ExcelScript.Chart,getWidth(),Method,Poor,false
 ExcelScript.Chart,getWorksheet(),Method,Poor,false
 ExcelScript.Chart,setCategoryLabelLevel(categoryLabelLevel),Method,Poor,false
 ExcelScript.Chart,setChartType(chartType),Method,Poor,false
-ExcelScript.Chart,setData(sourceData,Method,Poor,false
+ExcelScript.Chart,setData(sourceData, seriesBy),Method,Poor,false
 ExcelScript.Chart,setDisplayBlanksAs(displayBlanksAs),Method,Poor,false
 ExcelScript.Chart,setHeight(height),Method,Poor,false
 ExcelScript.Chart,setLeft(left),Method,Poor,false
 ExcelScript.Chart,setName(name),Method,Poor,true
 ExcelScript.Chart,setPlotBy(plotBy),Method,Poor,true
 ExcelScript.Chart,setPlotVisibleOnly(plotVisibleOnly),Method,Poor,false
-ExcelScript.Chart,setPosition(startCell,Method,Fine,true
+ExcelScript.Chart,setPosition(startCell, endCell),Method,Fine,true
 ExcelScript.Chart,setSeriesNameLevel(seriesNameLevel),Method,Poor,false
 ExcelScript.Chart,setShowAllFieldButtons(showAllFieldButtons),Method,Poor,false
 ExcelScript.Chart,setShowDataLabelsOverMaximum(showDataLabelsOverMaximum),Method,Poor,false
 ExcelScript.Chart,setStyle(style),Method,Poor,false
 ExcelScript.Chart,setTop(top),Method,Poor,false
 ExcelScript.Chart,setWidth(width),Method,Poor,false
-ExcelScript.ChartAreaFormat,N/A,Class,Poor,false
+ExcelScript.ChartAreaFormat,N/A,Class,Fine,false
 ExcelScript.ChartAreaFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartAreaFormat,getColorScheme(),Method,Poor,false
 ExcelScript.ChartAreaFormat,getFill(),Method,Poor,false
@@ -236,10 +236,10 @@ ExcelScript.ChartAreaFormat,setColorScheme(colorScheme),Method,Poor,false
 ExcelScript.ChartAreaFormat,setRoundedCorners(roundedCorners),Method,Poor,false
 ExcelScript.ChartAxes,N/A,Class,Poor,false
 ExcelScript.ChartAxes,getCategoryAxis(),Method,Poor,false
-ExcelScript.ChartAxes,getChartAxis(type,Method,Poor,false
+ExcelScript.ChartAxes,getChartAxis(type, group),Method,Poor,false
 ExcelScript.ChartAxes,getSeriesAxis(),Method,Poor,false
 ExcelScript.ChartAxes,getValueAxis(),Method,Poor,false
-ExcelScript.ChartAxis,N/A,Class,Poor,false
+ExcelScript.ChartAxis,N/A,Class,Fine,false
 ExcelScript.ChartAxis,getAlignment(),Method,Poor,false
 ExcelScript.ChartAxis,getAxisGroup(),Method,Poor,false
 ExcelScript.ChartAxis,getBaseTimeUnit(),Method,Poor,false
@@ -309,23 +309,23 @@ ExcelScript.ChartAxis,setTickLabelPosition(tickLabelPosition),Method,Poor,false
 ExcelScript.ChartAxis,setTickLabelSpacing(tickLabelSpacing),Method,Poor,false
 ExcelScript.ChartAxis,setTickMarkSpacing(tickMarkSpacing),Method,Poor,false
 ExcelScript.ChartAxis,setVisible(visible),Method,Poor,false
-ExcelScript.ChartAxisCategoryType,N/A,Enum,Poor,false
+ExcelScript.ChartAxisCategoryType,N/A,Enum,Fine,false
 ExcelScript.ChartAxisCategoryType,automatic,EnumField,Poor,false
-ExcelScript.ChartAxisCategoryType,dateAxis,EnumField,Poor,false
-ExcelScript.ChartAxisCategoryType,textAxis,EnumField,Poor,false
+ExcelScript.ChartAxisCategoryType,dateAxis,EnumField,Fine,false
+ExcelScript.ChartAxisCategoryType,textAxis,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,N/A,Enum,Missing,false
-ExcelScript.ChartAxisDisplayUnit,billions,EnumField,Poor,false
+ExcelScript.ChartAxisDisplayUnit,billions,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,custom,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,hundredMillions,EnumField,Fine,false
-ExcelScript.ChartAxisDisplayUnit,hundreds,EnumField,Poor,false
+ExcelScript.ChartAxisDisplayUnit,hundreds,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,hundredThousands,EnumField,Fine,false
-ExcelScript.ChartAxisDisplayUnit,millions,EnumField,Poor,false
+ExcelScript.ChartAxisDisplayUnit,millions,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,none,EnumField,Good,false
 ExcelScript.ChartAxisDisplayUnit,tenMillions,EnumField,Fine,false
 ExcelScript.ChartAxisDisplayUnit,tenThousands,EnumField,Fine,false
-ExcelScript.ChartAxisDisplayUnit,thousands,EnumField,Poor,false
-ExcelScript.ChartAxisDisplayUnit,trillions,EnumField,Poor,false
-ExcelScript.ChartAxisFormat,N/A,Class,Poor,false
+ExcelScript.ChartAxisDisplayUnit,thousands,EnumField,Fine,false
+ExcelScript.ChartAxisDisplayUnit,trillions,EnumField,Fine,false
+ExcelScript.ChartAxisFormat,N/A,Class,Fine,false
 ExcelScript.ChartAxisFormat,getFill(),Method,Poor,false
 ExcelScript.ChartAxisFormat,getFont(),Method,Poor,false
 ExcelScript.ChartAxisFormat,getLine(),Method,Poor,false
@@ -354,7 +354,7 @@ ExcelScript.ChartAxisTimeUnit,N/A,Enum,Fine,false
 ExcelScript.ChartAxisTimeUnit,days,EnumField,Missing,false
 ExcelScript.ChartAxisTimeUnit,months,EnumField,Missing,false
 ExcelScript.ChartAxisTimeUnit,years,EnumField,Missing,false
-ExcelScript.ChartAxisTitle,N/A,Class,Poor,false
+ExcelScript.ChartAxisTitle,N/A,Class,Fine,false
 ExcelScript.ChartAxisTitle,getFormat(),Method,Poor,false
 ExcelScript.ChartAxisTitle,getText(),Method,Poor,false
 ExcelScript.ChartAxisTitle,getTextOrientation(),Method,Poor,false
@@ -363,7 +363,7 @@ ExcelScript.ChartAxisTitle,setFormula(formula),Method,Poor,false
 ExcelScript.ChartAxisTitle,setText(text),Method,Poor,false
 ExcelScript.ChartAxisTitle,setTextOrientation(textOrientation),Method,Poor,false
 ExcelScript.ChartAxisTitle,setVisible(visible),Method,Poor,false
-ExcelScript.ChartAxisTitleFormat,N/A,Class,Poor,false
+ExcelScript.ChartAxisTitleFormat,N/A,Class,Fine,false
 ExcelScript.ChartAxisTitleFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartAxisTitleFormat,getFill(),Method,Poor,false
 ExcelScript.ChartAxisTitleFormat,getFont(),Method,Poor,false
@@ -392,7 +392,7 @@ ExcelScript.ChartBinType,auto,EnumField,Missing,false
 ExcelScript.ChartBinType,binCount,EnumField,Missing,false
 ExcelScript.ChartBinType,binWidth,EnumField,Missing,false
 ExcelScript.ChartBinType,category,EnumField,Missing,false
-ExcelScript.ChartBorder,N/A,Class,Poor,false
+ExcelScript.ChartBorder,N/A,Class,Fine,false
 ExcelScript.ChartBorder,clear(),Method,Poor,false
 ExcelScript.ChartBorder,getColor(),Method,Poor,false
 ExcelScript.ChartBorder,getLineStyle(),Method,Poor,false
@@ -403,7 +403,7 @@ ExcelScript.ChartBorder,setWeight(weight),Method,Poor,false
 ExcelScript.ChartBoxQuartileCalculation,N/A,Enum,Good,false
 ExcelScript.ChartBoxQuartileCalculation,exclusive,EnumField,Missing,false
 ExcelScript.ChartBoxQuartileCalculation,inclusive,EnumField,Missing,false
-ExcelScript.ChartBoxwhiskerOptions,N/A,Class,Poor,false
+ExcelScript.ChartBoxwhiskerOptions,N/A,Class,Fine,false
 ExcelScript.ChartBoxwhiskerOptions,getQuartileCalculation(),Method,Poor,false
 ExcelScript.ChartBoxwhiskerOptions,getShowInnerPoints(),Method,Poor,false
 ExcelScript.ChartBoxwhiskerOptions,getShowMeanLine(),Method,Poor,false
@@ -432,7 +432,7 @@ ExcelScript.ChartColorScheme,monochromaticPalette6,EnumField,Missing,false
 ExcelScript.ChartColorScheme,monochromaticPalette7,EnumField,Missing,false
 ExcelScript.ChartColorScheme,monochromaticPalette8,EnumField,Missing,false
 ExcelScript.ChartColorScheme,monochromaticPalette9,EnumField,Missing,false
-ExcelScript.ChartDataLabel,N/A,Class,Poor,false
+ExcelScript.ChartDataLabel,N/A,Class,Fine,false
 ExcelScript.ChartDataLabel,getAutoText(),Method,Poor,false
 ExcelScript.ChartDataLabel,getFormat(),Method,Poor,false
 ExcelScript.ChartDataLabel,getFormula(),Method,Poor,false
@@ -472,7 +472,7 @@ ExcelScript.ChartDataLabel,setText(text),Method,Poor,false
 ExcelScript.ChartDataLabel,setTextOrientation(textOrientation),Method,Poor,false
 ExcelScript.ChartDataLabel,setTop(top),Method,Poor,false
 ExcelScript.ChartDataLabel,setVerticalAlignment(verticalAlignment),Method,Poor,false
-ExcelScript.ChartDataLabelFormat,N/A,Class,Poor,false
+ExcelScript.ChartDataLabelFormat,N/A,Class,Fine,false
 ExcelScript.ChartDataLabelFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartDataLabelFormat,getFill(),Method,Poor,false
 ExcelScript.ChartDataLabelFormat,getFont(),Method,Poor,false
@@ -524,7 +524,7 @@ ExcelScript.ChartDataSourceType,externalRange,EnumField,Missing,false
 ExcelScript.ChartDataSourceType,list,EnumField,Missing,false
 ExcelScript.ChartDataSourceType,localRange,EnumField,Missing,false
 ExcelScript.ChartDataSourceType,unknown,EnumField,Missing,false
-ExcelScript.ChartDataTable,N/A,Class,Poor,false
+ExcelScript.ChartDataTable,N/A,Class,Fine,false
 ExcelScript.ChartDataTable,getFormat(),Method,Poor,false
 ExcelScript.ChartDataTable,getShowHorizontalBorder(),Method,Poor,false
 ExcelScript.ChartDataTable,getShowLegendKey(),Method,Poor,false
@@ -536,7 +536,7 @@ ExcelScript.ChartDataTable,setShowLegendKey(showLegendKey),Method,Poor,false
 ExcelScript.ChartDataTable,setShowOutlineBorder(showOutlineBorder),Method,Poor,false
 ExcelScript.ChartDataTable,setShowVerticalBorder(showVerticalBorder),Method,Poor,false
 ExcelScript.ChartDataTable,setVisible(visible),Method,Poor,false
-ExcelScript.ChartDataTableFormat,N/A,Class,Poor,false
+ExcelScript.ChartDataTableFormat,N/A,Class,Fine,false
 ExcelScript.ChartDataTableFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartDataTableFormat,getFill(),Method,Poor,false
 ExcelScript.ChartDataTableFormat,getFont(),Method,Poor,false
@@ -554,19 +554,19 @@ ExcelScript.ChartErrorBars,setEndStyleCap(endStyleCap),Method,Poor,false
 ExcelScript.ChartErrorBars,setInclude(include),Method,Poor,false
 ExcelScript.ChartErrorBars,setType(type),Method,Poor,false
 ExcelScript.ChartErrorBars,setVisible(visible),Method,Poor,false
-ExcelScript.ChartErrorBarsFormat,N/A,Class,Poor,false
+ExcelScript.ChartErrorBarsFormat,N/A,Class,Fine,false
 ExcelScript.ChartErrorBarsFormat,getLine(),Method,Poor,false
-ExcelScript.ChartErrorBarsInclude,N/A,Enum,Poor,false
+ExcelScript.ChartErrorBarsInclude,N/A,Enum,Fine,false
 ExcelScript.ChartErrorBarsInclude,both,EnumField,Missing,false
 ExcelScript.ChartErrorBarsInclude,minusValues,EnumField,Missing,false
 ExcelScript.ChartErrorBarsInclude,plusValues,EnumField,Missing,false
-ExcelScript.ChartErrorBarsType,N/A,Enum,Poor,true
+ExcelScript.ChartErrorBarsType,N/A,Enum,Fine,true
 ExcelScript.ChartErrorBarsType,custom,EnumField,Missing,false
 ExcelScript.ChartErrorBarsType,fixedValue,EnumField,Missing,false
 ExcelScript.ChartErrorBarsType,percent,EnumField,Missing,false
 ExcelScript.ChartErrorBarsType,stDev,EnumField,Missing,false
 ExcelScript.ChartErrorBarsType,stError,EnumField,Missing,false
-ExcelScript.ChartFill,N/A,Class,Poor,false
+ExcelScript.ChartFill,N/A,Class,Fine,false
 ExcelScript.ChartFill,clear(),Method,Poor,false
 ExcelScript.ChartFill,getSolidColor(),Method,Poor,false
 ExcelScript.ChartFill,setSolidColor(color),Method,Poor,false
@@ -592,13 +592,13 @@ ExcelScript.ChartGradientStyleType,N/A,Enum,Good,false
 ExcelScript.ChartGradientStyleType,extremeValue,EnumField,Missing,false
 ExcelScript.ChartGradientStyleType,number,EnumField,Missing,false
 ExcelScript.ChartGradientStyleType,percent,EnumField,Missing,false
-ExcelScript.ChartGridlines,N/A,Class,Poor,false
+ExcelScript.ChartGridlines,N/A,Class,Fine,false
 ExcelScript.ChartGridlines,getFormat(),Method,Poor,false
 ExcelScript.ChartGridlines,getVisible(),Method,Poor,false
 ExcelScript.ChartGridlines,setVisible(visible),Method,Poor,false
-ExcelScript.ChartGridlinesFormat,N/A,Class,Poor,false
+ExcelScript.ChartGridlinesFormat,N/A,Class,Fine,false
 ExcelScript.ChartGridlinesFormat,getLine(),Method,Poor,false
-ExcelScript.ChartLegend,N/A,Class,Poor,false
+ExcelScript.ChartLegend,N/A,Class,Fine,false
 ExcelScript.ChartLegend,getFormat(),Method,Poor,false
 ExcelScript.ChartLegend,getHeight(),Method,Poor,false
 ExcelScript.ChartLegend,getLeft(),Method,Poor,false
@@ -617,7 +617,7 @@ ExcelScript.ChartLegend,setShowShadow(showShadow),Method,Poor,false
 ExcelScript.ChartLegend,setTop(top),Method,Poor,false
 ExcelScript.ChartLegend,setVisible(visible),Method,Poor,false
 ExcelScript.ChartLegend,setWidth(width),Method,Poor,false
-ExcelScript.ChartLegendEntry,N/A,Class,Poor,false
+ExcelScript.ChartLegendEntry,N/A,Class,Fine,false
 ExcelScript.ChartLegendEntry,getHeight(),Method,Poor,false
 ExcelScript.ChartLegendEntry,getIndex(),Method,Poor,false
 ExcelScript.ChartLegendEntry,getLeft(),Method,Poor,false
@@ -625,7 +625,7 @@ ExcelScript.ChartLegendEntry,getTop(),Method,Poor,false
 ExcelScript.ChartLegendEntry,getVisible(),Method,Poor,false
 ExcelScript.ChartLegendEntry,getWidth(),Method,Poor,false
 ExcelScript.ChartLegendEntry,setVisible(visible),Method,Poor,false
-ExcelScript.ChartLegendFormat,N/A,Class,Poor,false
+ExcelScript.ChartLegendFormat,N/A,Class,Fine,false
 ExcelScript.ChartLegendFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartLegendFormat,getFill(),Method,Poor,false
 ExcelScript.ChartLegendFormat,getFont(),Method,Poor,false
@@ -637,7 +637,7 @@ ExcelScript.ChartLegendPosition,invalid,EnumField,Missing,false
 ExcelScript.ChartLegendPosition,left,EnumField,Missing,false
 ExcelScript.ChartLegendPosition,right,EnumField,Missing,false
 ExcelScript.ChartLegendPosition,top,EnumField,Missing,false
-ExcelScript.ChartLineFormat,N/A,Class,Poor,false
+ExcelScript.ChartLineFormat,N/A,Class,Fine,false
 ExcelScript.ChartLineFormat,clear(),Method,Poor,false
 ExcelScript.ChartLineFormat,getColor(),Method,Poor,false
 ExcelScript.ChartLineFormat,getLineStyle(),Method,Poor,false
@@ -670,7 +670,7 @@ ExcelScript.ChartMapLabelStrategy,N/A,Enum,Good,false
 ExcelScript.ChartMapLabelStrategy,bestFit,EnumField,Missing,false
 ExcelScript.ChartMapLabelStrategy,none,EnumField,Missing,false
 ExcelScript.ChartMapLabelStrategy,showAll,EnumField,Missing,false
-ExcelScript.ChartMapOptions,N/A,Class,Poor,false
+ExcelScript.ChartMapOptions,N/A,Class,Fine,false
 ExcelScript.ChartMapOptions,getLabelStrategy(),Method,Poor,false
 ExcelScript.ChartMapOptions,getLevel(),Method,Poor,false
 ExcelScript.ChartMapOptions,getProjectionType(),Method,Poor,false
@@ -701,7 +701,7 @@ ExcelScript.ChartParentLabelStrategy,N/A,Enum,Good,false
 ExcelScript.ChartParentLabelStrategy,banner,EnumField,Missing,false
 ExcelScript.ChartParentLabelStrategy,none,EnumField,Missing,false
 ExcelScript.ChartParentLabelStrategy,overlapping,EnumField,Missing,false
-ExcelScript.ChartPivotOptions,N/A,Class,Poor,false
+ExcelScript.ChartPivotOptions,N/A,Class,Fine,false
 ExcelScript.ChartPivotOptions,getShowAxisFieldButtons(),Method,Poor,false
 ExcelScript.ChartPivotOptions,getShowLegendFieldButtons(),Method,Poor,false
 ExcelScript.ChartPivotOptions,getShowReportFilterFieldButtons(),Method,Poor,false
@@ -730,7 +730,7 @@ ExcelScript.ChartPlotArea,setLeft(left),Method,Poor,false
 ExcelScript.ChartPlotArea,setPosition(position),Method,Poor,false
 ExcelScript.ChartPlotArea,setTop(top),Method,Poor,false
 ExcelScript.ChartPlotArea,setWidth(width),Method,Poor,false
-ExcelScript.ChartPlotAreaFormat,N/A,Class,Poor,false
+ExcelScript.ChartPlotAreaFormat,N/A,Class,Fine,false
 ExcelScript.ChartPlotAreaFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartPlotAreaFormat,getFill(),Method,Poor,false
 ExcelScript.ChartPlotAreaPosition,N/A,Enum,Missing,false
@@ -739,7 +739,7 @@ ExcelScript.ChartPlotAreaPosition,custom,EnumField,Missing,false
 ExcelScript.ChartPlotBy,N/A,Enum,Missing,true
 ExcelScript.ChartPlotBy,columns,EnumField,Missing,false
 ExcelScript.ChartPlotBy,rows,EnumField,Missing,false
-ExcelScript.ChartPoint,N/A,Class,Poor,false
+ExcelScript.ChartPoint,N/A,Class,Fine,false
 ExcelScript.ChartPoint,getDataLabel(),Method,Poor,false
 ExcelScript.ChartPoint,getFormat(),Method,Poor,false
 ExcelScript.ChartPoint,getHasDataLabel(),Method,Poor,false
@@ -753,10 +753,10 @@ ExcelScript.ChartPoint,setMarkerBackgroundColor(markerBackgroundColor),Method,Po
 ExcelScript.ChartPoint,setMarkerForegroundColor(markerForegroundColor),Method,Poor,false
 ExcelScript.ChartPoint,setMarkerSize(markerSize),Method,Poor,false
 ExcelScript.ChartPoint,setMarkerStyle(markerStyle),Method,Poor,false
-ExcelScript.ChartPointFormat,N/A,Class,Poor,false
+ExcelScript.ChartPointFormat,N/A,Class,Fine,false
 ExcelScript.ChartPointFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartPointFormat,getFill(),Method,Poor,false
-ExcelScript.ChartSeries,N/A,Class,Poor,true
+ExcelScript.ChartSeries,N/A,Class,Fine,true
 ExcelScript.ChartSeries,addChartTrendline(type),Method,Poor,false
 ExcelScript.ChartSeries,delete(),Method,Poor,false
 ExcelScript.ChartSeries,getAxisGroup(),Method,Poor,false
@@ -853,13 +853,13 @@ ExcelScript.ChartSeriesBy,N/A,Enum,Good,true
 ExcelScript.ChartSeriesBy,auto,EnumField,Good,false
 ExcelScript.ChartSeriesBy,columns,EnumField,Missing,false
 ExcelScript.ChartSeriesBy,rows,EnumField,Missing,false
-ExcelScript.ChartSeriesDimension,N/A,Enum,Poor,false
+ExcelScript.ChartSeriesDimension,N/A,Enum,Fine,false
 ExcelScript.ChartSeriesDimension,bubbleSizes,EnumField,Fine,false
-ExcelScript.ChartSeriesDimension,categories,EnumField,Poor,false
-ExcelScript.ChartSeriesDimension,values,EnumField,Poor,false
+ExcelScript.ChartSeriesDimension,categories,EnumField,Fine,false
+ExcelScript.ChartSeriesDimension,values,EnumField,Fine,false
 ExcelScript.ChartSeriesDimension,xvalues,EnumField,Fine,false
 ExcelScript.ChartSeriesDimension,yvalues,EnumField,Fine,false
-ExcelScript.ChartSeriesFormat,N/A,Class,Poor,false
+ExcelScript.ChartSeriesFormat,N/A,Class,Fine,false
 ExcelScript.ChartSeriesFormat,getFill(),Method,Poor,false
 ExcelScript.ChartSeriesFormat,getLine(),Method,Poor,false
 ExcelScript.ChartSplitType,N/A,Enum,Missing,false
@@ -867,13 +867,13 @@ ExcelScript.ChartSplitType,splitByCustomSplit,EnumField,Missing,false
 ExcelScript.ChartSplitType,splitByPercentValue,EnumField,Missing,false
 ExcelScript.ChartSplitType,splitByPosition,EnumField,Missing,false
 ExcelScript.ChartSplitType,splitByValue,EnumField,Missing,false
-ExcelScript.ChartTextHorizontalAlignment,N/A,Enum,Poor,false
+ExcelScript.ChartTextHorizontalAlignment,N/A,Enum,Fine,false
 ExcelScript.ChartTextHorizontalAlignment,center,EnumField,Missing,false
 ExcelScript.ChartTextHorizontalAlignment,distributed,EnumField,Missing,false
 ExcelScript.ChartTextHorizontalAlignment,justify,EnumField,Missing,false
 ExcelScript.ChartTextHorizontalAlignment,left,EnumField,Missing,false
 ExcelScript.ChartTextHorizontalAlignment,right,EnumField,Missing,false
-ExcelScript.ChartTextVerticalAlignment,N/A,Enum,Poor,false
+ExcelScript.ChartTextVerticalAlignment,N/A,Enum,Fine,false
 ExcelScript.ChartTextVerticalAlignment,bottom,EnumField,Missing,false
 ExcelScript.ChartTextVerticalAlignment,center,EnumField,Missing,false
 ExcelScript.ChartTextVerticalAlignment,distributed,EnumField,Missing,false
@@ -883,7 +883,7 @@ ExcelScript.ChartTickLabelAlignment,N/A,Enum,Missing,false
 ExcelScript.ChartTickLabelAlignment,center,EnumField,Missing,false
 ExcelScript.ChartTickLabelAlignment,left,EnumField,Missing,false
 ExcelScript.ChartTickLabelAlignment,right,EnumField,Missing,false
-ExcelScript.ChartTitle,N/A,Class,Poor,false
+ExcelScript.ChartTitle,N/A,Class,Fine,false
 ExcelScript.ChartTitle,getFormat(),Method,Poor,false
 ExcelScript.ChartTitle,getHeight(),Method,Poor,false
 ExcelScript.ChartTitle,getHorizontalAlignment(),Method,Poor,false
@@ -891,7 +891,7 @@ ExcelScript.ChartTitle,getLeft(),Method,Poor,false
 ExcelScript.ChartTitle,getOverlay(),Method,Poor,false
 ExcelScript.ChartTitle,getPosition(),Method,Poor,false
 ExcelScript.ChartTitle,getShowShadow(),Method,Poor,false
-ExcelScript.ChartTitle,getSubstring(start,Method,Poor,false
+ExcelScript.ChartTitle,getSubstring(start, length),Method,Poor,false
 ExcelScript.ChartTitle,getText(),Method,Poor,false
 ExcelScript.ChartTitle,getTextOrientation(),Method,Poor,false
 ExcelScript.ChartTitle,getTop(),Method,Poor,false
@@ -913,7 +913,7 @@ ExcelScript.ChartTitleFormat,N/A,Class,Fine,false
 ExcelScript.ChartTitleFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartTitleFormat,getFill(),Method,Poor,false
 ExcelScript.ChartTitleFormat,getFont(),Method,Poor,false
-ExcelScript.ChartTitlePosition,N/A,Enum,Poor,false
+ExcelScript.ChartTitlePosition,N/A,Enum,Fine,false
 ExcelScript.ChartTitlePosition,automatic,EnumField,Missing,false
 ExcelScript.ChartTitlePosition,bottom,EnumField,Missing,false
 ExcelScript.ChartTitlePosition,left,EnumField,Missing,false
@@ -941,7 +941,7 @@ ExcelScript.ChartTrendline,setPolynomialOrder(polynomialOrder),Method,Poor,false
 ExcelScript.ChartTrendline,setShowEquation(showEquation),Method,Poor,false
 ExcelScript.ChartTrendline,setShowRSquared(showRSquared),Method,Poor,false
 ExcelScript.ChartTrendline,setType(type),Method,Poor,false
-ExcelScript.ChartTrendlineFormat,N/A,Class,Poor,false
+ExcelScript.ChartTrendlineFormat,N/A,Class,Fine,false
 ExcelScript.ChartTrendlineFormat,getLine(),Method,Poor,false
 ExcelScript.ChartTrendlineLabel,N/A,Class,Fine,false
 ExcelScript.ChartTrendlineLabel,getAutoText(),Method,Poor,false
@@ -967,7 +967,7 @@ ExcelScript.ChartTrendlineLabel,setText(text),Method,Poor,false
 ExcelScript.ChartTrendlineLabel,setTextOrientation(textOrientation),Method,Poor,false
 ExcelScript.ChartTrendlineLabel,setTop(top),Method,Poor,false
 ExcelScript.ChartTrendlineLabel,setVerticalAlignment(verticalAlignment),Method,Poor,false
-ExcelScript.ChartTrendlineLabelFormat,N/A,Class,Poor,false
+ExcelScript.ChartTrendlineLabelFormat,N/A,Class,Fine,false
 ExcelScript.ChartTrendlineLabelFormat,getBorder(),Method,Poor,false
 ExcelScript.ChartTrendlineLabelFormat,getFill(),Method,Poor,false
 ExcelScript.ChartTrendlineLabelFormat,getFont(),Method,Poor,false
@@ -1053,16 +1053,16 @@ ExcelScript.ChartUnderlineStyle,none,EnumField,Missing,false
 ExcelScript.ChartUnderlineStyle,single,EnumField,Missing,false
 ExcelScript.ClearApplyTo,N/A,Enum,Missing,true
 ExcelScript.ClearApplyTo,all,EnumField,Missing,false
-ExcelScript.ClearApplyTo,contents,EnumField,Poor,false
-ExcelScript.ClearApplyTo,formats,EnumField,Poor,false
+ExcelScript.ClearApplyTo,contents,EnumField,Fine,false
+ExcelScript.ClearApplyTo,formats,EnumField,Fine,false
 ExcelScript.ClearApplyTo,hyperlinks,EnumField,Fine,false
 ExcelScript.ClearApplyTo,removeHyperlinks,EnumField,Fine,false
-ExcelScript.ColorScaleConditionalFormat,N/A,Class,Poor,false
+ExcelScript.ColorScaleConditionalFormat,N/A,Class,Fine,false
 ExcelScript.ColorScaleConditionalFormat,getCriteria(),Method,Poor,false
 ExcelScript.ColorScaleConditionalFormat,getThreeColorScale(),Method,Poor,false
 ExcelScript.ColorScaleConditionalFormat,setCriteria(criteria),Method,Poor,false
-ExcelScript.Comment,N/A,Class,Poor,false
-ExcelScript.Comment,addCommentReply(content,Method,Poor,false
+ExcelScript.Comment,N/A,Class,Fine,false
+ExcelScript.Comment,addCommentReply(content, contentType),Method,Poor,false
 ExcelScript.Comment,delete(),Method,Poor,false
 ExcelScript.Comment,getAuthorEmail(),Method,Poor,false
 ExcelScript.Comment,getAuthorName(),Method,Poor,false
@@ -1079,11 +1079,11 @@ ExcelScript.Comment,getRichContent(),Method,Poor,false
 ExcelScript.Comment,setContent(content),Method,Poor,false
 ExcelScript.Comment,setResolved(resolved),Method,Poor,false
 ExcelScript.Comment,updateMentions(contentWithMentions),Method,Poor,false
-ExcelScript.CommentMention,N/A,Class,Poor,true
+ExcelScript.CommentMention,N/A,Class,Fine,true
 ExcelScript.CommentMention,email,Property,Fine,false
 ExcelScript.CommentMention,id,Property,Good,false
 ExcelScript.CommentMention,name,Property,Fine,false
-ExcelScript.CommentReply,N/A,Class,Poor,false
+ExcelScript.CommentReply,N/A,Class,Fine,false
 ExcelScript.CommentReply,delete(),Method,Poor,false
 ExcelScript.CommentReply,getAuthorEmail(),Method,Poor,false
 ExcelScript.CommentReply,getAuthorName(),Method,Poor,false
@@ -1101,7 +1101,7 @@ ExcelScript.CommentReply,updateMentions(contentWithMentions),Method,Poor,false
 ExcelScript.CommentRichContent,N/A,Class,Good,false
 ExcelScript.CommentRichContent,mentions,Property,Fine,false
 ExcelScript.CommentRichContent,richContent,Property,Fine,true
-ExcelScript.ConditionalCellValueOperator,N/A,Enum,Poor,true
+ExcelScript.ConditionalCellValueOperator,N/A,Enum,Fine,true
 ExcelScript.ConditionalCellValueOperator,between,EnumField,Missing,false
 ExcelScript.ConditionalCellValueOperator,equalTo,EnumField,Missing,false
 ExcelScript.ConditionalCellValueOperator,greaterThan,EnumField,Missing,false
@@ -1111,23 +1111,23 @@ ExcelScript.ConditionalCellValueOperator,lessThan,EnumField,Missing,false
 ExcelScript.ConditionalCellValueOperator,lessThanOrEqual,EnumField,Missing,false
 ExcelScript.ConditionalCellValueOperator,notBetween,EnumField,Missing,false
 ExcelScript.ConditionalCellValueOperator,notEqualTo,EnumField,Missing,false
-ExcelScript.ConditionalCellValueRule,N/A,Class,Poor,true
+ExcelScript.ConditionalCellValueRule,N/A,Class,Fine,true
 ExcelScript.ConditionalCellValueRule,formula1,Property,Fine,false
 ExcelScript.ConditionalCellValueRule,formula2,Property,Fine,false
-ExcelScript.ConditionalCellValueRule,operator,Property,Poor,false
-ExcelScript.ConditionalColorScaleCriteria,N/A,Class,Poor,false
-ExcelScript.ConditionalColorScaleCriteria,maximum,Property,Poor,false
+ExcelScript.ConditionalCellValueRule,operator,Property,Fine,false
+ExcelScript.ConditionalColorScaleCriteria,N/A,Class,Fine,false
+ExcelScript.ConditionalColorScaleCriteria,maximum,Property,Fine,false
 ExcelScript.ConditionalColorScaleCriteria,midpoint,Property,Fine,false
-ExcelScript.ConditionalColorScaleCriteria,minimum,Property,Poor,false
+ExcelScript.ConditionalColorScaleCriteria,minimum,Property,Fine,false
 ExcelScript.ConditionalColorScaleCriterion,N/A,Class,Fine,false
 ExcelScript.ConditionalColorScaleCriterion,color,Property,Fine,false
 ExcelScript.ConditionalColorScaleCriterion,formula,Property,Fine,false
-ExcelScript.ConditionalColorScaleCriterion,type,Property,Poor,false
-ExcelScript.ConditionalDataBarAxisFormat,N/A,Enum,Poor,false
+ExcelScript.ConditionalColorScaleCriterion,type,Property,Fine,false
+ExcelScript.ConditionalDataBarAxisFormat,N/A,Enum,Fine,false
 ExcelScript.ConditionalDataBarAxisFormat,automatic,EnumField,Missing,false
 ExcelScript.ConditionalDataBarAxisFormat,cellMidPoint,EnumField,Missing,false
 ExcelScript.ConditionalDataBarAxisFormat,none,EnumField,Missing,false
-ExcelScript.ConditionalDataBarDirection,N/A,Enum,Poor,false
+ExcelScript.ConditionalDataBarDirection,N/A,Enum,Fine,false
 ExcelScript.ConditionalDataBarDirection,context,EnumField,Missing,false
 ExcelScript.ConditionalDataBarDirection,leftToRight,EnumField,Missing,false
 ExcelScript.ConditionalDataBarDirection,rightToLeft,EnumField,Missing,false
@@ -1147,9 +1147,9 @@ ExcelScript.ConditionalDataBarPositiveFormat,getGradientFill(),Method,Poor,false
 ExcelScript.ConditionalDataBarPositiveFormat,setBorderColor(borderColor),Method,Poor,false
 ExcelScript.ConditionalDataBarPositiveFormat,setFillColor(fillColor),Method,Poor,false
 ExcelScript.ConditionalDataBarPositiveFormat,setGradientFill(gradientFill),Method,Poor,false
-ExcelScript.ConditionalDataBarRule,N/A,Class,Poor,true
+ExcelScript.ConditionalDataBarRule,N/A,Class,Fine,true
 ExcelScript.ConditionalDataBarRule,formula,Property,Fine,false
-ExcelScript.ConditionalDataBarRule,type,Property,Poor,false
+ExcelScript.ConditionalDataBarRule,type,Property,Fine,false
 ExcelScript.ConditionalFormat,N/A,Class,Fine,false
 ExcelScript.ConditionalFormat,delete(),Method,Poor,false
 ExcelScript.ConditionalFormat,getCellValue(),Method,Poor,true
@@ -1168,7 +1168,7 @@ ExcelScript.ConditionalFormat,getTopBottom(),Method,Poor,false
 ExcelScript.ConditionalFormat,getType(),Method,Poor,false
 ExcelScript.ConditionalFormat,setPriority(priority),Method,Poor,false
 ExcelScript.ConditionalFormat,setStopIfTrue(stopIfTrue),Method,Poor,false
-ExcelScript.ConditionalFormatColorCriterionType,N/A,Enum,Poor,true
+ExcelScript.ConditionalFormatColorCriterionType,N/A,Enum,Fine,true
 ExcelScript.ConditionalFormatColorCriterionType,formula,EnumField,Missing,false
 ExcelScript.ConditionalFormatColorCriterionType,highestValue,EnumField,Missing,false
 ExcelScript.ConditionalFormatColorCriterionType,invalid,EnumField,Missing,false
@@ -1176,10 +1176,10 @@ ExcelScript.ConditionalFormatColorCriterionType,lowestValue,EnumField,Missing,fa
 ExcelScript.ConditionalFormatColorCriterionType,number,EnumField,Missing,false
 ExcelScript.ConditionalFormatColorCriterionType,percent,EnumField,Missing,false
 ExcelScript.ConditionalFormatColorCriterionType,percentile,EnumField,Missing,false
-ExcelScript.ConditionalFormatDirection,N/A,Enum,Poor,false
+ExcelScript.ConditionalFormatDirection,N/A,Enum,Fine,false
 ExcelScript.ConditionalFormatDirection,bottom,EnumField,Missing,false
 ExcelScript.ConditionalFormatDirection,top,EnumField,Missing,false
-ExcelScript.ConditionalFormatIconRuleType,N/A,Enum,Poor,true
+ExcelScript.ConditionalFormatIconRuleType,N/A,Enum,Fine,true
 ExcelScript.ConditionalFormatIconRuleType,formula,EnumField,Missing,false
 ExcelScript.ConditionalFormatIconRuleType,invalid,EnumField,Missing,false
 ExcelScript.ConditionalFormatIconRuleType,number,EnumField,Missing,false
@@ -1213,12 +1213,12 @@ ExcelScript.ConditionalFormatPresetCriterion,twoStdDevAboveAverage,EnumField,Mis
 ExcelScript.ConditionalFormatPresetCriterion,twoStdDevBelowAverage,EnumField,Missing,false
 ExcelScript.ConditionalFormatPresetCriterion,uniqueValues,EnumField,Missing,false
 ExcelScript.ConditionalFormatPresetCriterion,yesterday,EnumField,Missing,false
-ExcelScript.ConditionalFormatRule,N/A,Class,Poor,false
+ExcelScript.ConditionalFormatRule,N/A,Class,Fine,false
 ExcelScript.ConditionalFormatRule,getFormula(),Method,Poor,false
 ExcelScript.ConditionalFormatRule,getFormulaLocal(),Method,Poor,false
 ExcelScript.ConditionalFormatRule,setFormula(formula),Method,Poor,false
 ExcelScript.ConditionalFormatRule,setFormulaLocal(formulaLocal),Method,Poor,false
-ExcelScript.ConditionalFormatRuleType,N/A,Enum,Poor,true
+ExcelScript.ConditionalFormatRuleType,N/A,Enum,Fine,true
 ExcelScript.ConditionalFormatRuleType,automatic,EnumField,Missing,false
 ExcelScript.ConditionalFormatRuleType,formula,EnumField,Missing,false
 ExcelScript.ConditionalFormatRuleType,highestValue,EnumField,Missing,false
@@ -1238,16 +1238,16 @@ ExcelScript.ConditionalFormatType,presetCriteria,EnumField,Missing,false
 ExcelScript.ConditionalFormatType,topBottom,EnumField,Missing,false
 ExcelScript.ConditionalIconCriterion,N/A,Class,Fine,true
 ExcelScript.ConditionalIconCriterion,customIcon,Property,Fine,false
-ExcelScript.ConditionalIconCriterion,formula,Property,Poor,false
+ExcelScript.ConditionalIconCriterion,formula,Property,Fine,false
 ExcelScript.ConditionalIconCriterion,operator,Property,Fine,false
-ExcelScript.ConditionalIconCriterion,type,Property,Poor,false
-ExcelScript.ConditionalIconCriterionOperator,N/A,Enum,Poor,true
+ExcelScript.ConditionalIconCriterion,type,Property,Fine,false
+ExcelScript.ConditionalIconCriterionOperator,N/A,Enum,Fine,true
 ExcelScript.ConditionalIconCriterionOperator,greaterThan,EnumField,Missing,false
 ExcelScript.ConditionalIconCriterionOperator,greaterThanOrEqual,EnumField,Missing,false
 ExcelScript.ConditionalIconCriterionOperator,invalid,EnumField,Missing,false
-ExcelScript.ConditionalPresetCriteriaRule,N/A,Class,Poor,true
-ExcelScript.ConditionalPresetCriteriaRule,criterion,Property,Poor,false
-ExcelScript.ConditionalRangeBorder,N/A,Class,Poor,false
+ExcelScript.ConditionalPresetCriteriaRule,N/A,Class,Fine,true
+ExcelScript.ConditionalPresetCriteriaRule,criterion,Property,Fine,false
+ExcelScript.ConditionalRangeBorder,N/A,Class,Fine,false
 ExcelScript.ConditionalRangeBorder,getColor(),Method,Poor,false
 ExcelScript.ConditionalRangeBorder,getSideIndex(),Method,Poor,false
 ExcelScript.ConditionalRangeBorder,getStyle(),Method,Poor,false
@@ -1265,7 +1265,7 @@ ExcelScript.ConditionalRangeBorderLineStyle,dashDot,EnumField,Missing,false
 ExcelScript.ConditionalRangeBorderLineStyle,dashDotDot,EnumField,Missing,false
 ExcelScript.ConditionalRangeBorderLineStyle,dot,EnumField,Missing,false
 ExcelScript.ConditionalRangeBorderLineStyle,none,EnumField,Missing,false
-ExcelScript.ConditionalRangeFill,N/A,Class,Poor,false
+ExcelScript.ConditionalRangeFill,N/A,Class,Fine,false
 ExcelScript.ConditionalRangeFill,clear(),Method,Poor,false
 ExcelScript.ConditionalRangeFill,getColor(),Method,Poor,false
 ExcelScript.ConditionalRangeFill,setColor(color),Method,Poor,false
@@ -1296,10 +1296,10 @@ ExcelScript.ConditionalRangeFormat,getFill(),Method,Poor,false
 ExcelScript.ConditionalRangeFormat,getFont(),Method,Poor,false
 ExcelScript.ConditionalRangeFormat,getNumberFormat(),Method,Poor,false
 ExcelScript.ConditionalRangeFormat,setNumberFormat(numberFormat),Method,Poor,false
-ExcelScript.ConditionalTextComparisonRule,N/A,Class,Poor,true
-ExcelScript.ConditionalTextComparisonRule,operator,Property,Poor,false
-ExcelScript.ConditionalTextComparisonRule,text,Property,Poor,false
-ExcelScript.ConditionalTextOperator,N/A,Enum,Poor,true
+ExcelScript.ConditionalTextComparisonRule,N/A,Class,Fine,true
+ExcelScript.ConditionalTextComparisonRule,operator,Property,Fine,false
+ExcelScript.ConditionalTextComparisonRule,text,Property,Fine,false
+ExcelScript.ConditionalTextOperator,N/A,Enum,Fine,true
 ExcelScript.ConditionalTextOperator,beginsWith,EnumField,Missing,false
 ExcelScript.ConditionalTextOperator,contains,EnumField,Missing,false
 ExcelScript.ConditionalTextOperator,endsWith,EnumField,Missing,false
@@ -1311,24 +1311,24 @@ ExcelScript.ConditionalTopBottomCriterionType,bottomPercent,EnumField,Missing,fa
 ExcelScript.ConditionalTopBottomCriterionType,invalid,EnumField,Missing,false
 ExcelScript.ConditionalTopBottomCriterionType,topItems,EnumField,Missing,false
 ExcelScript.ConditionalTopBottomCriterionType,topPercent,EnumField,Missing,false
-ExcelScript.ConditionalTopBottomRule,N/A,Class,Poor,true
+ExcelScript.ConditionalTopBottomRule,N/A,Class,Fine,true
 ExcelScript.ConditionalTopBottomRule,rank,Property,Fine,false
-ExcelScript.ConditionalTopBottomRule,type,Property,Poor,false
+ExcelScript.ConditionalTopBottomRule,type,Property,Fine,false
 ExcelScript.ConnectorType,N/A,Enum,Missing,true
 ExcelScript.ConnectorType,curve,EnumField,Missing,false
 ExcelScript.ConnectorType,elbow,EnumField,Missing,false
 ExcelScript.ConnectorType,straight,EnumField,Missing,false
 ExcelScript.ContentType,N/A,Enum,Missing,true
 ExcelScript.ContentType,mention,EnumField,Poor,false
-ExcelScript.ContentType,plain,EnumField,Poor,false
+ExcelScript.ContentType,plain,EnumField,Fine,false
 ExcelScript.CultureInfo,N/A,Class,Good,false
 ExcelScript.CultureInfo,getDatetimeFormat(),Method,Poor,false
 ExcelScript.CultureInfo,getName(),Method,Poor,false
 ExcelScript.CultureInfo,getNumberFormat(),Method,Poor,false
-ExcelScript.CustomConditionalFormat,N/A,Class,Poor,true
+ExcelScript.CustomConditionalFormat,N/A,Class,Fine,true
 ExcelScript.CustomConditionalFormat,getFormat(),Method,Poor,false
 ExcelScript.CustomConditionalFormat,getRule(),Method,Poor,false
-ExcelScript.CustomDataValidation,N/A,Class,Poor,false
+ExcelScript.CustomDataValidation,N/A,Class,Fine,false
 ExcelScript.CustomDataValidation,formula,Property,Good,false
 ExcelScript.CustomProperty,N/A,Class,Poor,false
 ExcelScript.CustomProperty,delete(),Method,Poor,false
@@ -1336,13 +1336,13 @@ ExcelScript.CustomProperty,getKey(),Method,Poor,false
 ExcelScript.CustomProperty,getType(),Method,Poor,false
 ExcelScript.CustomProperty,getValue(),Method,Poor,false
 ExcelScript.CustomProperty,setValue(value),Method,Poor,false
-ExcelScript.CustomXmlPart,N/A,Class,Poor,false
+ExcelScript.CustomXmlPart,N/A,Class,Fine,false
 ExcelScript.CustomXmlPart,delete(),Method,Poor,false
 ExcelScript.CustomXmlPart,getId(),Method,Poor,false
 ExcelScript.CustomXmlPart,getNamespaceUri(),Method,Poor,false
 ExcelScript.CustomXmlPart,getXml(),Method,Poor,false
 ExcelScript.CustomXmlPart,setXml(xml),Method,Poor,false
-ExcelScript.DataBarConditionalFormat,N/A,Class,Poor,true
+ExcelScript.DataBarConditionalFormat,N/A,Class,Fine,true
 ExcelScript.DataBarConditionalFormat,getAxisColor(),Method,Poor,false
 ExcelScript.DataBarConditionalFormat,getAxisFormat(),Method,Poor,false
 ExcelScript.DataBarConditionalFormat,getBarDirection(),Method,Poor,false
@@ -1371,7 +1371,7 @@ ExcelScript.DataPivotHierarchy,setPosition(position),Method,Poor,false
 ExcelScript.DataPivotHierarchy,setShowAs(showAs),Method,Poor,false
 ExcelScript.DataPivotHierarchy,setSummarizeBy(summarizeBy),Method,Poor,true
 ExcelScript.DataPivotHierarchy,setToDefault(),Method,Poor,false
-ExcelScript.DataValidation,N/A,Class,Poor,false
+ExcelScript.DataValidation,N/A,Class,Fine,false
 ExcelScript.DataValidation,clear(),Method,Poor,false
 ExcelScript.DataValidation,getErrorAlert(),Method,Poor,false
 ExcelScript.DataValidation,getIgnoreBlanks(),Method,Poor,false
@@ -1388,12 +1388,12 @@ ExcelScript.DataValidationAlertStyle,N/A,Enum,Good,true
 ExcelScript.DataValidationAlertStyle,information,EnumField,Missing,false
 ExcelScript.DataValidationAlertStyle,stop,EnumField,Missing,false
 ExcelScript.DataValidationAlertStyle,warning,EnumField,Missing,false
-ExcelScript.DataValidationErrorAlert,N/A,Class,Poor,true
+ExcelScript.DataValidationErrorAlert,N/A,Class,Fine,true
 ExcelScript.DataValidationErrorAlert,message,Property,Poor,false
 ExcelScript.DataValidationErrorAlert,showAlert,Property,Good,false
 ExcelScript.DataValidationErrorAlert,style,Property,Fine,false
-ExcelScript.DataValidationErrorAlert,title,Property,Poor,false
-ExcelScript.DataValidationOperator,N/A,Enum,Poor,true
+ExcelScript.DataValidationErrorAlert,title,Property,Fine,false
+ExcelScript.DataValidationOperator,N/A,Enum,Fine,true
 ExcelScript.DataValidationOperator,between,EnumField,Missing,false
 ExcelScript.DataValidationOperator,equalTo,EnumField,Missing,false
 ExcelScript.DataValidationOperator,greaterThan,EnumField,Missing,false
@@ -1402,10 +1402,10 @@ ExcelScript.DataValidationOperator,lessThan,EnumField,Missing,false
 ExcelScript.DataValidationOperator,lessThanOrEqualTo,EnumField,Missing,false
 ExcelScript.DataValidationOperator,notBetween,EnumField,Missing,false
 ExcelScript.DataValidationOperator,notEqualTo,EnumField,Missing,false
-ExcelScript.DataValidationPrompt,N/A,Class,Poor,false
-ExcelScript.DataValidationPrompt,message,Property,Poor,false
+ExcelScript.DataValidationPrompt,N/A,Class,Fine,false
+ExcelScript.DataValidationPrompt,message,Property,Fine,false
 ExcelScript.DataValidationPrompt,showPrompt,Property,Fine,false
-ExcelScript.DataValidationPrompt,title,Property,Poor,false
+ExcelScript.DataValidationPrompt,title,Property,Fine,false
 ExcelScript.DataValidationRule,N/A,Class,Good,false
 ExcelScript.DataValidationRule,custom,Property,Poor,false
 ExcelScript.DataValidationRule,date,Property,Poor,false
@@ -1414,7 +1414,7 @@ ExcelScript.DataValidationRule,list,Property,Poor,false
 ExcelScript.DataValidationRule,textLength,Property,Poor,false
 ExcelScript.DataValidationRule,time,Property,Poor,false
 ExcelScript.DataValidationRule,wholeNumber,Property,Poor,true
-ExcelScript.DataValidationType,N/A,Enum,Poor,true
+ExcelScript.DataValidationType,N/A,Enum,Fine,true
 ExcelScript.DataValidationType,custom,EnumField,Poor,false
 ExcelScript.DataValidationType,date,EnumField,Poor,false
 ExcelScript.DataValidationType,decimal,EnumField,Poor,false
@@ -1422,9 +1422,9 @@ ExcelScript.DataValidationType,inconsistent,EnumField,Fine,false
 ExcelScript.DataValidationType,list,EnumField,Poor,false
 ExcelScript.DataValidationType,mixedCriteria,EnumField,Fine,false
 ExcelScript.DataValidationType,none,EnumField,Fine,false
-ExcelScript.DataValidationType,textLength,EnumField,Poor,false
+ExcelScript.DataValidationType,textLength,EnumField,Fine,false
 ExcelScript.DataValidationType,time,EnumField,Poor,false
-ExcelScript.DataValidationType,wholeNumber,EnumField,Poor,false
+ExcelScript.DataValidationType,wholeNumber,EnumField,Fine,false
 ExcelScript.DateFilterCondition,N/A,Enum,Good,true
 ExcelScript.DateFilterCondition,after,EnumField,Good,false
 ExcelScript.DateFilterCondition,afterOrEqualTo,EnumField,Good,false
@@ -1463,12 +1463,12 @@ ExcelScript.DateFilterCondition,thisYear,EnumField,Poor,false
 ExcelScript.DateFilterCondition,today,EnumField,Poor,false
 ExcelScript.DateFilterCondition,tomorrow,EnumField,Poor,false
 ExcelScript.DateFilterCondition,unknown,EnumField,Poor,false
-ExcelScript.DateFilterCondition,yearToDate,EnumField,Poor,false
+ExcelScript.DateFilterCondition,yearToDate,EnumField,Fine,false
 ExcelScript.DateFilterCondition,yesterday,EnumField,Poor,false
-ExcelScript.DateTimeDataValidation,N/A,Class,Poor,false
+ExcelScript.DateTimeDataValidation,N/A,Class,Fine,false
 ExcelScript.DateTimeDataValidation,formula1,Property,Good,false
 ExcelScript.DateTimeDataValidation,formula2,Property,Good,false
-ExcelScript.DateTimeDataValidation,operator,Property,Poor,false
+ExcelScript.DateTimeDataValidation,operator,Property,Fine,false
 ExcelScript.DatetimeFormatInfo,N/A,Class,Good,false
 ExcelScript.DatetimeFormatInfo,getDateSeparator(),Method,Poor,false
 ExcelScript.DatetimeFormatInfo,getLongDatePattern(),Method,Poor,false
@@ -1479,7 +1479,7 @@ ExcelScript.DeleteShiftDirection,N/A,Enum,Missing,true
 ExcelScript.DeleteShiftDirection,left,EnumField,Missing,false
 ExcelScript.DeleteShiftDirection,up,EnumField,Missing,false
 ExcelScript.DocumentProperties,N/A,Class,Poor,true
-ExcelScript.DocumentProperties,addCustomProperty(key,Method,Fine,true
+ExcelScript.DocumentProperties,addCustomProperty(key, value),Method,Fine,true
 ExcelScript.DocumentProperties,deleteAllCustomProperties(),Method,Poor,false
 ExcelScript.DocumentProperties,getAuthor(),Method,Poor,false
 ExcelScript.DocumentProperties,getCategory(),Method,Poor,false
@@ -1487,7 +1487,7 @@ ExcelScript.DocumentProperties,getComments(),Method,Poor,false
 ExcelScript.DocumentProperties,getCompany(),Method,Poor,false
 ExcelScript.DocumentProperties,getCreationDate(),Method,Poor,false
 ExcelScript.DocumentProperties,getCustom(),Method,Poor,false
-ExcelScript.DocumentProperties,getCustomProperty(key),Method,Poor,true
+ExcelScript.DocumentProperties,getCustomProperty(key),Method,Fine,true
 ExcelScript.DocumentProperties,getKeywords(),Method,Poor,false
 ExcelScript.DocumentProperties,getLastAuthor(),Method,Poor,false
 ExcelScript.DocumentProperties,getManager(),Method,Poor,false
@@ -1567,12 +1567,12 @@ ExcelScript.FillPattern,semiGray75,EnumField,Missing,false
 ExcelScript.FillPattern,solid,EnumField,Missing,false
 ExcelScript.FillPattern,up,EnumField,Missing,false
 ExcelScript.FillPattern,vertical,EnumField,Missing,false
-ExcelScript.Filter,N/A,Class,Poor,false
+ExcelScript.Filter,N/A,Class,Fine,false
 ExcelScript.Filter,apply(criteria),Method,Poor,false
 ExcelScript.Filter,applyBottomItemsFilter(count),Method,Poor,false
 ExcelScript.Filter,applyBottomPercentFilter(percent),Method,Poor,false
 ExcelScript.Filter,applyCellColorFilter(color),Method,Poor,false
-ExcelScript.Filter,applyCustomFilter(criteria1,Method,Poor,true
+ExcelScript.Filter,applyCustomFilter(criteria1, criteria2, oper),Method,Poor,true
 ExcelScript.Filter,applyDynamicFilter(criteria),Method,Poor,true
 ExcelScript.Filter,applyFontColorFilter(color),Method,Poor,false
 ExcelScript.Filter,applyIconFilter(icon),Method,Poor,false
@@ -1581,7 +1581,7 @@ ExcelScript.Filter,applyTopPercentFilter(percent),Method,Poor,false
 ExcelScript.Filter,applyValuesFilter(values),Method,Fine,true
 ExcelScript.Filter,clear(),Method,Poor,false
 ExcelScript.Filter,getCriteria(),Method,Poor,false
-ExcelScript.FilterCriteria,N/A,Class,Poor,false
+ExcelScript.FilterCriteria,N/A,Class,Fine,false
 ExcelScript.FilterCriteria,color,Property,Good,false
 ExcelScript.FilterCriteria,criterion1,Property,Good,true
 ExcelScript.FilterCriteria,criterion2,Property,Good,true
@@ -1592,7 +1592,7 @@ ExcelScript.FilterCriteria,operator,Property,Fine,false
 ExcelScript.FilterCriteria,subField,Property,Fine,false
 ExcelScript.FilterCriteria,values,Property,Fine,false
 ExcelScript.FilterDatetime,N/A,Class,Fine,true
-ExcelScript.FilterDatetime,date,Property,Poor,false
+ExcelScript.FilterDatetime,date,Property,Fine,false
 ExcelScript.FilterDatetime,specificity,Property,Good,false
 ExcelScript.FilterDatetimeSpecificity,N/A,Enum,Missing,true
 ExcelScript.FilterDatetimeSpecificity,day,EnumField,Missing,false
@@ -1626,14 +1626,14 @@ ExcelScript.FilterPivotHierarchy,setEnableMultipleFilterItems(enableMultipleFilt
 ExcelScript.FilterPivotHierarchy,setName(name),Method,Poor,false
 ExcelScript.FilterPivotHierarchy,setPosition(position),Method,Poor,false
 ExcelScript.FilterPivotHierarchy,setToDefault(),Method,Poor,false
-ExcelScript.FormatProtection,N/A,Class,Poor,false
+ExcelScript.FormatProtection,N/A,Class,Fine,false
 ExcelScript.FormatProtection,getFormulaHidden(),Method,Poor,false
 ExcelScript.FormatProtection,getLocked(),Method,Poor,false
 ExcelScript.FormatProtection,setFormulaHidden(formulaHidden),Method,Poor,false
 ExcelScript.FormatProtection,setLocked(locked),Method,Poor,false
 ExcelScript.GeometricShape,N/A,Class,Good,false
 ExcelScript.GeometricShape,getId(),Method,Poor,false
-ExcelScript.GeometricShapeType,N/A,Enum,Poor,true
+ExcelScript.GeometricShapeType,N/A,Enum,Fine,true
 ExcelScript.GeometricShapeType,accentBorderCallout1,EnumField,Missing,false
 ExcelScript.GeometricShapeType,accentBorderCallout2,EnumField,Missing,false
 ExcelScript.GeometricShapeType,accentBorderCallout3,EnumField,Missing,false
@@ -1854,7 +1854,7 @@ ExcelScript.HorizontalAlignment,left,EnumField,Missing,false
 ExcelScript.HorizontalAlignment,right,EnumField,Missing,false
 ExcelScript.Icon,N/A,Class,Poor,false
 ExcelScript.Icon,index,Property,Fine,false
-ExcelScript.Icon,set,Property,Poor,false
+ExcelScript.Icon,set,Property,Fine,false
 ExcelScript.IconSet,N/A,Enum,Missing,true
 ExcelScript.IconSet,fiveArrows,EnumField,Missing,false
 ExcelScript.IconSet,fiveArrowsGray,EnumField,Missing,false
@@ -1877,7 +1877,7 @@ ExcelScript.IconSet,threeSymbols2,EnumField,Missing,false
 ExcelScript.IconSet,threeTrafficLights1,EnumField,Missing,false
 ExcelScript.IconSet,threeTrafficLights2,EnumField,Missing,false
 ExcelScript.IconSet,threeTriangles,EnumField,Missing,false
-ExcelScript.IconSetConditionalFormat,N/A,Class,Poor,true
+ExcelScript.IconSetConditionalFormat,N/A,Class,Fine,true
 ExcelScript.IconSetConditionalFormat,getCriteria(),Method,Poor,false
 ExcelScript.IconSetConditionalFormat,getReverseIconOrder(),Method,Poor,false
 ExcelScript.IconSetConditionalFormat,getShowIconOnly(),Method,Poor,false
@@ -1915,14 +1915,14 @@ ExcelScript.LabelFilterCondition,between,EnumField,Good,false
 ExcelScript.LabelFilterCondition,contains,EnumField,Good,false
 ExcelScript.LabelFilterCondition,endsWith,EnumField,Good,false
 ExcelScript.LabelFilterCondition,equals,EnumField,Good,false
-ExcelScript.LabelFilterCondition,greaterThan,EnumField,Poor,false
+ExcelScript.LabelFilterCondition,greaterThan,EnumField,Fine,false
 ExcelScript.LabelFilterCondition,greaterThanOrEqualTo,EnumField,Fine,false
-ExcelScript.LabelFilterCondition,lessThan,EnumField,Poor,false
+ExcelScript.LabelFilterCondition,lessThan,EnumField,Fine,false
 ExcelScript.LabelFilterCondition,lessThanOrEqualTo,EnumField,Fine,false
 ExcelScript.LabelFilterCondition,unknown,EnumField,Poor,false
 ExcelScript.Line,N/A,Class,Good,false
-ExcelScript.Line,connectBeginShape(shape,Method,Poor,false
-ExcelScript.Line,connectEndShape(shape,Method,Poor,false
+ExcelScript.Line,connectBeginShape(shape, connectionSite),Method,Poor,false
+ExcelScript.Line,connectEndShape(shape, connectionSite),Method,Poor,false
 ExcelScript.Line,disconnectBeginShape(),Method,Poor,false
 ExcelScript.Line,disconnectEndShape(),Method,Poor,false
 ExcelScript.Line,getBeginArrowheadLength(),Method,Poor,false
@@ -1956,10 +1956,10 @@ ExcelScript.LinkedDataTypeState,validLinkedData,EnumField,Missing,false
 ExcelScript.LinkedWorkbook,N/A,Class,Good,false
 ExcelScript.LinkedWorkbook,breakLinks(),Method,Poor,false
 ExcelScript.LinkedWorkbook,refreshLinks(),Method,Poor,false
-ExcelScript.ListDataValidation,N/A,Class,Poor,false
+ExcelScript.ListDataValidation,N/A,Class,Fine,false
 ExcelScript.ListDataValidation,inCellDropDown,Property,Good,false
 ExcelScript.ListDataValidation,source,Property,Fine,false
-ExcelScript.LoadToType,N/A,Enum,Poor,false
+ExcelScript.LoadToType,N/A,Enum,Fine,false
 ExcelScript.LoadToType,connectionOnly,EnumField,Poor,false
 ExcelScript.LoadToType,pivotChart,EnumField,Poor,false
 ExcelScript.LoadToType,pivotTable,EnumField,Poor,false
@@ -1999,13 +1999,13 @@ ExcelScript.NamedSheetView,delete(),Method,Poor,false
 ExcelScript.NamedSheetView,duplicate(name),Method,Poor,false
 ExcelScript.NamedSheetView,getName(),Method,Poor,false
 ExcelScript.NamedSheetView,setName(name),Method,Poor,false
-ExcelScript.NumberFormatCategory,N/A,Enum,Poor,true
+ExcelScript.NumberFormatCategory,N/A,Enum,Fine,true
 ExcelScript.NumberFormatCategory,accounting,EnumField,Fine,false
 ExcelScript.NumberFormatCategory,currency,EnumField,Good,false
 ExcelScript.NumberFormatCategory,custom,EnumField,Fine,false
 ExcelScript.NumberFormatCategory,date,EnumField,Good,false
 ExcelScript.NumberFormatCategory,fraction,EnumField,Fine,false
-ExcelScript.NumberFormatCategory,general,EnumField,Poor,false
+ExcelScript.NumberFormatCategory,general,EnumField,Fine,false
 ExcelScript.NumberFormatCategory,number,EnumField,Good,false
 ExcelScript.NumberFormatCategory,percentage,EnumField,Fine,false
 ExcelScript.NumberFormatCategory,scientific,EnumField,Fine,false
@@ -2059,14 +2059,14 @@ ExcelScript.PageLayout,setPrintComments(printComments),Method,Poor,true
 ExcelScript.PageLayout,setPrintErrors(printErrors),Method,Poor,false
 ExcelScript.PageLayout,setPrintGridlines(printGridlines),Method,Poor,false
 ExcelScript.PageLayout,setPrintHeadings(printHeadings),Method,Poor,false
-ExcelScript.PageLayout,setPrintMargins(unit,Method,Poor,false
+ExcelScript.PageLayout,setPrintMargins(unit, marginOptions),Method,Poor,false
 ExcelScript.PageLayout,setPrintOrder(printOrder),Method,Poor,true
 ExcelScript.PageLayout,setPrintTitleColumns(printTitleColumns),Method,Poor,false
 ExcelScript.PageLayout,setPrintTitleRows(printTitleRows),Method,Poor,false
 ExcelScript.PageLayout,setRightMargin(rightMargin),Method,Poor,false
 ExcelScript.PageLayout,setTopMargin(topMargin),Method,Poor,false
 ExcelScript.PageLayout,setZoom(zoom),Method,Poor,false
-ExcelScript.PageLayoutMarginOptions,N/A,Class,Poor,false
+ExcelScript.PageLayoutMarginOptions,N/A,Class,Fine,false
 ExcelScript.PageLayoutMarginOptions,bottom,Property,Fine,false
 ExcelScript.PageLayoutMarginOptions,footer,Property,Fine,false
 ExcelScript.PageLayoutMarginOptions,header,Property,Fine,false
@@ -2129,12 +2129,12 @@ ExcelScript.PictureFormat,jpeg,EnumField,Poor,false
 ExcelScript.PictureFormat,png,EnumField,Poor,false
 ExcelScript.PictureFormat,svg,EnumField,Poor,false
 ExcelScript.PictureFormat,unknown,EnumField,Missing,false
-ExcelScript.PivotAxis,N/A,Enum,Poor,false
+ExcelScript.PivotAxis,N/A,Enum,Fine,false
 ExcelScript.PivotAxis,column,EnumField,Poor,false
 ExcelScript.PivotAxis,data,EnumField,Poor,false
 ExcelScript.PivotAxis,filter,EnumField,Poor,false
 ExcelScript.PivotAxis,row,EnumField,Poor,false
-ExcelScript.PivotAxis,unknown,EnumField,Poor,false
+ExcelScript.PivotAxis,unknown,EnumField,Fine,false
 ExcelScript.PivotDateFilter,N/A,Class,Good,false
 ExcelScript.PivotDateFilter,comparator,Property,Good,false
 ExcelScript.PivotDateFilter,condition,Property,Fine,true
@@ -2158,13 +2158,13 @@ ExcelScript.PivotField,setName(name),Method,Poor,false
 ExcelScript.PivotField,setShowAllItems(showAllItems),Method,Poor,false
 ExcelScript.PivotField,setSubtotals(subtotals),Method,Poor,false
 ExcelScript.PivotField,sortByLabels(sortBy),Method,Poor,false
-ExcelScript.PivotField,sortByValues(sortBy,Method,Fine,true
+ExcelScript.PivotField,sortByValues(sortBy, valuesHierarchy, pivotItemScope),Method,Fine,true
 ExcelScript.PivotFilters,N/A,Class,Fine,false
 ExcelScript.PivotFilters,dateFilter,Property,Good,true
 ExcelScript.PivotFilters,labelFilter,Property,Good,true
 ExcelScript.PivotFilters,manualFilter,Property,Good,true
 ExcelScript.PivotFilters,valueFilter,Property,Good,true
-ExcelScript.PivotFilterTopBottomCriterion,N/A,Enum,Poor,false
+ExcelScript.PivotFilterTopBottomCriterion,N/A,Enum,Fine,false
 ExcelScript.PivotFilterTopBottomCriterion,bottomItems,EnumField,Missing,false
 ExcelScript.PivotFilterTopBottomCriterion,bottomPercent,EnumField,Missing,false
 ExcelScript.PivotFilterTopBottomCriterion,bottomSum,EnumField,Missing,false
@@ -2175,7 +2175,7 @@ ExcelScript.PivotFilterTopBottomCriterion,topSum,EnumField,Missing,false
 ExcelScript.PivotFilterType,N/A,Enum,Fine,true
 ExcelScript.PivotFilterType,date,EnumField,Good,false
 ExcelScript.PivotFilterType,label,EnumField,Good,false
-ExcelScript.PivotFilterType,manual,EnumField,Poor,false
+ExcelScript.PivotFilterType,manual,EnumField,Fine,false
 ExcelScript.PivotFilterType,unknown,EnumField,Poor,false
 ExcelScript.PivotFilterType,value,EnumField,Fine,false
 ExcelScript.PivotHierarchy,N/A,Class,Poor,true
@@ -2198,7 +2198,7 @@ ExcelScript.PivotLabelFilter,exclusive,Property,Good,false
 ExcelScript.PivotLabelFilter,lowerBound,Property,Good,false
 ExcelScript.PivotLabelFilter,substring,Property,Fine,false
 ExcelScript.PivotLabelFilter,upperBound,Property,Good,false
-ExcelScript.PivotLayout,N/A,Class,Poor,false
+ExcelScript.PivotLayout,N/A,Class,Fine,false
 ExcelScript.PivotLayout,getAutoFormat(),Method,Poor,false
 ExcelScript.PivotLayout,getBodyAndTotalRange(),Method,Poor,true
 ExcelScript.PivotLayout,getColumnLabelRange(),Method,Poor,false
@@ -2213,7 +2213,7 @@ ExcelScript.PivotLayout,getShowColumnGrandTotals(),Method,Poor,false
 ExcelScript.PivotLayout,getShowRowGrandTotals(),Method,Poor,false
 ExcelScript.PivotLayout,getSubtotalLocation(),Method,Poor,false
 ExcelScript.PivotLayout,setAutoFormat(autoFormat),Method,Poor,false
-ExcelScript.PivotLayout,setAutoSortOnCell(cell,Method,Poor,false
+ExcelScript.PivotLayout,setAutoSortOnCell(cell, sortBy),Method,Poor,false
 ExcelScript.PivotLayout,setEnableFieldList(enableFieldList),Method,Poor,false
 ExcelScript.PivotLayout,setLayoutType(layoutType),Method,Poor,true
 ExcelScript.PivotLayout,setPreserveFormatting(preserveFormatting),Method,Poor,false
@@ -2246,7 +2246,7 @@ ExcelScript.PivotTable,getId(),Method,Poor,false
 ExcelScript.PivotTable,getLayout(),Method,Fine,true
 ExcelScript.PivotTable,getName(),Method,Poor,false
 ExcelScript.PivotTable,getRowHierarchies(),Method,Poor,false
-ExcelScript.PivotTable,getRowHierarchy(name),Method,Poor,true
+ExcelScript.PivotTable,getRowHierarchy(name),Method,Fine,true
 ExcelScript.PivotTable,getUseCustomSortLists(),Method,Poor,false
 ExcelScript.PivotTable,getWorksheet(),Method,Poor,false
 ExcelScript.PivotTable,refresh(),Method,Poor,false
@@ -2275,9 +2275,9 @@ ExcelScript.PivotValueFilter,upperBound,Property,Fine,false
 ExcelScript.PivotValueFilter,value,Property,Fine,false
 ExcelScript.Placement,N/A,Enum,Fine,true
 ExcelScript.Placement,absolute,EnumField,Poor,false
-ExcelScript.Placement,oneCell,EnumField,Poor,false
-ExcelScript.Placement,twoCell,EnumField,Poor,false
-ExcelScript.PredefinedCellStyle,N/A,Class,Poor,false
+ExcelScript.Placement,oneCell,EnumField,Fine,false
+ExcelScript.Placement,twoCell,EnumField,Fine,false
+ExcelScript.PredefinedCellStyle,N/A,Class,Fine,false
 ExcelScript.PredefinedCellStyle,delete(),Method,Poor,false
 ExcelScript.PredefinedCellStyle,getAutoIndent(),Method,Poor,false
 ExcelScript.PredefinedCellStyle,getBorders(),Method,Poor,false
@@ -2337,15 +2337,15 @@ ExcelScript.PrintErrorType,blank,EnumField,Missing,false
 ExcelScript.PrintErrorType,dash,EnumField,Missing,false
 ExcelScript.PrintErrorType,notAvailable,EnumField,Missing,false
 ExcelScript.PrintMarginUnit,N/A,Enum,Missing,false
-ExcelScript.PrintMarginUnit,centimeters,EnumField,Poor,false
-ExcelScript.PrintMarginUnit,inches,EnumField,Poor,false
+ExcelScript.PrintMarginUnit,centimeters,EnumField,Fine,false
+ExcelScript.PrintMarginUnit,inches,EnumField,Fine,false
 ExcelScript.PrintMarginUnit,points,EnumField,Good,false
 ExcelScript.PrintOrder,N/A,Enum,Missing,true
 ExcelScript.PrintOrder,downThenOver,EnumField,Fine,false
 ExcelScript.PrintOrder,overThenDown,EnumField,Fine,false
 ExcelScript.ProtectionSelectionMode,N/A,Enum,Missing,true
-ExcelScript.ProtectionSelectionMode,none,EnumField,Poor,false
-ExcelScript.ProtectionSelectionMode,normal,EnumField,Poor,false
+ExcelScript.ProtectionSelectionMode,none,EnumField,Fine,false
+ExcelScript.ProtectionSelectionMode,normal,EnumField,Fine,false
 ExcelScript.ProtectionSelectionMode,unlocked,EnumField,Fine,false
 ExcelScript.Query,N/A,Class,Poor,false
 ExcelScript.Query,getError(),Method,Poor,false
@@ -2354,29 +2354,29 @@ ExcelScript.Query,getLoadedToDataModel(),Method,Poor,false
 ExcelScript.Query,getName(),Method,Poor,false
 ExcelScript.Query,getRefreshDate(),Method,Poor,false
 ExcelScript.Query,getRowsLoadedCount(),Method,Poor,false
-ExcelScript.QueryError,N/A,Enum,Poor,false
+ExcelScript.QueryError,N/A,Enum,Fine,false
 ExcelScript.QueryError,failedDownload,EnumField,Poor,false
-ExcelScript.QueryError,failedLoadToDataModel,EnumField,Poor,false
+ExcelScript.QueryError,failedLoadToDataModel,EnumField,Fine,false
 ExcelScript.QueryError,failedLoadToWorksheet,EnumField,Poor,false
 ExcelScript.QueryError,failedToCompleteDownload,EnumField,Poor,false
 ExcelScript.QueryError,none,EnumField,Poor,false
 ExcelScript.QueryError,unknown,EnumField,Poor,false
 ExcelScript.Range,N/A,Class,Fine,true
 ExcelScript.Range,addConditionalFormat(type),Method,Fine,true
-ExcelScript.Range,autoFill(destinationRange,Method,Good,true
+ExcelScript.Range,autoFill(destinationRange, autoFillType),Method,Good,true
 ExcelScript.Range,calculate(),Method,Poor,true
-ExcelScript.Range,clear(applyTo),Method,Poor,true
+ExcelScript.Range,clear(applyTo),Method,Fine,true
 ExcelScript.Range,clearAllConditionalFormats(),Method,Poor,false
 ExcelScript.Range,convertDataTypeToText(),Method,Poor,false
-ExcelScript.Range,copyFrom(sourceRange,Method,Fine,true
+ExcelScript.Range,copyFrom(sourceRange, copyType, skipBlanks, transpose),Method,Fine,true
 ExcelScript.Range,delete(shift),Method,Fine,true
-ExcelScript.Range,find(text,Method,Fine,true
+ExcelScript.Range,find(text, criteria),Method,Fine,true
 ExcelScript.Range,flashFill(),Method,Good,true
-ExcelScript.Range,getAbsoluteResizedRange(numRows,Method,Poor,false
+ExcelScript.Range,getAbsoluteResizedRange(numRows, numColumns),Method,Poor,false
 ExcelScript.Range,getAddress(),Method,Fine,true
 ExcelScript.Range,getAddressLocal(),Method,Poor,false
-ExcelScript.Range,getBoundingRect(anotherRange),Method,Poor,true
-ExcelScript.Range,getCell(row,Method,Poor,false
+ExcelScript.Range,getBoundingRect(anotherRange),Method,Fine,true
+ExcelScript.Range,getCell(row, column),Method,Fine,false
 ExcelScript.Range,getCellCount(),Method,Poor,false
 ExcelScript.Range,getColumn(column),Method,Poor,false
 ExcelScript.Range,getColumnCount(),Method,Poor,true
@@ -2390,7 +2390,7 @@ ExcelScript.Range,getDataValidation(),Method,Poor,true
 ExcelScript.Range,getDirectPrecedents(),Method,Poor,false
 ExcelScript.Range,getEntireColumn(),Method,Poor,false
 ExcelScript.Range,getEntireRow(),Method,Poor,false
-ExcelScript.Range,getExtendedRange(direction,Method,Fine,true
+ExcelScript.Range,getExtendedRange(direction, activeCell),Method,Fine,true
 ExcelScript.Range,getFormat(),Method,Poor,true
 ExcelScript.Range,getFormula(),Method,Fine,true
 ExcelScript.Range,getFormulaLocal(),Method,Poor,false
@@ -2401,7 +2401,7 @@ ExcelScript.Range,getFormulasR1C1(),Method,Poor,false
 ExcelScript.Range,getHasSpill(),Method,Poor,false
 ExcelScript.Range,getHeight(),Method,Poor,false
 ExcelScript.Range,getHidden(),Method,Poor,false
-ExcelScript.Range,getHyperlink(),Method,Poor,true
+ExcelScript.Range,getHyperlink(),Method,Fine,true
 ExcelScript.Range,getImage(),Method,Poor,false
 ExcelScript.Range,getIntersection(anotherRange),Method,Poor,false
 ExcelScript.Range,getIsEntireColumn(),Method,Poor,false
@@ -2419,11 +2419,11 @@ ExcelScript.Range,getNumberFormatCategory(),Method,Poor,false
 ExcelScript.Range,getNumberFormatLocal(),Method,Poor,false
 ExcelScript.Range,getNumberFormats(),Method,Poor,false
 ExcelScript.Range,getNumberFormatsLocal(),Method,Poor,false
-ExcelScript.Range,getOffsetRange(rowOffset,Method,Fine,true
+ExcelScript.Range,getOffsetRange(rowOffset, columnOffset),Method,Fine,true
 ExcelScript.Range,getPivotTables(fullyContained),Method,Poor,false
 ExcelScript.Range,getPredefinedCellStyle(),Method,Poor,false
-ExcelScript.Range,getRangeEdge(direction,Method,Fine,true
-ExcelScript.Range,getResizedRange(deltaRows,Method,Fine,true
+ExcelScript.Range,getRangeEdge(direction, activeCell),Method,Fine,true
+ExcelScript.Range,getResizedRange(deltaRows, deltaColumns),Method,Fine,true
 ExcelScript.Range,getRow(row),Method,Poor,false
 ExcelScript.Range,getRowCount(),Method,Poor,true
 ExcelScript.Range,getRowHidden(),Method,Poor,false
@@ -2432,7 +2432,7 @@ ExcelScript.Range,getRowsAbove(count),Method,Poor,false
 ExcelScript.Range,getRowsBelow(count),Method,Poor,false
 ExcelScript.Range,getSavedAsArray(),Method,Poor,false
 ExcelScript.Range,getSort(),Method,Poor,false
-ExcelScript.Range,getSpecialCells(cellType,Method,Fine,true
+ExcelScript.Range,getSpecialCells(cellType, cellValueType),Method,Fine,true
 ExcelScript.Range,getSpillingToRange(),Method,Poor,false
 ExcelScript.Range,getSpillParent(),Method,Poor,false
 ExcelScript.Range,getSurroundingRegion(),Method,Poor,false
@@ -2448,13 +2448,13 @@ ExcelScript.Range,getValueTypes(),Method,Poor,false
 ExcelScript.Range,getVisibleView(),Method,Poor,true
 ExcelScript.Range,getWidth(),Method,Poor,false
 ExcelScript.Range,getWorksheet(),Method,Poor,false
-ExcelScript.Range,group(groupOption),Method,Poor,true
+ExcelScript.Range,group(groupOption),Method,Fine,true
 ExcelScript.Range,hideGroupDetails(groupOption),Method,Poor,false
 ExcelScript.Range,insert(shift),Method,Fine,true
 ExcelScript.Range,merge(across),Method,Poor,false
 ExcelScript.Range,moveTo(destinationRange),Method,Poor,false
-ExcelScript.Range,removeDuplicates(columns,Method,Poor,false
-ExcelScript.Range,replaceAll(text,Method,Poor,true
+ExcelScript.Range,removeDuplicates(columns, includesHeader),Method,Poor,false
+ExcelScript.Range,replaceAll(text, replacement, criteria),Method,Poor,true
 ExcelScript.Range,select(),Method,Poor,false
 ExcelScript.Range,setColumnHidden(columnHidden),Method,Poor,false
 ExcelScript.Range,setDirty(),Method,Poor,false
@@ -2483,7 +2483,7 @@ ExcelScript.RangeAreas,calculate(),Method,Poor,false
 ExcelScript.RangeAreas,clear(applyTo),Method,Fine,true
 ExcelScript.RangeAreas,clearAllConditionalFormats(),Method,Poor,false
 ExcelScript.RangeAreas,convertDataTypeToText(),Method,Poor,false
-ExcelScript.RangeAreas,copyFrom(sourceRange,Method,Fine,false
+ExcelScript.RangeAreas,copyFrom(sourceRange, copyType, skipBlanks, transpose),Method,Fine,false
 ExcelScript.RangeAreas,getAddress(),Method,Poor,false
 ExcelScript.RangeAreas,getAddressLocal(),Method,Poor,false
 ExcelScript.RangeAreas,getAreaCount(),Method,Poor,false
@@ -2498,15 +2498,15 @@ ExcelScript.RangeAreas,getFormat(),Method,Poor,true
 ExcelScript.RangeAreas,getIntersection(anotherRange),Method,Poor,false
 ExcelScript.RangeAreas,getIsEntireColumn(),Method,Poor,false
 ExcelScript.RangeAreas,getIsEntireRow(),Method,Poor,false
-ExcelScript.RangeAreas,getOffsetRangeAreas(rowOffset,Method,Fine,false
+ExcelScript.RangeAreas,getOffsetRangeAreas(rowOffset, columnOffset),Method,Fine,false
 ExcelScript.RangeAreas,getPredefinedCellStyle(),Method,Poor,false
-ExcelScript.RangeAreas,getSpecialCells(cellType,Method,Poor,false
+ExcelScript.RangeAreas,getSpecialCells(cellType, cellValueType),Method,Poor,false
 ExcelScript.RangeAreas,getTables(fullyContained),Method,Poor,false
 ExcelScript.RangeAreas,getUsedRangeAreas(valuesOnly),Method,Poor,false
 ExcelScript.RangeAreas,getWorksheet(),Method,Poor,false
 ExcelScript.RangeAreas,setDirty(),Method,Poor,false
 ExcelScript.RangeAreas,setPredefinedCellStyle(predefinedCellStyle),Method,Poor,true
-ExcelScript.RangeBorder,N/A,Class,Poor,false
+ExcelScript.RangeBorder,N/A,Class,Fine,false
 ExcelScript.RangeBorder,getColor(),Method,Poor,false
 ExcelScript.RangeBorder,getSideIndex(),Method,Poor,false
 ExcelScript.RangeBorder,getStyle(),Method,Poor,false
@@ -2522,7 +2522,7 @@ ExcelScript.RangeCopyType,formats,EnumField,Missing,false
 ExcelScript.RangeCopyType,formulas,EnumField,Missing,false
 ExcelScript.RangeCopyType,link,EnumField,Missing,false
 ExcelScript.RangeCopyType,values,EnumField,Missing,false
-ExcelScript.RangeFill,N/A,Class,Poor,true
+ExcelScript.RangeFill,N/A,Class,Fine,true
 ExcelScript.RangeFill,clear(),Method,Poor,true
 ExcelScript.RangeFill,getColor(),Method,Poor,false
 ExcelScript.RangeFill,getPattern(),Method,Poor,false
@@ -2567,7 +2567,7 @@ ExcelScript.RangeFormat,getFont(),Method,Poor,true
 ExcelScript.RangeFormat,getHorizontalAlignment(),Method,Poor,false
 ExcelScript.RangeFormat,getIndentLevel(),Method,Poor,false
 ExcelScript.RangeFormat,getProtection(),Method,Poor,false
-ExcelScript.RangeFormat,getRangeBorder(index),Method,Poor,true
+ExcelScript.RangeFormat,getRangeBorder(index),Method,Fine,true
 ExcelScript.RangeFormat,getRangeBorderTintAndShade(),Method,Poor,false
 ExcelScript.RangeFormat,getReadingOrder(),Method,Poor,false
 ExcelScript.RangeFormat,getRowHeight(),Method,Fine,true
@@ -2591,12 +2591,12 @@ ExcelScript.RangeFormat,setUseStandardWidth(useStandardWidth),Method,Poor,false
 ExcelScript.RangeFormat,setVerticalAlignment(verticalAlignment),Method,Poor,true
 ExcelScript.RangeFormat,setWrapText(wrapText),Method,Poor,false
 ExcelScript.RangeHyperlink,N/A,Class,Fine,false
-ExcelScript.RangeHyperlink,address,Property,Poor,false
-ExcelScript.RangeHyperlink,documentReference,Property,Poor,false
-ExcelScript.RangeHyperlink,screenTip,Property,Poor,false
+ExcelScript.RangeHyperlink,address,Property,Fine,false
+ExcelScript.RangeHyperlink,documentReference,Property,Fine,false
+ExcelScript.RangeHyperlink,screenTip,Property,Fine,false
 ExcelScript.RangeHyperlink,textToDisplay,Property,Fine,false
-ExcelScript.RangeSort,N/A,Class,Poor,false
-ExcelScript.RangeSort,apply(fields,Method,Poor,false
+ExcelScript.RangeSort,N/A,Class,Fine,false
+ExcelScript.RangeSort,apply(fields, matchCase, hasHeaders, orientation, method),Method,Fine,false
 ExcelScript.RangeUnderlineStyle,N/A,Enum,Missing,false
 ExcelScript.RangeUnderlineStyle,double,EnumField,Missing,false
 ExcelScript.RangeUnderlineStyle,doubleAccountant,EnumField,Missing,false
@@ -2636,10 +2636,10 @@ ExcelScript.ReadingOrder,N/A,Enum,Missing,false
 ExcelScript.ReadingOrder,context,EnumField,Good,false
 ExcelScript.ReadingOrder,leftToRight,EnumField,Poor,false
 ExcelScript.ReadingOrder,rightToLeft,EnumField,Poor,false
-ExcelScript.RemoveDuplicatesResult,N/A,Class,Poor,false
+ExcelScript.RemoveDuplicatesResult,N/A,Class,Fine,false
 ExcelScript.RemoveDuplicatesResult,getRemoved(),Method,Poor,false
 ExcelScript.RemoveDuplicatesResult,getUniqueRemaining(),Method,Poor,false
-ExcelScript.ReplaceCriteria,N/A,Class,Poor,false
+ExcelScript.ReplaceCriteria,N/A,Class,Fine,false
 ExcelScript.ReplaceCriteria,completeMatch,Property,Good,true
 ExcelScript.ReplaceCriteria,matchCase,Property,Good,true
 ExcelScript.RowColumnPivotHierarchy,N/A,Class,Poor,true
@@ -2651,7 +2651,7 @@ ExcelScript.RowColumnPivotHierarchy,getPosition(),Method,Poor,false
 ExcelScript.RowColumnPivotHierarchy,setName(name),Method,Poor,false
 ExcelScript.RowColumnPivotHierarchy,setPosition(position),Method,Poor,false
 ExcelScript.RowColumnPivotHierarchy,setToDefault(),Method,Poor,false
-ExcelScript.SearchCriteria,N/A,Class,Poor,true
+ExcelScript.SearchCriteria,N/A,Class,Fine,true
 ExcelScript.SearchCriteria,completeMatch,Property,Good,false
 ExcelScript.SearchCriteria,matchCase,Property,Good,false
 ExcelScript.SearchCriteria,searchDirection,Property,Good,false
@@ -2663,7 +2663,7 @@ ExcelScript.Shape,copyTo(destinationSheet),Method,Poor,false
 ExcelScript.Shape,delete(),Method,Poor,true
 ExcelScript.Shape,getAltTextDescription(),Method,Poor,false
 ExcelScript.Shape,getAltTextTitle(),Method,Poor,false
-ExcelScript.Shape,getAsImage(format),Method,Fine,true
+ExcelScript.Shape,getAsImage(format),Method,Deprecated,true
 ExcelScript.Shape,getConnectionSiteCount(),Method,Poor,false
 ExcelScript.Shape,getFill(),Method,Poor,false
 ExcelScript.Shape,getGeometricShape(),Method,Poor,false
@@ -2691,8 +2691,8 @@ ExcelScript.Shape,getZOrderPosition(),Method,Poor,false
 ExcelScript.Shape,incrementLeft(increment),Method,Poor,false
 ExcelScript.Shape,incrementRotation(increment),Method,Poor,false
 ExcelScript.Shape,incrementTop(increment),Method,Poor,false
-ExcelScript.Shape,scaleHeight(scaleFactor,Method,Fine,false
-ExcelScript.Shape,scaleWidth(scaleFactor,Method,Fine,false
+ExcelScript.Shape,scaleHeight(scaleFactor, scaleType, scaleFrom),Method,Fine,false
+ExcelScript.Shape,scaleWidth(scaleFactor, scaleType, scaleFrom),Method,Fine,false
 ExcelScript.Shape,setAltTextDescription(altTextDescription),Method,Poor,false
 ExcelScript.Shape,setAltTextTitle(altTextTitle),Method,Poor,false
 ExcelScript.Shape,setGeometricShapeType(geometricShapeType),Method,Poor,false
@@ -2706,12 +2706,12 @@ ExcelScript.Shape,setTop(top),Method,Poor,false
 ExcelScript.Shape,setVisible(visible),Method,Poor,false
 ExcelScript.Shape,setWidth(width),Method,Poor,false
 ExcelScript.Shape,setZOrder(position),Method,Poor,false
-ExcelScript.ShapeAutoSize,N/A,Enum,Poor,true
-ExcelScript.ShapeAutoSize,autoSizeMixed,EnumField,Poor,false
+ExcelScript.ShapeAutoSize,N/A,Enum,Fine,true
+ExcelScript.ShapeAutoSize,autoSizeMixed,EnumField,Fine,false
 ExcelScript.ShapeAutoSize,autoSizeNone,EnumField,Poor,false
-ExcelScript.ShapeAutoSize,autoSizeShapeToFitText,EnumField,Poor,false
-ExcelScript.ShapeAutoSize,autoSizeTextToFitShape,EnumField,Poor,false
-ExcelScript.ShapeFill,N/A,Class,Poor,false
+ExcelScript.ShapeAutoSize,autoSizeShapeToFitText,EnumField,Fine,false
+ExcelScript.ShapeAutoSize,autoSizeTextToFitShape,EnumField,Fine,false
+ExcelScript.ShapeFill,N/A,Class,Fine,false
 ExcelScript.ShapeFill,clear(),Method,Poor,false
 ExcelScript.ShapeFill,getForegroundColor(),Method,Poor,false
 ExcelScript.ShapeFill,getTransparency(),Method,Poor,false
@@ -2739,7 +2739,7 @@ ExcelScript.ShapeFont,setItalic(italic),Method,Poor,false
 ExcelScript.ShapeFont,setName(name),Method,Poor,false
 ExcelScript.ShapeFont,setSize(size),Method,Poor,false
 ExcelScript.ShapeFont,setUnderline(underline),Method,Poor,false
-ExcelScript.ShapeFontUnderlineStyle,N/A,Enum,Poor,false
+ExcelScript.ShapeFontUnderlineStyle,N/A,Enum,Fine,false
 ExcelScript.ShapeFontUnderlineStyle,dash,EnumField,Missing,false
 ExcelScript.ShapeFontUnderlineStyle,dashHeavy,EnumField,Missing,false
 ExcelScript.ShapeFontUnderlineStyle,dashLong,EnumField,Missing,false
@@ -2763,7 +2763,7 @@ ExcelScript.ShapeGroup,getId(),Method,Poor,false
 ExcelScript.ShapeGroup,getShape(key),Method,Poor,false
 ExcelScript.ShapeGroup,getShapes(),Method,Poor,false
 ExcelScript.ShapeGroup,ungroup(),Method,Poor,false
-ExcelScript.ShapeLineDashStyle,N/A,Enum,Poor,false
+ExcelScript.ShapeLineDashStyle,N/A,Enum,Fine,false
 ExcelScript.ShapeLineDashStyle,dash,EnumField,Missing,false
 ExcelScript.ShapeLineDashStyle,dashDot,EnumField,Missing,false
 ExcelScript.ShapeLineDashStyle,dashDotDot,EnumField,Missing,false
@@ -2791,7 +2791,7 @@ ExcelScript.ShapeLineFormat,setVisible(visible),Method,Poor,false
 ExcelScript.ShapeLineFormat,setWeight(weight),Method,Poor,false
 ExcelScript.ShapeLineStyle,N/A,Enum,Poor,false
 ExcelScript.ShapeLineStyle,single,EnumField,Poor,false
-ExcelScript.ShapeLineStyle,thickBetweenThin,EnumField,Poor,false
+ExcelScript.ShapeLineStyle,thickBetweenThin,EnumField,Fine,false
 ExcelScript.ShapeLineStyle,thickThin,EnumField,Good,false
 ExcelScript.ShapeLineStyle,thinThick,EnumField,Good,false
 ExcelScript.ShapeLineStyle,thinThin,EnumField,Poor,false
@@ -2834,7 +2834,7 @@ ExcelScript.ShapeTextVerticalOverflow,N/A,Enum,Fine,false
 ExcelScript.ShapeTextVerticalOverflow,clip,EnumField,Fine,false
 ExcelScript.ShapeTextVerticalOverflow,ellipsis,EnumField,Fine,false
 ExcelScript.ShapeTextVerticalOverflow,overflow,EnumField,Fine,false
-ExcelScript.ShapeType,N/A,Enum,Poor,false
+ExcelScript.ShapeType,N/A,Enum,Fine,false
 ExcelScript.ShapeType,geometricShape,EnumField,Missing,false
 ExcelScript.ShapeType,group,EnumField,Missing,false
 ExcelScript.ShapeType,image,EnumField,Missing,false
@@ -2849,28 +2849,28 @@ ExcelScript.SheetVisibility,N/A,Enum,Missing,true
 ExcelScript.SheetVisibility,hidden,EnumField,Missing,false
 ExcelScript.SheetVisibility,veryHidden,EnumField,Missing,false
 ExcelScript.SheetVisibility,visible,EnumField,Missing,false
-ExcelScript.ShowAsCalculation,N/A,Enum,Poor,false
-ExcelScript.ShowAsCalculation,differenceFrom,EnumField,Poor,false
+ExcelScript.ShowAsCalculation,N/A,Enum,Fine,false
+ExcelScript.ShowAsCalculation,differenceFrom,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,index,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,none,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,percentDifferenceFrom,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,percentOf,EnumField,Poor,false
+ExcelScript.ShowAsCalculation,percentDifferenceFrom,EnumField,Fine,false
+ExcelScript.ShowAsCalculation,percentOf,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,percentOfColumnTotal,EnumField,Poor,false
 ExcelScript.ShowAsCalculation,percentOfGrandTotal,EnumField,Poor,false
 ExcelScript.ShowAsCalculation,percentOfParentColumnTotal,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,percentOfParentRowTotal,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,percentOfParentTotal,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,percentOfRowTotal,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,percentRunningTotal,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,rankAscending,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,rankDecending,EnumField,Poor,false
-ExcelScript.ShowAsCalculation,runningTotal,EnumField,Poor,false
+ExcelScript.ShowAsCalculation,percentRunningTotal,EnumField,Fine,false
+ExcelScript.ShowAsCalculation,rankAscending,EnumField,Fine,false
+ExcelScript.ShowAsCalculation,rankDecending,EnumField,Fine,false
+ExcelScript.ShowAsCalculation,runningTotal,EnumField,Fine,false
 ExcelScript.ShowAsCalculation,unknown,EnumField,Poor,false
 ExcelScript.ShowAsRule,N/A,Class,Missing,false
 ExcelScript.ShowAsRule,baseField,Property,Fine,false
 ExcelScript.ShowAsRule,baseItem,Property,Fine,false
 ExcelScript.ShowAsRule,calculation,Property,Good,false
-ExcelScript.Slicer,N/A,Class,Poor,true
+ExcelScript.Slicer,N/A,Class,Fine,true
 ExcelScript.Slicer,clearFilters(),Method,Poor,false
 ExcelScript.Slicer,delete(),Method,Poor,false
 ExcelScript.Slicer,getCaption(),Method,Poor,false
@@ -2896,16 +2896,16 @@ ExcelScript.Slicer,setSortBy(sortBy),Method,Poor,false
 ExcelScript.Slicer,setStyle(style),Method,Poor,false
 ExcelScript.Slicer,setTop(top),Method,Poor,false
 ExcelScript.Slicer,setWidth(width),Method,Poor,false
-ExcelScript.SlicerItem,N/A,Class,Poor,false
+ExcelScript.SlicerItem,N/A,Class,Fine,false
 ExcelScript.SlicerItem,getHasData(),Method,Poor,false
 ExcelScript.SlicerItem,getIsSelected(),Method,Poor,false
 ExcelScript.SlicerItem,getKey(),Method,Poor,false
 ExcelScript.SlicerItem,getName(),Method,Poor,false
 ExcelScript.SlicerItem,setIsSelected(isSelected),Method,Poor,false
-ExcelScript.SlicerSortType,N/A,Enum,Poor,false
-ExcelScript.SlicerSortType,ascending,EnumField,Poor,false
+ExcelScript.SlicerSortType,N/A,Enum,Fine,false
+ExcelScript.SlicerSortType,ascending,EnumField,Fine,false
 ExcelScript.SlicerSortType,dataSourceOrder,EnumField,Fine,false
-ExcelScript.SlicerSortType,descending,EnumField,Poor,false
+ExcelScript.SlicerSortType,descending,EnumField,Fine,false
 ExcelScript.SlicerStyle,N/A,Class,Fine,false
 ExcelScript.SlicerStyle,delete(),Method,Poor,false
 ExcelScript.SlicerStyle,duplicate(),Method,Poor,false
@@ -2913,18 +2913,18 @@ ExcelScript.SlicerStyle,getName(),Method,Poor,false
 ExcelScript.SlicerStyle,getReadOnly(),Method,Poor,false
 ExcelScript.SlicerStyle,setName(name),Method,Poor,false
 ExcelScript.SortBy,N/A,Enum,Poor,false
-ExcelScript.SortBy,ascending,EnumField,Poor,false
-ExcelScript.SortBy,descending,EnumField,Poor,false
+ExcelScript.SortBy,ascending,EnumField,Good,false
+ExcelScript.SortBy,descending,EnumField,Good,false
 ExcelScript.SortDataOption,N/A,Enum,Missing,true
 ExcelScript.SortDataOption,normal,EnumField,Missing,false
 ExcelScript.SortDataOption,textAsNumber,EnumField,Missing,false
-ExcelScript.SortField,N/A,Class,Poor,false
+ExcelScript.SortField,N/A,Class,Fine,false
 ExcelScript.SortField,ascending,Property,Fine,false
 ExcelScript.SortField,color,Property,Fine,true
-ExcelScript.SortField,dataOption,Property,Poor,true
+ExcelScript.SortField,dataOption,Property,Fine,true
 ExcelScript.SortField,icon,Property,Fine,false
 ExcelScript.SortField,key,Property,Good,false
-ExcelScript.SortField,sortOn,Property,Poor,false
+ExcelScript.SortField,sortOn,Property,Fine,false
 ExcelScript.SortField,subField,Property,Fine,false
 ExcelScript.SortMethod,N/A,Enum,Missing,true
 ExcelScript.SortMethod,pinYin,EnumField,Missing,false
@@ -2947,21 +2947,21 @@ ExcelScript.SpecialCellType,sameConditionalFormat,EnumField,Fine,false
 ExcelScript.SpecialCellType,sameDataValidation,EnumField,Fine,false
 ExcelScript.SpecialCellType,visible,EnumField,Poor,false
 ExcelScript.SpecialCellValueType,N/A,Enum,Missing,true
-ExcelScript.SpecialCellValueType,all,EnumField,Poor,false
+ExcelScript.SpecialCellValueType,all,EnumField,Fine,false
 ExcelScript.SpecialCellValueType,errors,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsLogical,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsLogicalNumber,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsLogicalText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsNumbers,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsNumberText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,errorsText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,logical,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,logicalNumbers,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,logicalNumbersText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,logicalText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,numbers,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,numbersText,EnumField,Poor,false
-ExcelScript.SpecialCellValueType,text,EnumField,Poor,false
+ExcelScript.SpecialCellValueType,errorsLogical,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,errorsLogicalNumber,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,errorsLogicalText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,errorsNumbers,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,errorsNumberText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,errorsText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,logical,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,logicalNumbers,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,logicalNumbersText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,logicalText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,numbers,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,numbersText,EnumField,Fine,false
+ExcelScript.SpecialCellValueType,text,EnumField,Fine,false
 ExcelScript.SubtotalLocationType,N/A,Enum,Missing,true
 ExcelScript.SubtotalLocationType,atBottom,EnumField,Poor,false
 ExcelScript.SubtotalLocationType,atTop,EnumField,Poor,false
@@ -2980,13 +2980,13 @@ ExcelScript.Subtotals,sum,Property,Poor,false
 ExcelScript.Subtotals,variance,Property,Poor,false
 ExcelScript.Subtotals,varianceP,Property,Poor,false
 ExcelScript.Table,N/A,Class,Poor,false
-ExcelScript.Table,addColumn(index,Method,Fine,true
-ExcelScript.Table,addRow(index,Method,Poor,false
-ExcelScript.Table,addRows(index,Method,Poor,false
+ExcelScript.Table,addColumn(index, values, name),Method,Fine,true
+ExcelScript.Table,addRow(index, values),Method,Poor,false
+ExcelScript.Table,addRows(index, values),Method,Poor,false
 ExcelScript.Table,clearFilters(),Method,Poor,false
 ExcelScript.Table,convertToRange(),Method,Poor,false
 ExcelScript.Table,delete(),Method,Poor,false
-ExcelScript.Table,deleteRowsAt(index,Method,Poor,false
+ExcelScript.Table,deleteRowsAt(index, count),Method,Poor,false
 ExcelScript.Table,getAutoFilter(),Method,Poor,false
 ExcelScript.Table,getColumn(key),Method,Poor,false
 ExcelScript.Table,getColumnById(key),Method,Poor,false
@@ -2999,7 +2999,7 @@ ExcelScript.Table,getId(),Method,Poor,false
 ExcelScript.Table,getLegacyId(),Method,Poor,false
 ExcelScript.Table,getName(),Method,Poor,false
 ExcelScript.Table,getPredefinedTableStyle(),Method,Poor,false
-ExcelScript.Table,getRange(),Method,Poor,true
+ExcelScript.Table,getRange(),Method,Fine,true
 ExcelScript.Table,getRangeBetweenHeaderAndTotal(),Method,Poor,false
 ExcelScript.Table,getRowCount(),Method,Poor,false
 ExcelScript.Table,getShowBandedColumns(),Method,Poor,false
@@ -3021,7 +3021,7 @@ ExcelScript.Table,setShowBandedRows(showBandedRows),Method,Poor,false
 ExcelScript.Table,setShowFilterButton(showFilterButton),Method,Poor,false
 ExcelScript.Table,setShowHeaders(showHeaders),Method,Poor,false
 ExcelScript.Table,setShowTotals(showTotals),Method,Poor,false
-ExcelScript.TableColumn,N/A,Class,Poor,false
+ExcelScript.TableColumn,N/A,Class,Fine,false
 ExcelScript.TableColumn,delete(),Method,Poor,false
 ExcelScript.TableColumn,getFilter(),Method,Poor,false
 ExcelScript.TableColumn,getHeaderRowRange(),Method,Poor,false
@@ -3032,8 +3032,8 @@ ExcelScript.TableColumn,getRange(),Method,Poor,false
 ExcelScript.TableColumn,getRangeBetweenHeaderAndTotal(),Method,Fine,true
 ExcelScript.TableColumn,getTotalRowRange(),Method,Poor,false
 ExcelScript.TableColumn,setName(name),Method,Poor,false
-ExcelScript.TableSort,N/A,Class,Poor,false
-ExcelScript.TableSort,apply(fields,Method,Poor,true
+ExcelScript.TableSort,N/A,Class,Fine,false
+ExcelScript.TableSort,apply(fields, matchCase, method),Method,Fine,true
 ExcelScript.TableSort,clear(),Method,Poor,false
 ExcelScript.TableSort,getFields(),Method,Poor,false
 ExcelScript.TableSort,getMatchCase(),Method,Poor,false
@@ -3045,11 +3045,11 @@ ExcelScript.TableStyle,duplicate(),Method,Poor,false
 ExcelScript.TableStyle,getName(),Method,Poor,false
 ExcelScript.TableStyle,getReadOnly(),Method,Poor,false
 ExcelScript.TableStyle,setName(name),Method,Poor,false
-ExcelScript.TextConditionalFormat,N/A,Class,Poor,true
+ExcelScript.TextConditionalFormat,N/A,Class,Fine,true
 ExcelScript.TextConditionalFormat,getFormat(),Method,Poor,false
 ExcelScript.TextConditionalFormat,getRule(),Method,Poor,false
 ExcelScript.TextConditionalFormat,setRule(rule),Method,Poor,false
-ExcelScript.TextFrame,N/A,Class,Poor,true
+ExcelScript.TextFrame,N/A,Class,Fine,true
 ExcelScript.TextFrame,deleteText(),Method,Poor,false
 ExcelScript.TextFrame,getAutoSizeSetting(),Method,Poor,false
 ExcelScript.TextFrame,getBottomMargin(),Method,Poor,false
@@ -3077,7 +3077,7 @@ ExcelScript.TextFrame,setVerticalAlignment(verticalAlignment),Method,Poor,false
 ExcelScript.TextFrame,setVerticalOverflow(verticalOverflow),Method,Poor,false
 ExcelScript.TextRange,N/A,Class,Fine,false
 ExcelScript.TextRange,getFont(),Method,Poor,false
-ExcelScript.TextRange,getSubstring(start,Method,Poor,false
+ExcelScript.TextRange,getSubstring(start, length),Method,Poor,false
 ExcelScript.TextRange,getText(),Method,Poor,false
 ExcelScript.TextRange,setText(text),Method,Poor,false
 ExcelScript.TimelineStyle,N/A,Class,Fine,false
@@ -3111,24 +3111,24 @@ ExcelScript.VerticalAlignment,distributed,EnumField,Missing,false
 ExcelScript.VerticalAlignment,justify,EnumField,Missing,false
 ExcelScript.VerticalAlignment,top,EnumField,Missing,false
 ExcelScript.Workbook,N/A,Class,Fine,true
-ExcelScript.Workbook,addBinding(range,Method,Poor,false
-ExcelScript.Workbook,addBindingFromNamedItem(name,Method,Poor,false
-ExcelScript.Workbook,addBindingFromSelection(bindingType,Method,Poor,false
-ExcelScript.Workbook,addComment(cellAddress,Method,Fine,false
+ExcelScript.Workbook,addBinding(range, bindingType, id),Method,Poor,false
+ExcelScript.Workbook,addBindingFromNamedItem(name, bindingType, id),Method,Poor,false
+ExcelScript.Workbook,addBindingFromSelection(bindingType, id),Method,Poor,false
+ExcelScript.Workbook,addComment(cellAddress, content, contentType),Method,Fine,false
 ExcelScript.Workbook,addCustomXmlPart(xml),Method,Poor,false
-ExcelScript.Workbook,addNamedItem(name,Method,Poor,true
-ExcelScript.Workbook,addNamedItemFormulaLocal(name,Method,Poor,false
-ExcelScript.Workbook,addPivotTable(name,Method,Poor,true
-ExcelScript.Workbook,addPivotTableStyle(name,Method,Poor,false
+ExcelScript.Workbook,addNamedItem(name, reference, comment),Method,Fine,true
+ExcelScript.Workbook,addNamedItemFormulaLocal(name, formula, comment),Method,Poor,false
+ExcelScript.Workbook,addPivotTable(name, source, destination),Method,Poor,true
+ExcelScript.Workbook,addPivotTableStyle(name, makeUniqueName),Method,Poor,false
 ExcelScript.Workbook,addPredefinedCellStyle(name),Method,Poor,false
-ExcelScript.Workbook,addSlicer(slicerSource,Method,Fine,true
-ExcelScript.Workbook,addSlicerStyle(name,Method,Poor,false
-ExcelScript.Workbook,addTable(address,Method,Fine,true
-ExcelScript.Workbook,addTableStyle(name,Method,Poor,false
-ExcelScript.Workbook,addTimelineStyle(name,Method,Poor,false
+ExcelScript.Workbook,addSlicer(slicerSource, sourceField, slicerDestination),Method,Fine,true
+ExcelScript.Workbook,addSlicerStyle(name, makeUniqueName),Method,Poor,false
+ExcelScript.Workbook,addTable(address, hasHeaders),Method,Fine,true
+ExcelScript.Workbook,addTableStyle(name, makeUniqueName),Method,Poor,false
+ExcelScript.Workbook,addTimelineStyle(name, makeUniqueName),Method,Poor,false
 ExcelScript.Workbook,addWorksheet(name),Method,Fine,true
 ExcelScript.Workbook,breakAllLinksToLinkedWorkbooks(),Method,Poor,false
-ExcelScript.Workbook,getActiveCell(),Method,Poor,true
+ExcelScript.Workbook,getActiveCell(),Method,Fine,true
 ExcelScript.Workbook,getActiveChart(),Method,Poor,false
 ExcelScript.Workbook,getActiveSlicer(),Method,Poor,false
 ExcelScript.Workbook,getActiveWorksheet(),Method,Poor,false
@@ -3143,7 +3143,7 @@ ExcelScript.Workbook,getCommentByCell(cellAddress),Method,Poor,false
 ExcelScript.Workbook,getCommentByReplyId(replyId),Method,Poor,false
 ExcelScript.Workbook,getComments(),Method,Poor,false
 ExcelScript.Workbook,getCustomXmlPart(id),Method,Poor,false
-ExcelScript.Workbook,getCustomXmlPartByNamespace(namespaceUri),Method,Poor,false
+ExcelScript.Workbook,getCustomXmlPartByNamespace(namespaceUri),Method,Deprecated,false
 ExcelScript.Workbook,getCustomXmlParts(),Method,Poor,false
 ExcelScript.Workbook,getCustomXmlPartsByNamespace(namespaceUri),Method,Poor,false
 ExcelScript.Workbook,getDefaultPivotTableStyle(),Method,Poor,false
@@ -3184,8 +3184,8 @@ ExcelScript.Workbook,getTableStyles(),Method,Poor,false
 ExcelScript.Workbook,getTimelineStyle(name),Method,Poor,false
 ExcelScript.Workbook,getTimelineStyles(),Method,Poor,false
 ExcelScript.Workbook,getUsePrecisionAsDisplayed(),Method,Poor,false
-ExcelScript.Workbook,getWorksheet(key),Method,Poor,true
-ExcelScript.Workbook,getWorksheets(),Method,Poor,true
+ExcelScript.Workbook,getWorksheet(key),Method,Fine,true
+ExcelScript.Workbook,getWorksheets(),Method,Fine,true
 ExcelScript.Workbook,refreshAllDataConnections(),Method,Poor,false
 ExcelScript.Workbook,refreshAllLinksToLinkedWorkbooks(),Method,Poor,false
 ExcelScript.Workbook,refreshAllPivotTables(),Method,Poor,false
@@ -3197,10 +3197,10 @@ ExcelScript.Workbook,setDefaultTimelineStyle(newDefaultStyle),Method,Poor,false
 ExcelScript.Workbook,setIsDirty(isDirty),Method,Poor,false
 ExcelScript.Workbook,setLinkedWorkbookRefreshMode(linkedWorkbookRefreshMode),Method,Poor,false
 ExcelScript.Workbook,setUsePrecisionAsDisplayed(usePrecisionAsDisplayed),Method,Poor,false
-ExcelScript.WorkbookLinksRefreshMode,N/A,Enum,Poor,true
+ExcelScript.WorkbookLinksRefreshMode,N/A,Enum,Fine,true
 ExcelScript.WorkbookLinksRefreshMode,automatic,EnumField,Fine,false
-ExcelScript.WorkbookLinksRefreshMode,manual,EnumField,Poor,false
-ExcelScript.WorkbookProtection,N/A,Class,Poor,false
+ExcelScript.WorkbookLinksRefreshMode,manual,EnumField,Fine,false
+ExcelScript.WorkbookProtection,N/A,Class,Fine,false
 ExcelScript.WorkbookProtection,getProtected(),Method,Poor,false
 ExcelScript.WorkbookProtection,protect(password),Method,Poor,false
 ExcelScript.WorkbookProtection,unprotect(password),Method,Poor,false
@@ -3211,32 +3211,32 @@ ExcelScript.WorkbookRangeAreas,getRangeAreasBySheet(key),Method,Poor,false
 ExcelScript.WorkbookRangeAreas,getRanges(),Method,Poor,false
 ExcelScript.Worksheet,N/A,Class,Good,true
 ExcelScript.Worksheet,activate(),Method,Poor,true
-ExcelScript.Worksheet,addChart(type,Method,Poor,true
-ExcelScript.Worksheet,addComment(cellAddress,Method,Fine,false
+ExcelScript.Worksheet,addChart(type, sourceData, seriesBy),Method,Fine,true
+ExcelScript.Worksheet,addComment(cellAddress, content, contentType),Method,Fine,false
 ExcelScript.Worksheet,addGeometricShape(geometricShapeType),Method,Fine,true
 ExcelScript.Worksheet,addGroup(values),Method,Poor,false
 ExcelScript.Worksheet,addHorizontalPageBreak(pageBreakRange),Method,Poor,false
 ExcelScript.Worksheet,addImage(base64ImageString),Method,Fine,true
-ExcelScript.Worksheet,addLine(startLeft,Method,Poor,false
-ExcelScript.Worksheet,addNamedItem(name,Method,Poor,false
-ExcelScript.Worksheet,addNamedItemFormulaLocal(name,Method,Poor,false
+ExcelScript.Worksheet,addLine(startLeft, startTop, endLeft, endTop, connectorType),Method,Poor,false
+ExcelScript.Worksheet,addNamedItem(name, reference, comment),Method,Poor,false
+ExcelScript.Worksheet,addNamedItemFormulaLocal(name, formula, comment),Method,Poor,false
 ExcelScript.Worksheet,addNamedSheetView(name),Method,Poor,false
-ExcelScript.Worksheet,addPivotTable(name,Method,Poor,true
-ExcelScript.Worksheet,addSlicer(slicerSource,Method,Fine,true
-ExcelScript.Worksheet,addTable(address,Method,Fine,true
+ExcelScript.Worksheet,addPivotTable(name, source, destination),Method,Poor,true
+ExcelScript.Worksheet,addSlicer(slicerSource, sourceField, slicerDestination),Method,Fine,true
+ExcelScript.Worksheet,addTable(address, hasHeaders),Method,Fine,true
 ExcelScript.Worksheet,addTextBox(text),Method,Poor,false
 ExcelScript.Worksheet,addVerticalPageBreak(pageBreakRange),Method,Poor,false
-ExcelScript.Worksheet,addWorksheetCustomProperty(key,Method,Poor,false
+ExcelScript.Worksheet,addWorksheetCustomProperty(key, value),Method,Poor,false
 ExcelScript.Worksheet,calculate(markAllDirty),Method,Poor,false
-ExcelScript.Worksheet,copy(positionType,Method,Fine,true
+ExcelScript.Worksheet,copy(positionType, relativeTo),Method,Fine,true
 ExcelScript.Worksheet,delete(),Method,Fine,true
 ExcelScript.Worksheet,enterTemporaryNamedSheetView(),Method,Poor,false
 ExcelScript.Worksheet,exitActiveNamedSheetView(),Method,Poor,false
-ExcelScript.Worksheet,findAll(text,Method,Poor,true
+ExcelScript.Worksheet,findAll(text, criteria),Method,Poor,true
 ExcelScript.Worksheet,getActiveNamedSheetView(),Method,Poor,false
-ExcelScript.Worksheet,getAutoFilter(),Method,Poor,true
-ExcelScript.Worksheet,getCell(row,Method,Fine,false
-ExcelScript.Worksheet,getChart(name),Method,Poor,true
+ExcelScript.Worksheet,getAutoFilter(),Method,Fine,true
+ExcelScript.Worksheet,getCell(row, column),Method,Fine,false
+ExcelScript.Worksheet,getChart(name),Method,Fine,true
 ExcelScript.Worksheet,getCharts(),Method,Poor,false
 ExcelScript.Worksheet,getComment(commentId),Method,Poor,false
 ExcelScript.Worksheet,getCommentByCell(cellAddress),Method,Poor,false
@@ -3260,7 +3260,7 @@ ExcelScript.Worksheet,getPosition(),Method,Poor,false
 ExcelScript.Worksheet,getPrevious(visibleOnly),Method,Poor,false
 ExcelScript.Worksheet,getProtection(),Method,Poor,true
 ExcelScript.Worksheet,getRange(address),Method,Fine,true
-ExcelScript.Worksheet,getRangeByIndexes(startRow,Method,Poor,false
+ExcelScript.Worksheet,getRangeByIndexes(startRow, startColumn, rowCount, columnCount),Method,Poor,false
 ExcelScript.Worksheet,getRanges(address),Method,Poor,false
 ExcelScript.Worksheet,getShape(key),Method,Poor,false
 ExcelScript.Worksheet,getShapes(),Method,Poor,false
@@ -3281,7 +3281,7 @@ ExcelScript.Worksheet,getWorksheetCustomProperty(key),Method,Poor,false
 ExcelScript.Worksheet,refreshAllPivotTables(),Method,Poor,false
 ExcelScript.Worksheet,removeAllHorizontalPageBreaks(),Method,Poor,false
 ExcelScript.Worksheet,removeAllVerticalPageBreaks(),Method,Poor,false
-ExcelScript.Worksheet,replaceAll(text,Method,Poor,false
+ExcelScript.Worksheet,replaceAll(text, replacement, criteria),Method,Poor,false
 ExcelScript.Worksheet,setEnableCalculation(enableCalculation),Method,Poor,false
 ExcelScript.Worksheet,setName(name),Method,Poor,true
 ExcelScript.Worksheet,setPosition(position),Method,Poor,true
@@ -3290,7 +3290,7 @@ ExcelScript.Worksheet,setShowHeadings(showHeadings),Method,Poor,false
 ExcelScript.Worksheet,setStandardWidth(standardWidth),Method,Poor,false
 ExcelScript.Worksheet,setTabColor(tabColor),Method,Poor,true
 ExcelScript.Worksheet,setVisibility(visibility),Method,Poor,true
-ExcelScript.Worksheet,showOutlineLevels(rowLevels,Method,Poor,false
+ExcelScript.Worksheet,showOutlineLevels(rowLevels, columnLevels),Method,Poor,false
 ExcelScript.WorksheetCustomProperty,N/A,Class,Poor,false
 ExcelScript.WorksheetCustomProperty,delete(),Method,Poor,false
 ExcelScript.WorksheetCustomProperty,getKey(),Method,Poor,false
@@ -3308,8 +3308,8 @@ ExcelScript.WorksheetPositionType,before,EnumField,Missing,false
 ExcelScript.WorksheetPositionType,beginning,EnumField,Missing,false
 ExcelScript.WorksheetPositionType,end,EnumField,Missing,false
 ExcelScript.WorksheetPositionType,none,EnumField,Missing,false
-ExcelScript.WorksheetProtection,N/A,Class,Poor,false
-ExcelScript.WorksheetProtection,addAllowEditRange(title,Method,Poor,false
+ExcelScript.WorksheetProtection,N/A,Class,Fine,false
+ExcelScript.WorksheetProtection,addAllowEditRange(title, rangeAddress, options),Method,Poor,false
 ExcelScript.WorksheetProtection,checkPassword(password),Method,Poor,false
 ExcelScript.WorksheetProtection,getAllowEditRange(key),Method,Poor,false
 ExcelScript.WorksheetProtection,getAllowEditRanges(),Method,Poor,false
@@ -3321,26 +3321,26 @@ ExcelScript.WorksheetProtection,getProtected(),Method,Poor,false
 ExcelScript.WorksheetProtection,getSavedOptions(),Method,Poor,false
 ExcelScript.WorksheetProtection,pauseProtection(password),Method,Poor,false
 ExcelScript.WorksheetProtection,pauseProtectionForAllAllowEditRanges(password),Method,Poor,false
-ExcelScript.WorksheetProtection,protect(options,Method,Poor,true
+ExcelScript.WorksheetProtection,protect(options, password),Method,Poor,true
 ExcelScript.WorksheetProtection,resumeProtection(),Method,Poor,false
 ExcelScript.WorksheetProtection,setPassword(password),Method,Poor,false
 ExcelScript.WorksheetProtection,unprotect(password),Method,Poor,false
 ExcelScript.WorksheetProtection,updateOptions(options),Method,Poor,false
-ExcelScript.WorksheetProtectionOptions,N/A,Class,Poor,true
+ExcelScript.WorksheetProtectionOptions,N/A,Class,Fine,true
 ExcelScript.WorksheetProtectionOptions,allowAutoFilter,Property,Fine,false
-ExcelScript.WorksheetProtectionOptions,allowDeleteColumns,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowDeleteRows,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowEditObjects,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowEditScenarios,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowFormatCells,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowFormatColumns,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowFormatRows,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowInsertColumns,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowInsertHyperlinks,Property,Poor,false
-ExcelScript.WorksheetProtectionOptions,allowInsertRows,Property,Poor,false
+ExcelScript.WorksheetProtectionOptions,allowDeleteColumns,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowDeleteRows,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowEditObjects,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowEditScenarios,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowFormatCells,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowFormatColumns,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowFormatRows,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowInsertColumns,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowInsertHyperlinks,Property,Fine,false
+ExcelScript.WorksheetProtectionOptions,allowInsertRows,Property,Fine,false
 ExcelScript.WorksheetProtectionOptions,allowPivotTables,Property,Fine,false
 ExcelScript.WorksheetProtectionOptions,allowSort,Property,Fine,false
-ExcelScript.WorksheetProtectionOptions,selectionMode,Property,Poor,false
-ExcelScript.WorksheetSearchCriteria,N/A,Class,Poor,false
+ExcelScript.WorksheetProtectionOptions,selectionMode,Property,Fine,false
+ExcelScript.WorksheetSearchCriteria,N/A,Class,Fine,false
 ExcelScript.WorksheetSearchCriteria,completeMatch,Property,Good,false
 ExcelScript.WorksheetSearchCriteria,matchCase,Property,Good,false

--- a/generate-docs/tools/coverage-tester.ts
+++ b/generate-docs/tools/coverage-tester.ts
@@ -32,6 +32,7 @@ class CoverageRating {
     type: ApiType;
     descriptionRating: DescriptionRating;
     hasExample: boolean;
+    isDeprecated: boolean;
 }
 
 /**
@@ -46,7 +47,8 @@ class ClassCoverageRating {
         this.classRating = {
             type: ApiType.Class,
             descriptionRating: DescriptionRating.Missing,
-            hasExample: false
+            hasExample: false,
+            isDeprecated: false
         };
     }
 }
@@ -151,11 +153,12 @@ function rateClass(classYml: ApiYaml) : ClassCoverageRating {
     ymlCoverage.classRating = rateClassDescription(classYml);
 
     classYml.fields?.forEach((field) => {
-        // Note: examples in enum fields are intentionally not supported.
+        // Note: Examples in enum fields are intentionally not supported.
         ymlCoverage.apiRatings.set(field.name, {
             type: ApiType.EnumField,
             descriptionRating: rateDescriptionString(field.summary),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: false
         });
     });
 
@@ -164,8 +167,7 @@ function rateClass(classYml: ApiYaml) : ClassCoverageRating {
     });
 
     classYml.methods?.forEach((field) => {
-        let name = field.name.indexOf(",") < 0 ? field.name : field.name.substring(0, field.name.indexOf(","));
-        ymlCoverage.apiRatings.set(name, rateFieldDescription(field, true));
+        ymlCoverage.apiRatings.set(field.name, rateFieldDescription(field, true));
     });
 
     return ymlCoverage;
@@ -175,22 +177,25 @@ function rateClassDescription(classYml: ApiYaml) : CoverageRating {
     let rating : CoverageRating;
     let type: ApiType = classYml.type === "interface" || classYml.type === "class" ? ApiType.Class : ApiType.Enum;
     let indexOfExample = classYml.remarks?.indexOf("#### Examples");
-    if (indexOfExample >= 0) {
+    if (indexOfExample > 0) {
         rating = {
             type: type,
             descriptionRating: rateDescriptionString((classYml.summary + " " + classYml.remarks.substring(0, indexOfExample)).trim()),
-            hasExample: true
+            hasExample: true,
+            isDeprecated: classYml.isDeprecated
         }
     } else {
         rating = {
             type: type,
             descriptionRating: rateDescriptionString((classYml.summary + " " + classYml.remarks).trim()),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: classYml.isDeprecated
         }
     }
 
     return rating;
 }
+
 
 function rateFieldDescription(fieldYml: ApiPropertyYaml | ApiMethodYaml, isMethod: boolean) : CoverageRating {
     let rating : CoverageRating;
@@ -201,15 +206,17 @@ function rateFieldDescription(fieldYml: ApiPropertyYaml | ApiMethodYaml, isMetho
 
     if (indexOfExample >= 0) {
         rating = {
-            type: isMethod ? ApiType.Method : ApiType.Property,
+            type: isMethod ? ApiType.Method: ApiType.Property,
             descriptionRating: rateDescriptionString((fieldYml.summary + " " + fieldYml.remarks.substring(0, indexOfExample)).trim()),
-            hasExample: true
+            hasExample: true,
+            isDeprecated: fieldYml.isDeprecated
         }
     } else {
         rating = {
-            type: isMethod ? ApiType.Method : ApiType.Property,
+            type: isMethod ? ApiType.Method: ApiType.Property,
             descriptionRating: rateDescriptionString((fieldYml.summary + " " + fieldYml.remarks).trim()),
-            hasExample: false
+            hasExample: false,
+            isDeprecated: fieldYml.isDeprecated
         }
     }
 
@@ -225,6 +232,13 @@ function rateFieldDescription(fieldYml: ApiPropertyYaml | ApiMethodYaml, isMetho
     return rating;
 }
 
+/**
+ * Apply a rudimentary system for descriptions.
+ * Missing: No description.
+ * Poor: 5 words or fewer - Implies a terse description that's unlikely to be a complete sentence.
+ * Fine: A single sentence of notable length. Enough to describe the field, but likely missing the finer points.
+ * Great: Multiple sentences, which implies notes about usage and edge cases.
+ */
 function rateDescriptionString(description: string) : DescriptionRating{
     if (description === "") {
         return DescriptionRating.Missing;
@@ -232,7 +246,7 @@ function rateDescriptionString(description: string) : DescriptionRating{
 
     let sentenceCount = description.split(". ").length;
     let wordCount = description.split(" ").length;
-    if (wordCount < 10) {
+    if (wordCount <= 5) {
         return DescriptionRating.Poor;
     } else if (sentenceCount < 2) {
         return DescriptionRating.Fine;
@@ -272,9 +286,9 @@ function averageDescriptionRatings(ratings: DescriptionRating[]) : DescriptionRa
 function convertToCsv(apiCoverage: Map<string, ClassCoverageRating>) : string {
     let csvString = "Class,Field,Type,Description Rating,Has Example?\n";
     apiCoverage.forEach((coverage, className) => {
-        csvString += `${className},N/A,${coverage.classRating.type},${coverage.classRating.descriptionRating},${coverage.classRating.hasExample}\n`;
+        csvString += `${className},N/A,${coverage.classRating.type},${coverage.classRating.isDeprecated ? "Deprecated" : coverage.classRating.descriptionRating},${coverage.classRating.hasExample}\n`;
         coverage.apiRatings.forEach((fieldCoverage, fieldName) => {
-            csvString += `${className},${fieldName},${fieldCoverage.type},${fieldCoverage.descriptionRating},${fieldCoverage.hasExample}\n`;
+            csvString += `${className},${fieldName},${fieldCoverage.type},${fieldCoverage.isDeprecated ? "Deprecated" : fieldCoverage.descriptionRating},${fieldCoverage.hasExample}\n`;
         });
     });
 


### PR DESCRIPTION
This PR brings the Scripts version of the Coverage Tester in line with the Office JS one (as of [this PR](https://github.com/OfficeDev/office-js-docs-reference/pull/1666)).