### PR TITLE
[excel] (Range) Adding RangeFormat samples

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeformat.yml
@@ -4,7 +4,27 @@ uid: 'ExcelScript!ExcelScript.RangeFormat:interface'
 package: ExcelScript!
 fullName: ExcelScript.RangeFormat
 summary: 'A format object encapsulating the range''s font, fill, borders, alignment, and other properties.'
-remarks: ''
+remarks: |-
+
+
+  #### Examples
+
+  ```TypeScript
+  /**
+   * This script applies some simple formatting to the top row of the used range.
+   */
+  function main(workbook: ExcelScript.Workbook) {
+    // Get the top row of the used range in the current worksheet.
+    const selectedSheet = workbook.getActiveWorksheet();
+    const topRow = selectedSheet.getUsedRange().getRow(0);
+
+    // For the top row, set the fill to black, the font color to white, and the font to be bold.
+    const format: ExcelScript.RangeFormat = topRow.getFormat();
+    format.getFill().setColor("black");
+    format.getFont().setColor("white");
+    format.getFont().setBold(true);
+  }
+  ```
 isPreview: false
 isDeprecated: false
 type: interface
@@ -30,7 +50,28 @@ methods:
           type: number
       return:
         type: void
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script adjusts the indentation of a specific table column.
+           */
+          function main(workbook: ExcelScript.Workbook) {
+            // Get the first table in the current worksheet.
+            const selectedSheet = workbook.getActiveWorksheet();
+            const table = selectedSheet.getTables()[0];
+
+            // Get the data range of the second column.
+            const secondColumn = table.getColumn(2);
+            const data = secondColumn.getRangeBetweenHeaderAndTotal();
+
+            // Add an indentation of 1 character space to the data range.
+            data.getFormat().adjustIndent(1);
+          }
+          ```
   - name: autofitColumns()
     uid: 'ExcelScript!ExcelScript.RangeFormat#autofitColumns:member(1)'
     package: ExcelScript!

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.table.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.table.yml
@@ -214,7 +214,28 @@ methods:
           type: number | string
       return:
         type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> | undefined'
-        description: ''
+        description: |-
+
+
+          #### Examples
+
+          ```TypeScript
+          /**
+           * This script adjusts the indentation of a specific table column.
+           */
+          function main(workbook: ExcelScript.Workbook) {
+            // Get the first table in the current worksheet.
+            const selectedSheet = workbook.getActiveWorksheet();
+            const table = selectedSheet.getTables()[0];
+
+            // Get the data range of the second column.
+            const secondColumn = table.getColumn(2);
+            const data = secondColumn.getRangeBetweenHeaderAndTotal();
+
+            // Add an indentation of 1 character space to the data range.
+            data.getFormat().adjustIndent(1);
+          }
+          ```
   - name: getColumnById(key)
     uid: 'ExcelScript!ExcelScript.Table#getColumnById:member(1)'
     package: ExcelScript!

--- a/docs/sample-scripts/excel-scripts.yaml
+++ b/docs/sample-scripts/excel-scripts.yaml
@@ -4264,6 +4264,39 @@
       selected.getFormat().getFill().setPattern(ExcelScript.FillPattern.checker);
       selected.getFormat().getFill().setPatternColor("black");
     }
+'ExcelScript.RangeFormat:interface':
+  - |-
+    /**
+     * This script applies some simple formatting to the top row of the used range.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the top row of the used range in the current worksheet.
+      const selectedSheet = workbook.getActiveWorksheet();
+      const topRow = selectedSheet.getUsedRange().getRow(0);
+
+      // For the top row, set the fill to black, the font color to white, and the font to be bold.
+      const format: ExcelScript.RangeFormat = topRow.getFormat();
+      format.getFill().setColor("black");
+      format.getFont().setColor("white");
+      format.getFont().setBold(true);
+    }
+'ExcelScript.RangeFormat#adjustIndent:member(1)':
+  - |-
+    /**
+     * This script adjusts the indentation of a specific table column.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the first table in the current worksheet.
+      const selectedSheet = workbook.getActiveWorksheet();
+      const table = selectedSheet.getTables()[0];
+
+      // Get the data range of the second column.
+      const secondColumn = table.getColumn(2);
+      const data = secondColumn.getRangeBetweenHeaderAndTotal();
+
+      // Add an indentation of 1 character space to the data range.
+      data.getFormat().adjustIndent(1);
+    }
 'ExcelScript.RangeFormat#getFill:member(1)':
   - |-
     /**

--- a/docs/sample-scripts/excel-scripts.yaml
+++ b/docs/sample-scripts/excel-scripts.yaml
@@ -5172,6 +5172,23 @@
         const lastColumn = table.getColumn(table.getColumns().length);
         lastColumn.getTotalRowRange().setFormula(`=SUBTOTAL(109,[${lastColumn.getName()}])`);
     }
+'ExcelScript.Table#getColumn:member(1)':
+  - |-
+    /**
+     * This script adjusts the indentation of a specific table column.
+     */
+    function main(workbook: ExcelScript.Workbook) {
+      // Get the first table in the current worksheet.
+      const selectedSheet = workbook.getActiveWorksheet();
+      const table = selectedSheet.getTables()[0];
+
+      // Get the data range of the second column.
+      const secondColumn = table.getColumn(2);
+      const data = secondColumn.getRangeBetweenHeaderAndTotal();
+
+      // Add an indentation of 1 character space to the data range.
+      data.getFormat().adjustIndent(1);
+    }
 'ExcelScript.Table#getColumns:member(1)':
   - |-
     /**

--- a/generate-docs/API Coverage Report.csv
+++ b/generate-docs/API Coverage Report.csv
@@ -2987,7 +2987,7 @@ ExcelScript.Table,"convertToRange()",Method,Poor,false
 ExcelScript.Table,"delete()",Method,Poor,false
 ExcelScript.Table,"deleteRowsAt(index, count)",Method,Poor,false
 ExcelScript.Table,"getAutoFilter()",Method,Poor,false
-ExcelScript.Table,"getColumn(key)",Method,Poor,false
+ExcelScript.Table,"getColumn(key)",Method,Poor,true
 ExcelScript.Table,"getColumnById(key)",Method,Poor,false
 ExcelScript.Table,"getColumnByName(key)",Method,Poor,false
 ExcelScript.Table,"getColumns()",Method,Fine,true

--- a/generate-docs/API Coverage Report.csv
+++ b/generate-docs/API Coverage Report.csv
@@ -2555,8 +2555,8 @@ ExcelScript.RangeFont,"setSubscript(subscript)",Method,Poor,false
 ExcelScript.RangeFont,"setSuperscript(superscript)",Method,Poor,false
 ExcelScript.RangeFont,"setTintAndShade(tintAndShade)",Method,Poor,false
 ExcelScript.RangeFont,"setUnderline(underline)",Method,Poor,false
-ExcelScript.RangeFormat,N/A,Class,Fine,false
-ExcelScript.RangeFormat,"adjustIndent(amount)",Method,Poor,false
+ExcelScript.RangeFormat,N/A,Class,Fine,true
+ExcelScript.RangeFormat,"adjustIndent(amount)",Method,Fine,true
 ExcelScript.RangeFormat,"autofitColumns()",Method,Poor,true
 ExcelScript.RangeFormat,"autofitRows()",Method,Poor,true
 ExcelScript.RangeFormat,"getAutoIndent()",Method,Poor,false


### PR DESCRIPTION
This PR adds a top-level sample for `RangeFormat` and one for the `RangeFormat.adjustIndent` method. The second sample is also mapped to the `Table.getColumn` method.