### PR TITLE
[excel] (Range) Fix AutoFillType typo

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilltype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilltype.yml
@@ -46,7 +46,7 @@ fields:
   - name: fillFormats
     uid: 'ExcelScript!ExcelScript.AutoFillType.fillFormats:member'
     package: ExcelScript!
-    summary: Populates the adjacent cells with the selected formulas.
+    summary: Populates the adjacent cells with the selected formats.
   - name: fillMonths
     uid: 'ExcelScript!ExcelScript.AutoFillType.fillMonths:member'
     package: ExcelScript!

--- a/generate-docs/api-extractor-inputs-excel/excel.d.ts
+++ b/generate-docs/api-extractor-inputs-excel/excel.d.ts
@@ -13866,7 +13866,7 @@ export declare namespace ExcelScript {
         fillSeries,
 
         /**
-         * Populates the adjacent cells with the selected formulas.
+         * Populates the adjacent cells with the selected formats.
          */
         fillFormats,
 

--- a/generate-docs/script-inputs/excel.d.ts
+++ b/generate-docs/script-inputs/excel.d.ts
@@ -13866,7 +13866,7 @@ declare namespace ExcelScript {
         fillSeries,
 
         /**
-         * Populates the adjacent cells with the selected formulas.
+         * Populates the adjacent cells with the selected formats.
          */
         fillFormats,
 


### PR DESCRIPTION
Fixes #282.

This PR makes the text for `fillFormats` match the enum value name.