### PR TITLE
[excel] (Comments) Update getCommentByCell to mention error condition

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
@@ -758,7 +758,7 @@ methods:
     uid: 'ExcelScript!ExcelScript.Workbook#getCommentByCell:member(1)'
     package: ExcelScript!
     fullName: getCommentByCell(cellAddress)
-    summary: Gets the comment from the specified cell.
+    summary: 'Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.'
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
@@ -948,7 +948,7 @@ methods:
     uid: 'ExcelScript!ExcelScript.Worksheet#getCommentByCell:member(1)'
     package: ExcelScript!
     fullName: getCommentByCell(cellAddress)
-    summary: Gets the comment from the specified cell.
+    summary: 'Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.'
     remarks: ''
     isPreview: false
     isDeprecated: false

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -389,7 +389,7 @@ export declare namespace ExcelScript {
         ): Comment;
 
         /**
-         * Gets the comment from the specified cell.
+         * Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.
          * @param cellAddress - The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          */
         getCommentByCell(cellAddress: Range | string): Comment;
@@ -1061,7 +1061,7 @@ export declare namespace ExcelScript {
         ): Comment;
 
         /**
-         * Gets the comment from the specified cell.
+         * Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.
          * @param cellAddress - The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          */
         getCommentByCell(cellAddress: Range | string): Comment;

--- a/generate-docs/script-inputs/excel.d.ts
+++ b/generate-docs/script-inputs/excel.d.ts
@@ -389,7 +389,7 @@ declare namespace ExcelScript {
         ): Comment;
 
         /**
-         * Gets the comment from the specified cell.
+         * Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.
          * @param cellAddress The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          */
         getCommentByCell(cellAddress: Range | string): Comment;
@@ -1061,7 +1061,7 @@ declare namespace ExcelScript {
         ): Comment;
 
         /**
-         * Gets the comment from the specified cell.
+         * Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.
          * @param cellAddress The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided range is larger than one cell.
          */
         getCommentByCell(cellAddress: Range | string): Comment;


### PR DESCRIPTION
Fixes #271.

This PR adds a line to the Workbook/Worksheet.getCommentByCell description to mention that an error is thrown when there isn't a comment.