### PR TITLE
Force LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Title says it all :)

Git checks out files with CRLF by default on Windows, but Cygwin trips when reading shell scripts with CRLF line endings :(