### PR TITLE
[admin] Display links to component types in TypeAliases

### DIFF
--- a/docs/docs-ref-autogen/excel/excelscript.yml
+++ b/docs/docs-ref-autogen/excel/excelscript.yml
@@ -4,351 +4,352 @@ name: ExcelScript
 type: package
 summary: ''
 enums:
-  - 'ExcelScript!ExcelScript.AggregationFunction:enum'
-  - 'ExcelScript!ExcelScript.ArrowheadLength:enum'
-  - 'ExcelScript!ExcelScript.ArrowheadStyle:enum'
-  - 'ExcelScript!ExcelScript.ArrowheadWidth:enum'
-  - 'ExcelScript!ExcelScript.AutoFillType:enum'
-  - 'ExcelScript!ExcelScript.BindingType:enum'
-  - 'ExcelScript!ExcelScript.BorderIndex:enum'
-  - 'ExcelScript!ExcelScript.BorderLineStyle:enum'
-  - 'ExcelScript!ExcelScript.BorderWeight:enum'
-  - 'ExcelScript!ExcelScript.BuiltInStyle:enum'
-  - 'ExcelScript!ExcelScript.CalculationMode:enum'
-  - 'ExcelScript!ExcelScript.CalculationState:enum'
-  - 'ExcelScript!ExcelScript.CalculationType:enum'
-  - 'ExcelScript!ExcelScript.CellControlType:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisCategoryType:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisGroup:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisPosition:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisScaleType:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisTickMark:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisTimeUnit:enum'
-  - 'ExcelScript!ExcelScript.ChartAxisType:enum'
-  - 'ExcelScript!ExcelScript.ChartBinType:enum'
-  - 'ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum'
-  - 'ExcelScript!ExcelScript.ChartColorScheme:enum'
-  - 'ExcelScript!ExcelScript.ChartDataLabelPosition:enum'
-  - 'ExcelScript!ExcelScript.ChartDataSourceType:enum'
-  - 'ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum'
-  - 'ExcelScript!ExcelScript.ChartErrorBarsInclude:enum'
-  - 'ExcelScript!ExcelScript.ChartErrorBarsType:enum'
-  - 'ExcelScript!ExcelScript.ChartGradientStyle:enum'
-  - 'ExcelScript!ExcelScript.ChartGradientStyleType:enum'
-  - 'ExcelScript!ExcelScript.ChartLegendPosition:enum'
-  - 'ExcelScript!ExcelScript.ChartLineStyle:enum'
-  - 'ExcelScript!ExcelScript.ChartMapAreaLevel:enum'
-  - 'ExcelScript!ExcelScript.ChartMapLabelStrategy:enum'
-  - 'ExcelScript!ExcelScript.ChartMapProjectionType:enum'
-  - 'ExcelScript!ExcelScript.ChartMarkerStyle:enum'
-  - 'ExcelScript!ExcelScript.ChartParentLabelStrategy:enum'
-  - 'ExcelScript!ExcelScript.ChartPlotAreaPosition:enum'
-  - 'ExcelScript!ExcelScript.ChartPlotBy:enum'
-  - 'ExcelScript!ExcelScript.ChartSeriesBy:enum'
-  - 'ExcelScript!ExcelScript.ChartSeriesDimension:enum'
-  - 'ExcelScript!ExcelScript.ChartSplitType:enum'
-  - 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum'
-  - 'ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum'
-  - 'ExcelScript!ExcelScript.ChartTickLabelAlignment:enum'
-  - 'ExcelScript!ExcelScript.ChartTitlePosition:enum'
-  - 'ExcelScript!ExcelScript.ChartTrendlineType:enum'
-  - 'ExcelScript!ExcelScript.ChartType:enum'
-  - 'ExcelScript!ExcelScript.ChartUnderlineStyle:enum'
-  - 'ExcelScript!ExcelScript.ClearApplyTo:enum'
-  - 'ExcelScript!ExcelScript.ConditionalCellValueOperator:enum'
-  - 'ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum'
-  - 'ExcelScript!ExcelScript.ConditionalDataBarDirection:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatDirection:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatRuleType:enum'
-  - 'ExcelScript!ExcelScript.ConditionalFormatType:enum'
-  - 'ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum'
-  - 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum'
-  - 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum'
-  - 'ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum'
-  - 'ExcelScript!ExcelScript.ConditionalTextOperator:enum'
-  - 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum'
-  - 'ExcelScript!ExcelScript.ConnectorType:enum'
-  - 'ExcelScript!ExcelScript.ContentType:enum'
-  - 'ExcelScript!ExcelScript.DataSourceType:enum'
-  - 'ExcelScript!ExcelScript.DataValidationAlertStyle:enum'
-  - 'ExcelScript!ExcelScript.DataValidationOperator:enum'
-  - 'ExcelScript!ExcelScript.DataValidationType:enum'
-  - 'ExcelScript!ExcelScript.DateFilterCondition:enum'
-  - 'ExcelScript!ExcelScript.DeleteShiftDirection:enum'
-  - 'ExcelScript!ExcelScript.DocumentPropertyType:enum'
-  - 'ExcelScript!ExcelScript.DynamicFilterCriteria:enum'
-  - 'ExcelScript!ExcelScript.FillPattern:enum'
-  - 'ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum'
-  - 'ExcelScript!ExcelScript.FilterOn:enum'
-  - 'ExcelScript!ExcelScript.FilterOperator:enum'
-  - 'ExcelScript!ExcelScript.GeometricShapeType:enum'
-  - 'ExcelScript!ExcelScript.GroupOption:enum'
-  - 'ExcelScript!ExcelScript.HeaderFooterState:enum'
-  - 'ExcelScript!ExcelScript.HorizontalAlignment:enum'
-  - 'ExcelScript!ExcelScript.IconSet:enum'
-  - 'ExcelScript!ExcelScript.ImageFittingMode:enum'
-  - 'ExcelScript!ExcelScript.InsertShiftDirection:enum'
-  - 'ExcelScript!ExcelScript.KeyboardDirection:enum'
-  - 'ExcelScript!ExcelScript.LabelFilterCondition:enum'
-  - 'ExcelScript!ExcelScript.LinkedDataTypeState:enum'
-  - 'ExcelScript!ExcelScript.LoadToType:enum'
-  - 'ExcelScript!ExcelScript.NamedItemScope:enum'
-  - 'ExcelScript!ExcelScript.NamedItemType:enum'
-  - 'ExcelScript!ExcelScript.NumberFormatCategory:enum'
-  - 'ExcelScript!ExcelScript.PageOrientation:enum'
-  - 'ExcelScript!ExcelScript.PaperType:enum'
-  - 'ExcelScript!ExcelScript.PictureFormat:enum'
-  - 'ExcelScript!ExcelScript.PivotAxis:enum'
-  - 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion:enum'
-  - 'ExcelScript!ExcelScript.PivotFilterType:enum'
-  - 'ExcelScript!ExcelScript.PivotLayoutType:enum'
-  - 'ExcelScript!ExcelScript.Placement:enum'
-  - 'ExcelScript!ExcelScript.PrintComments:enum'
-  - 'ExcelScript!ExcelScript.PrintErrorType:enum'
-  - 'ExcelScript!ExcelScript.PrintMarginUnit:enum'
-  - 'ExcelScript!ExcelScript.PrintOrder:enum'
-  - 'ExcelScript!ExcelScript.ProtectionSelectionMode:enum'
-  - 'ExcelScript!ExcelScript.QueryError:enum'
-  - 'ExcelScript!ExcelScript.RangeCopyType:enum'
-  - 'ExcelScript!ExcelScript.RangeUnderlineStyle:enum'
-  - 'ExcelScript!ExcelScript.RangeValueType:enum'
-  - 'ExcelScript!ExcelScript.ReadingOrder:enum'
-  - 'ExcelScript!ExcelScript.SearchDirection:enum'
-  - 'ExcelScript!ExcelScript.ShapeAutoSize:enum'
-  - 'ExcelScript!ExcelScript.ShapeFillType:enum'
-  - 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum'
-  - 'ExcelScript!ExcelScript.ShapeLineDashStyle:enum'
-  - 'ExcelScript!ExcelScript.ShapeLineStyle:enum'
-  - 'ExcelScript!ExcelScript.ShapeScaleFrom:enum'
-  - 'ExcelScript!ExcelScript.ShapeScaleType:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextOrientation:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextReadingOrder:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum'
-  - 'ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum'
-  - 'ExcelScript!ExcelScript.ShapeType:enum'
-  - 'ExcelScript!ExcelScript.ShapeZOrder:enum'
-  - 'ExcelScript!ExcelScript.SheetVisibility:enum'
-  - 'ExcelScript!ExcelScript.ShowAsCalculation:enum'
-  - 'ExcelScript!ExcelScript.SlicerSortType:enum'
-  - 'ExcelScript!ExcelScript.SortBy:enum'
-  - 'ExcelScript!ExcelScript.SortDataOption:enum'
-  - 'ExcelScript!ExcelScript.SortMethod:enum'
-  - 'ExcelScript!ExcelScript.SortOn:enum'
-  - 'ExcelScript!ExcelScript.SortOrientation:enum'
-  - 'ExcelScript!ExcelScript.SpecialCellType:enum'
-  - 'ExcelScript!ExcelScript.SpecialCellValueType:enum'
-  - 'ExcelScript!ExcelScript.SubtotalLocationType:enum'
-  - 'ExcelScript!ExcelScript.TopBottomSelectionType:enum'
-  - 'ExcelScript!ExcelScript.ValueFilterCondition:enum'
-  - 'ExcelScript!ExcelScript.VerticalAlignment:enum'
-  - 'ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum'
-  - 'ExcelScript!ExcelScript.WorksheetPositionType:enum'
-  - 'ExcelScript!Global.OfficeScript.EmailContentType:enum'
-  - 'ExcelScript!Global.OfficeScript.EmailImportance:enum'
+  - ExcelScript!ExcelScript.AggregationFunction:enum
+  - ExcelScript!ExcelScript.ArrowheadLength:enum
+  - ExcelScript!ExcelScript.ArrowheadStyle:enum
+  - ExcelScript!ExcelScript.ArrowheadWidth:enum
+  - ExcelScript!ExcelScript.AutoFillType:enum
+  - ExcelScript!ExcelScript.BindingType:enum
+  - ExcelScript!ExcelScript.BorderIndex:enum
+  - ExcelScript!ExcelScript.BorderLineStyle:enum
+  - ExcelScript!ExcelScript.BorderWeight:enum
+  - ExcelScript!ExcelScript.BuiltInStyle:enum
+  - ExcelScript!ExcelScript.CalculationMode:enum
+  - ExcelScript!ExcelScript.CalculationState:enum
+  - ExcelScript!ExcelScript.CalculationType:enum
+  - ExcelScript!ExcelScript.CellControlType:enum
+  - ExcelScript!ExcelScript.ChartAxisCategoryType:enum
+  - ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum
+  - ExcelScript!ExcelScript.ChartAxisGroup:enum
+  - ExcelScript!ExcelScript.ChartAxisPosition:enum
+  - ExcelScript!ExcelScript.ChartAxisScaleType:enum
+  - ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum
+  - ExcelScript!ExcelScript.ChartAxisTickMark:enum
+  - ExcelScript!ExcelScript.ChartAxisTimeUnit:enum
+  - ExcelScript!ExcelScript.ChartAxisType:enum
+  - ExcelScript!ExcelScript.ChartBinType:enum
+  - ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum
+  - ExcelScript!ExcelScript.ChartColorScheme:enum
+  - ExcelScript!ExcelScript.ChartDataLabelPosition:enum
+  - ExcelScript!ExcelScript.ChartDataSourceType:enum
+  - ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum
+  - ExcelScript!ExcelScript.ChartErrorBarsInclude:enum
+  - ExcelScript!ExcelScript.ChartErrorBarsType:enum
+  - ExcelScript!ExcelScript.ChartGradientStyle:enum
+  - ExcelScript!ExcelScript.ChartGradientStyleType:enum
+  - ExcelScript!ExcelScript.ChartLegendPosition:enum
+  - ExcelScript!ExcelScript.ChartLineStyle:enum
+  - ExcelScript!ExcelScript.ChartMapAreaLevel:enum
+  - ExcelScript!ExcelScript.ChartMapLabelStrategy:enum
+  - ExcelScript!ExcelScript.ChartMapProjectionType:enum
+  - ExcelScript!ExcelScript.ChartMarkerStyle:enum
+  - ExcelScript!ExcelScript.ChartParentLabelStrategy:enum
+  - ExcelScript!ExcelScript.ChartPlotAreaPosition:enum
+  - ExcelScript!ExcelScript.ChartPlotBy:enum
+  - ExcelScript!ExcelScript.ChartSeriesBy:enum
+  - ExcelScript!ExcelScript.ChartSeriesDimension:enum
+  - ExcelScript!ExcelScript.ChartSplitType:enum
+  - ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum
+  - ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum
+  - ExcelScript!ExcelScript.ChartTickLabelAlignment:enum
+  - ExcelScript!ExcelScript.ChartTitlePosition:enum
+  - ExcelScript!ExcelScript.ChartTrendlineType:enum
+  - ExcelScript!ExcelScript.ChartType:enum
+  - ExcelScript!ExcelScript.ChartUnderlineStyle:enum
+  - ExcelScript!ExcelScript.ClearApplyTo:enum
+  - ExcelScript!ExcelScript.ConditionalCellValueOperator:enum
+  - ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum
+  - ExcelScript!ExcelScript.ConditionalDataBarDirection:enum
+  - ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum
+  - ExcelScript!ExcelScript.ConditionalFormatDirection:enum
+  - ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum
+  - ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum
+  - ExcelScript!ExcelScript.ConditionalFormatRuleType:enum
+  - ExcelScript!ExcelScript.ConditionalFormatType:enum
+  - ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum
+  - ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum
+  - ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum
+  - ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum
+  - ExcelScript!ExcelScript.ConditionalTextOperator:enum
+  - ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum
+  - ExcelScript!ExcelScript.ConnectorType:enum
+  - ExcelScript!ExcelScript.ContentType:enum
+  - ExcelScript!ExcelScript.DataSourceType:enum
+  - ExcelScript!ExcelScript.DataValidationAlertStyle:enum
+  - ExcelScript!ExcelScript.DataValidationOperator:enum
+  - ExcelScript!ExcelScript.DataValidationType:enum
+  - ExcelScript!ExcelScript.DateFilterCondition:enum
+  - ExcelScript!ExcelScript.DeleteShiftDirection:enum
+  - ExcelScript!ExcelScript.DocumentPropertyType:enum
+  - ExcelScript!ExcelScript.DynamicFilterCriteria:enum
+  - ExcelScript!ExcelScript.FillPattern:enum
+  - ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum
+  - ExcelScript!ExcelScript.FilterOn:enum
+  - ExcelScript!ExcelScript.FilterOperator:enum
+  - ExcelScript!ExcelScript.GeometricShapeType:enum
+  - ExcelScript!ExcelScript.GroupOption:enum
+  - ExcelScript!ExcelScript.HeaderFooterState:enum
+  - ExcelScript!ExcelScript.HorizontalAlignment:enum
+  - ExcelScript!ExcelScript.IconSet:enum
+  - ExcelScript!ExcelScript.ImageFittingMode:enum
+  - ExcelScript!ExcelScript.InsertShiftDirection:enum
+  - ExcelScript!ExcelScript.KeyboardDirection:enum
+  - ExcelScript!ExcelScript.LabelFilterCondition:enum
+  - ExcelScript!ExcelScript.LinkedDataTypeState:enum
+  - ExcelScript!ExcelScript.LoadToType:enum
+  - ExcelScript!ExcelScript.NamedItemScope:enum
+  - ExcelScript!ExcelScript.NamedItemType:enum
+  - ExcelScript!ExcelScript.NumberFormatCategory:enum
+  - ExcelScript!ExcelScript.PageOrientation:enum
+  - ExcelScript!ExcelScript.PaperType:enum
+  - ExcelScript!ExcelScript.PictureFormat:enum
+  - ExcelScript!ExcelScript.PivotAxis:enum
+  - ExcelScript!ExcelScript.PivotFilterTopBottomCriterion:enum
+  - ExcelScript!ExcelScript.PivotFilterType:enum
+  - ExcelScript!ExcelScript.PivotLayoutType:enum
+  - ExcelScript!ExcelScript.Placement:enum
+  - ExcelScript!ExcelScript.PrintComments:enum
+  - ExcelScript!ExcelScript.PrintErrorType:enum
+  - ExcelScript!ExcelScript.PrintMarginUnit:enum
+  - ExcelScript!ExcelScript.PrintOrder:enum
+  - ExcelScript!ExcelScript.ProtectionSelectionMode:enum
+  - ExcelScript!ExcelScript.QueryError:enum
+  - ExcelScript!ExcelScript.RangeCopyType:enum
+  - ExcelScript!ExcelScript.RangeUnderlineStyle:enum
+  - ExcelScript!ExcelScript.RangeValueType:enum
+  - ExcelScript!ExcelScript.ReadingOrder:enum
+  - ExcelScript!ExcelScript.SearchDirection:enum
+  - ExcelScript!ExcelScript.ShapeAutoSize:enum
+  - ExcelScript!ExcelScript.ShapeFillType:enum
+  - ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum
+  - ExcelScript!ExcelScript.ShapeLineDashStyle:enum
+  - ExcelScript!ExcelScript.ShapeLineStyle:enum
+  - ExcelScript!ExcelScript.ShapeScaleFrom:enum
+  - ExcelScript!ExcelScript.ShapeScaleType:enum
+  - ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum
+  - ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum
+  - ExcelScript!ExcelScript.ShapeTextOrientation:enum
+  - ExcelScript!ExcelScript.ShapeTextReadingOrder:enum
+  - ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum
+  - ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum
+  - ExcelScript!ExcelScript.ShapeType:enum
+  - ExcelScript!ExcelScript.ShapeZOrder:enum
+  - ExcelScript!ExcelScript.SheetVisibility:enum
+  - ExcelScript!ExcelScript.ShowAsCalculation:enum
+  - ExcelScript!ExcelScript.SlicerSortType:enum
+  - ExcelScript!ExcelScript.SortBy:enum
+  - ExcelScript!ExcelScript.SortDataOption:enum
+  - ExcelScript!ExcelScript.SortMethod:enum
+  - ExcelScript!ExcelScript.SortOn:enum
+  - ExcelScript!ExcelScript.SortOrientation:enum
+  - ExcelScript!ExcelScript.SpecialCellType:enum
+  - ExcelScript!ExcelScript.SpecialCellValueType:enum
+  - ExcelScript!ExcelScript.SubtotalLocationType:enum
+  - ExcelScript!ExcelScript.TopBottomSelectionType:enum
+  - ExcelScript!ExcelScript.ValueFilterCondition:enum
+  - ExcelScript!ExcelScript.VerticalAlignment:enum
+  - ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum
+  - ExcelScript!ExcelScript.WorksheetPositionType:enum
+  - ExcelScript!Global.OfficeScript.EmailContentType:enum
+  - ExcelScript!Global.OfficeScript.EmailImportance:enum
 interfaces:
-  - 'ExcelScript!ExcelScript.AllowEditRange:interface'
-  - 'ExcelScript!ExcelScript.AllowEditRangeOptions:interface'
-  - 'ExcelScript!ExcelScript.Application:interface'
-  - 'ExcelScript!ExcelScript.AutoFilter:interface'
-  - 'ExcelScript!ExcelScript.BasicDataValidation:interface'
-  - 'ExcelScript!ExcelScript.Binding:interface'
-  - 'ExcelScript!ExcelScript.CellValueConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.Chart:interface'
-  - 'ExcelScript!ExcelScript.ChartAreaFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartAxes:interface'
-  - 'ExcelScript!ExcelScript.ChartAxis:interface'
-  - 'ExcelScript!ExcelScript.ChartAxisFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartAxisTitle:interface'
-  - 'ExcelScript!ExcelScript.ChartAxisTitleFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartBinOptions:interface'
-  - 'ExcelScript!ExcelScript.ChartBorder:interface'
-  - 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface'
-  - 'ExcelScript!ExcelScript.ChartDataLabel:interface'
-  - 'ExcelScript!ExcelScript.ChartDataLabelAnchor:interface'
-  - 'ExcelScript!ExcelScript.ChartDataLabelFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartDataLabels:interface'
-  - 'ExcelScript!ExcelScript.ChartDataTable:interface'
-  - 'ExcelScript!ExcelScript.ChartDataTableFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartErrorBars:interface'
-  - 'ExcelScript!ExcelScript.ChartErrorBarsFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartFill:interface'
-  - 'ExcelScript!ExcelScript.ChartFont:interface'
-  - 'ExcelScript!ExcelScript.ChartFormatString:interface'
-  - 'ExcelScript!ExcelScript.ChartGridlines:interface'
-  - 'ExcelScript!ExcelScript.ChartGridlinesFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartLeaderLines:interface'
-  - 'ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartLegend:interface'
-  - 'ExcelScript!ExcelScript.ChartLegendEntry:interface'
-  - 'ExcelScript!ExcelScript.ChartLegendFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartLineFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartMapOptions:interface'
-  - 'ExcelScript!ExcelScript.ChartPivotOptions:interface'
-  - 'ExcelScript!ExcelScript.ChartPlotArea:interface'
-  - 'ExcelScript!ExcelScript.ChartPlotAreaFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartPoint:interface'
-  - 'ExcelScript!ExcelScript.ChartPointFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartSeries:interface'
-  - 'ExcelScript!ExcelScript.ChartSeriesFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartTitle:interface'
-  - 'ExcelScript!ExcelScript.ChartTitleFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartTrendline:interface'
-  - 'ExcelScript!ExcelScript.ChartTrendlineFormat:interface'
-  - 'ExcelScript!ExcelScript.ChartTrendlineLabel:interface'
-  - 'ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface'
-  - 'ExcelScript!ExcelScript.CheckboxCellControl:interface'
-  - 'ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.Comment:interface'
-  - 'ExcelScript!ExcelScript.CommentMention:interface'
-  - 'ExcelScript!ExcelScript.CommentReply:interface'
-  - 'ExcelScript!ExcelScript.CommentRichContent:interface'
-  - 'ExcelScript!ExcelScript.ConditionalCellValueRule:interface'
-  - 'ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface'
-  - 'ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface'
-  - 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface'
-  - 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface'
-  - 'ExcelScript!ExcelScript.ConditionalDataBarRule:interface'
-  - 'ExcelScript!ExcelScript.ConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.ConditionalFormatRule:interface'
-  - 'ExcelScript!ExcelScript.ConditionalIconCriterion:interface'
-  - 'ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface'
-  - 'ExcelScript!ExcelScript.ConditionalRangeBorder:interface'
-  - 'ExcelScript!ExcelScript.ConditionalRangeFill:interface'
-  - 'ExcelScript!ExcelScript.ConditionalRangeFont:interface'
-  - 'ExcelScript!ExcelScript.ConditionalRangeFormat:interface'
-  - 'ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface'
-  - 'ExcelScript!ExcelScript.ConditionalTopBottomRule:interface'
-  - 'ExcelScript!ExcelScript.CultureInfo:interface'
-  - 'ExcelScript!ExcelScript.CustomConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.CustomDataValidation:interface'
-  - 'ExcelScript!ExcelScript.CustomProperty:interface'
-  - 'ExcelScript!ExcelScript.CustomXmlPart:interface'
-  - 'ExcelScript!ExcelScript.DataBarConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.DataPivotHierarchy:interface'
-  - 'ExcelScript!ExcelScript.DataValidation:interface'
-  - 'ExcelScript!ExcelScript.DataValidationErrorAlert:interface'
-  - 'ExcelScript!ExcelScript.DataValidationPrompt:interface'
-  - 'ExcelScript!ExcelScript.DataValidationRule:interface'
-  - 'ExcelScript!ExcelScript.DateTimeDataValidation:interface'
-  - 'ExcelScript!ExcelScript.DatetimeFormatInfo:interface'
-  - 'ExcelScript!ExcelScript.DocumentProperties:interface'
-  - 'ExcelScript!ExcelScript.EmptyCellControl:interface'
-  - 'ExcelScript!ExcelScript.Filter:interface'
-  - 'ExcelScript!ExcelScript.FilterCriteria:interface'
-  - 'ExcelScript!ExcelScript.FilterDatetime:interface'
-  - 'ExcelScript!ExcelScript.FilterPivotHierarchy:interface'
-  - 'ExcelScript!ExcelScript.FormatProtection:interface'
-  - 'ExcelScript!ExcelScript.GeometricShape:interface'
-  - 'ExcelScript!ExcelScript.HeaderFooter:interface'
-  - 'ExcelScript!ExcelScript.HeaderFooterGroup:interface'
-  - 'ExcelScript!ExcelScript.Icon:interface'
-  - 'ExcelScript!ExcelScript.IconSetConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.Image:interface'
-  - 'ExcelScript!ExcelScript.IterativeCalculation:interface'
-  - 'ExcelScript!ExcelScript.Line:interface'
-  - 'ExcelScript!ExcelScript.LinkedWorkbook:interface'
-  - 'ExcelScript!ExcelScript.ListDataValidation:interface'
-  - 'ExcelScript!ExcelScript.MixedCellControl:interface'
-  - 'ExcelScript!ExcelScript.NamedItem:interface'
-  - 'ExcelScript!ExcelScript.NamedItemArrayValues:interface'
-  - 'ExcelScript!ExcelScript.NamedSheetView:interface'
-  - 'ExcelScript!ExcelScript.NumberFormatInfo:interface'
-  - 'ExcelScript!ExcelScript.PageBreak:interface'
-  - 'ExcelScript!ExcelScript.PageLayout:interface'
-  - 'ExcelScript!ExcelScript.PageLayoutMarginOptions:interface'
-  - 'ExcelScript!ExcelScript.PageLayoutZoomOptions:interface'
-  - 'ExcelScript!ExcelScript.PivotDateFilter:interface'
-  - 'ExcelScript!ExcelScript.PivotField:interface'
-  - 'ExcelScript!ExcelScript.PivotFilters:interface'
-  - 'ExcelScript!ExcelScript.PivotHierarchy:interface'
-  - 'ExcelScript!ExcelScript.PivotItem:interface'
-  - 'ExcelScript!ExcelScript.PivotLabelFilter:interface'
-  - 'ExcelScript!ExcelScript.PivotLayout:interface'
-  - 'ExcelScript!ExcelScript.PivotManualFilter:interface'
-  - 'ExcelScript!ExcelScript.PivotTable:interface'
-  - 'ExcelScript!ExcelScript.PivotTableStyle:interface'
-  - 'ExcelScript!ExcelScript.PivotValueFilter:interface'
-  - 'ExcelScript!ExcelScript.PredefinedCellStyle:interface'
-  - 'ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.Query:interface'
-  - 'ExcelScript!ExcelScript.Range:interface'
-  - 'ExcelScript!ExcelScript.RangeAreas:interface'
-  - 'ExcelScript!ExcelScript.RangeBorder:interface'
-  - 'ExcelScript!ExcelScript.RangeFill:interface'
-  - 'ExcelScript!ExcelScript.RangeFont:interface'
-  - 'ExcelScript!ExcelScript.RangeFormat:interface'
-  - 'ExcelScript!ExcelScript.RangeHyperlink:interface'
-  - 'ExcelScript!ExcelScript.RangeSort:interface'
-  - 'ExcelScript!ExcelScript.RangeView:interface'
-  - 'ExcelScript!ExcelScript.RemoveDuplicatesResult:interface'
-  - 'ExcelScript!ExcelScript.ReplaceCriteria:interface'
-  - 'ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface'
-  - 'ExcelScript!ExcelScript.SearchCriteria:interface'
-  - 'ExcelScript!ExcelScript.Shape:interface'
-  - 'ExcelScript!ExcelScript.ShapeFill:interface'
-  - 'ExcelScript!ExcelScript.ShapeFont:interface'
-  - 'ExcelScript!ExcelScript.ShapeGroup:interface'
-  - 'ExcelScript!ExcelScript.ShapeLineFormat:interface'
-  - 'ExcelScript!ExcelScript.ShowAsRule:interface'
-  - 'ExcelScript!ExcelScript.Slicer:interface'
-  - 'ExcelScript!ExcelScript.SlicerItem:interface'
-  - 'ExcelScript!ExcelScript.SlicerStyle:interface'
-  - 'ExcelScript!ExcelScript.SortField:interface'
-  - 'ExcelScript!ExcelScript.Subtotals:interface'
-  - 'ExcelScript!ExcelScript.Table:interface'
-  - 'ExcelScript!ExcelScript.TableColumn:interface'
-  - 'ExcelScript!ExcelScript.TableSort:interface'
-  - 'ExcelScript!ExcelScript.TableStyle:interface'
-  - 'ExcelScript!ExcelScript.TextConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.TextFrame:interface'
-  - 'ExcelScript!ExcelScript.TextRange:interface'
-  - 'ExcelScript!ExcelScript.TimelineStyle:interface'
-  - 'ExcelScript!ExcelScript.TopBottomConditionalFormat:interface'
-  - 'ExcelScript!ExcelScript.UnknownCellControl:interface'
-  - 'ExcelScript!ExcelScript.Workbook:interface'
-  - 'ExcelScript!ExcelScript.WorkbookProtection:interface'
-  - 'ExcelScript!ExcelScript.WorkbookRangeAreas:interface'
-  - 'ExcelScript!ExcelScript.Worksheet:interface'
-  - 'ExcelScript!ExcelScript.WorksheetCustomProperty:interface'
-  - 'ExcelScript!ExcelScript.WorksheetFreezePanes:interface'
-  - 'ExcelScript!ExcelScript.WorksheetProtection:interface'
-  - 'ExcelScript!ExcelScript.WorksheetProtectionOptions:interface'
-  - 'ExcelScript!ExcelScript.WorksheetSearchCriteria:interface'
-  - 'ExcelScript!Global.OfficeScript.EmailAttachment:interface'
-  - 'ExcelScript!Global.OfficeScript.MailProperties:interface'
+  - ExcelScript!ExcelScript.AllowEditRange:interface
+  - ExcelScript!ExcelScript.AllowEditRangeOptions:interface
+  - ExcelScript!ExcelScript.Application:interface
+  - ExcelScript!ExcelScript.AutoFilter:interface
+  - ExcelScript!ExcelScript.BasicDataValidation:interface
+  - ExcelScript!ExcelScript.Binding:interface
+  - ExcelScript!ExcelScript.CellValueConditionalFormat:interface
+  - ExcelScript!ExcelScript.Chart:interface
+  - ExcelScript!ExcelScript.ChartAreaFormat:interface
+  - ExcelScript!ExcelScript.ChartAxes:interface
+  - ExcelScript!ExcelScript.ChartAxis:interface
+  - ExcelScript!ExcelScript.ChartAxisFormat:interface
+  - ExcelScript!ExcelScript.ChartAxisTitle:interface
+  - ExcelScript!ExcelScript.ChartAxisTitleFormat:interface
+  - ExcelScript!ExcelScript.ChartBinOptions:interface
+  - ExcelScript!ExcelScript.ChartBorder:interface
+  - ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface
+  - ExcelScript!ExcelScript.ChartDataLabel:interface
+  - ExcelScript!ExcelScript.ChartDataLabelAnchor:interface
+  - ExcelScript!ExcelScript.ChartDataLabelFormat:interface
+  - ExcelScript!ExcelScript.ChartDataLabels:interface
+  - ExcelScript!ExcelScript.ChartDataTable:interface
+  - ExcelScript!ExcelScript.ChartDataTableFormat:interface
+  - ExcelScript!ExcelScript.ChartErrorBars:interface
+  - ExcelScript!ExcelScript.ChartErrorBarsFormat:interface
+  - ExcelScript!ExcelScript.ChartFill:interface
+  - ExcelScript!ExcelScript.ChartFont:interface
+  - ExcelScript!ExcelScript.ChartFormatString:interface
+  - ExcelScript!ExcelScript.ChartGridlines:interface
+  - ExcelScript!ExcelScript.ChartGridlinesFormat:interface
+  - ExcelScript!ExcelScript.ChartLeaderLines:interface
+  - ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface
+  - ExcelScript!ExcelScript.ChartLegend:interface
+  - ExcelScript!ExcelScript.ChartLegendEntry:interface
+  - ExcelScript!ExcelScript.ChartLegendFormat:interface
+  - ExcelScript!ExcelScript.ChartLineFormat:interface
+  - ExcelScript!ExcelScript.ChartMapOptions:interface
+  - ExcelScript!ExcelScript.ChartPivotOptions:interface
+  - ExcelScript!ExcelScript.ChartPlotArea:interface
+  - ExcelScript!ExcelScript.ChartPlotAreaFormat:interface
+  - ExcelScript!ExcelScript.ChartPoint:interface
+  - ExcelScript!ExcelScript.ChartPointFormat:interface
+  - ExcelScript!ExcelScript.ChartSeries:interface
+  - ExcelScript!ExcelScript.ChartSeriesFormat:interface
+  - ExcelScript!ExcelScript.ChartTitle:interface
+  - ExcelScript!ExcelScript.ChartTitleFormat:interface
+  - ExcelScript!ExcelScript.ChartTrendline:interface
+  - ExcelScript!ExcelScript.ChartTrendlineFormat:interface
+  - ExcelScript!ExcelScript.ChartTrendlineLabel:interface
+  - ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface
+  - ExcelScript!ExcelScript.CheckboxCellControl:interface
+  - ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface
+  - ExcelScript!ExcelScript.Comment:interface
+  - ExcelScript!ExcelScript.CommentMention:interface
+  - ExcelScript!ExcelScript.CommentReply:interface
+  - ExcelScript!ExcelScript.CommentRichContent:interface
+  - ExcelScript!ExcelScript.ConditionalCellValueRule:interface
+  - ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface
+  - ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface
+  - ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface
+  - ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface
+  - ExcelScript!ExcelScript.ConditionalDataBarRule:interface
+  - ExcelScript!ExcelScript.ConditionalFormat:interface
+  - ExcelScript!ExcelScript.ConditionalFormatRule:interface
+  - ExcelScript!ExcelScript.ConditionalIconCriterion:interface
+  - ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface
+  - ExcelScript!ExcelScript.ConditionalRangeBorder:interface
+  - ExcelScript!ExcelScript.ConditionalRangeFill:interface
+  - ExcelScript!ExcelScript.ConditionalRangeFont:interface
+  - ExcelScript!ExcelScript.ConditionalRangeFormat:interface
+  - ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface
+  - ExcelScript!ExcelScript.ConditionalTopBottomRule:interface
+  - ExcelScript!ExcelScript.CultureInfo:interface
+  - ExcelScript!ExcelScript.CustomConditionalFormat:interface
+  - ExcelScript!ExcelScript.CustomDataValidation:interface
+  - ExcelScript!ExcelScript.CustomProperty:interface
+  - ExcelScript!ExcelScript.CustomXmlPart:interface
+  - ExcelScript!ExcelScript.DataBarConditionalFormat:interface
+  - ExcelScript!ExcelScript.DataPivotHierarchy:interface
+  - ExcelScript!ExcelScript.DataValidation:interface
+  - ExcelScript!ExcelScript.DataValidationErrorAlert:interface
+  - ExcelScript!ExcelScript.DataValidationPrompt:interface
+  - ExcelScript!ExcelScript.DataValidationRule:interface
+  - ExcelScript!ExcelScript.DateTimeDataValidation:interface
+  - ExcelScript!ExcelScript.DatetimeFormatInfo:interface
+  - ExcelScript!ExcelScript.DocumentProperties:interface
+  - ExcelScript!ExcelScript.EmptyCellControl:interface
+  - ExcelScript!ExcelScript.Filter:interface
+  - ExcelScript!ExcelScript.FilterCriteria:interface
+  - ExcelScript!ExcelScript.FilterDatetime:interface
+  - ExcelScript!ExcelScript.FilterPivotHierarchy:interface
+  - ExcelScript!ExcelScript.FormatProtection:interface
+  - ExcelScript!ExcelScript.GeometricShape:interface
+  - ExcelScript!ExcelScript.HeaderFooter:interface
+  - ExcelScript!ExcelScript.HeaderFooterGroup:interface
+  - ExcelScript!ExcelScript.Icon:interface
+  - ExcelScript!ExcelScript.IconSetConditionalFormat:interface
+  - ExcelScript!ExcelScript.Image:interface
+  - ExcelScript!ExcelScript.IterativeCalculation:interface
+  - ExcelScript!ExcelScript.Line:interface
+  - ExcelScript!ExcelScript.LinkedWorkbook:interface
+  - ExcelScript!ExcelScript.ListDataValidation:interface
+  - ExcelScript!ExcelScript.MixedCellControl:interface
+  - ExcelScript!ExcelScript.NamedItem:interface
+  - ExcelScript!ExcelScript.NamedItemArrayValues:interface
+  - ExcelScript!ExcelScript.NamedSheetView:interface
+  - ExcelScript!ExcelScript.NumberFormatInfo:interface
+  - ExcelScript!ExcelScript.PageBreak:interface
+  - ExcelScript!ExcelScript.PageLayout:interface
+  - ExcelScript!ExcelScript.PageLayoutMarginOptions:interface
+  - ExcelScript!ExcelScript.PageLayoutZoomOptions:interface
+  - ExcelScript!ExcelScript.PivotDateFilter:interface
+  - ExcelScript!ExcelScript.PivotField:interface
+  - ExcelScript!ExcelScript.PivotFilters:interface
+  - ExcelScript!ExcelScript.PivotHierarchy:interface
+  - ExcelScript!ExcelScript.PivotItem:interface
+  - ExcelScript!ExcelScript.PivotLabelFilter:interface
+  - ExcelScript!ExcelScript.PivotLayout:interface
+  - ExcelScript!ExcelScript.PivotManualFilter:interface
+  - ExcelScript!ExcelScript.PivotTable:interface
+  - ExcelScript!ExcelScript.PivotTableStyle:interface
+  - ExcelScript!ExcelScript.PivotValueFilter:interface
+  - ExcelScript!ExcelScript.PredefinedCellStyle:interface
+  - ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface
+  - ExcelScript!ExcelScript.Query:interface
+  - ExcelScript!ExcelScript.Range:interface
+  - ExcelScript!ExcelScript.RangeAreas:interface
+  - ExcelScript!ExcelScript.RangeBorder:interface
+  - ExcelScript!ExcelScript.RangeFill:interface
+  - ExcelScript!ExcelScript.RangeFont:interface
+  - ExcelScript!ExcelScript.RangeFormat:interface
+  - ExcelScript!ExcelScript.RangeHyperlink:interface
+  - ExcelScript!ExcelScript.RangeSort:interface
+  - ExcelScript!ExcelScript.RangeView:interface
+  - ExcelScript!ExcelScript.RemoveDuplicatesResult:interface
+  - ExcelScript!ExcelScript.ReplaceCriteria:interface
+  - ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface
+  - ExcelScript!ExcelScript.SearchCriteria:interface
+  - ExcelScript!ExcelScript.Shape:interface
+  - ExcelScript!ExcelScript.ShapeFill:interface
+  - ExcelScript!ExcelScript.ShapeFont:interface
+  - ExcelScript!ExcelScript.ShapeGroup:interface
+  - ExcelScript!ExcelScript.ShapeLineFormat:interface
+  - ExcelScript!ExcelScript.ShowAsRule:interface
+  - ExcelScript!ExcelScript.Slicer:interface
+  - ExcelScript!ExcelScript.SlicerItem:interface
+  - ExcelScript!ExcelScript.SlicerStyle:interface
+  - ExcelScript!ExcelScript.SortField:interface
+  - ExcelScript!ExcelScript.Subtotals:interface
+  - ExcelScript!ExcelScript.Table:interface
+  - ExcelScript!ExcelScript.TableColumn:interface
+  - ExcelScript!ExcelScript.TableSort:interface
+  - ExcelScript!ExcelScript.TableStyle:interface
+  - ExcelScript!ExcelScript.TextConditionalFormat:interface
+  - ExcelScript!ExcelScript.TextFrame:interface
+  - ExcelScript!ExcelScript.TextRange:interface
+  - ExcelScript!ExcelScript.TimelineStyle:interface
+  - ExcelScript!ExcelScript.TopBottomConditionalFormat:interface
+  - ExcelScript!ExcelScript.UnknownCellControl:interface
+  - ExcelScript!ExcelScript.Workbook:interface
+  - ExcelScript!ExcelScript.WorkbookProtection:interface
+  - ExcelScript!ExcelScript.WorkbookRangeAreas:interface
+  - ExcelScript!ExcelScript.Worksheet:interface
+  - ExcelScript!ExcelScript.WorksheetCustomProperty:interface
+  - ExcelScript!ExcelScript.WorksheetFreezePanes:interface
+  - ExcelScript!ExcelScript.WorksheetProtection:interface
+  - ExcelScript!ExcelScript.WorksheetProtectionOptions:interface
+  - ExcelScript!ExcelScript.WorksheetSearchCriteria:interface
+  - ExcelScript!Global.OfficeScript.EmailAttachment:interface
+  - ExcelScript!Global.OfficeScript.MailProperties:interface
 typeAliases:
-  - 'ExcelScript!ExcelScript.CellControl:type'
+  - ExcelScript!ExcelScript.CellControl:type
 functions:
   - name: Global.OfficeScript.convertToPdf()
-    uid: 'ExcelScript!Global.OfficeScript.convertToPdf:function(1)'
+    uid: ExcelScript!Global.OfficeScript.convertToPdf:function(1)
     package: ExcelScript!
     summary: >-
-      Return the text encoding of the document as a PDF. If the document is empty, then the following error is shown:
-      "We didn't find anything to print".
+      Return the text encoding of the document as a PDF. If the document is
+      empty, then the following error is shown: "We didn't find anything to
+      print".
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'export function convertToPdf(): string;'
       return:
         type: string
-        description: 'The content of the workbook as a string, in PDF format.'
-  - name: |-
-      Global.OfficeScript.downloadFile({
-                  name,
-                  content,
-              })
-    uid: 'ExcelScript!Global.OfficeScript.downloadFile:function(1)'
+        description: The content of the workbook as a string, in PDF format.
+  - name: "Global.OfficeScript.downloadFile({\r\n            name,\r\n            content,\r\n        })"
+    uid: ExcelScript!Global.OfficeScript.downloadFile:function(1)
     package: ExcelScript!
-    summary: Downloads a specified file to the default download location specified by the local machine.
+    summary: >-
+      Downloads a specified file to the default download location specified by
+      the local machine.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -361,11 +362,7 @@ functions:
                     content: string;
                 }): void;
       parameters:
-        - id: |-
-            {
-                        name,
-                        content,
-                    }
+        - id: "{\r\n            name,\r\n            content,\r\n        }"
           description: ''
           type: |-
             {
@@ -376,10 +373,11 @@ functions:
         type: void
         description: ''
   - name: Global.OfficeScript.Metadata.getScriptName()
-    uid: 'ExcelScript!Global.OfficeScript.Metadata.getScriptName:function(1)'
+    uid: ExcelScript!Global.OfficeScript.Metadata.getScriptName:function(1)
     package: ExcelScript!
     summary: Get the current executing scripts name.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -388,12 +386,14 @@ functions:
         type: string
         description: ''
   - name: Global.OfficeScript.sendMail(mailProperties)
-    uid: 'ExcelScript!Global.OfficeScript.sendMail:function(1)'
+    uid: ExcelScript!Global.OfficeScript.sendMail:function(1)
     package: ExcelScript!
     summary: >-
-      Send an email with an Office Script. Use `MailProperties` to specify the content and recipients of the email. If
-      the request body includes content, this method returns 400 Bad request.
+      Send an email with an Office Script. Use `MailProperties` to specify the
+      content and recipients of the email. If the request body includes content,
+      this method returns 400 Bad request.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -401,7 +401,9 @@ functions:
       parameters:
         - id: mailProperties
           description: ''
-          type: '<xref uid="ExcelScript!Global.OfficeScript.MailProperties:interface" />'
+          type: >-
+            <xref uid="ExcelScript!Global.OfficeScript.MailProperties:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.aggregationfunction.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.aggregationfunction.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.AggregationFunction
-uid: 'ExcelScript!ExcelScript.AggregationFunction:enum'
+uid: ExcelScript!ExcelScript.AggregationFunction:enum
 package: ExcelScript!
 fullName: ExcelScript.AggregationFunction
 summary: Aggregation function for the `DataPivotHierarchy`<!-- -->.
@@ -22,58 +22,75 @@ remarks: |-
     dataHierarchy.setSummarizeBy(ExcelScript.AggregationFunction.average);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.automatic:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.automatic:member
     package: ExcelScript!
     summary: Excel will automatically select the aggregation based on the data items.
   - name: average
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.average:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.average:member
     package: ExcelScript!
-    summary: 'Aggregate using the average of the data, equivalent to the AVERAGE function.'
+    summary: >-
+      Aggregate using the average of the data, equivalent to the AVERAGE
+      function.
   - name: count
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.count:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.count:member
     package: ExcelScript!
-    summary: 'Aggregate using the count of items in the data, equivalent to the COUNTA function.'
+    summary: >-
+      Aggregate using the count of items in the data, equivalent to the COUNTA
+      function.
   - name: countNumbers
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.countNumbers:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.countNumbers:member
     package: ExcelScript!
-    summary: 'Aggregate using the count of numbers in the data, equivalent to the COUNT function.'
+    summary: >-
+      Aggregate using the count of numbers in the data, equivalent to the COUNT
+      function.
   - name: max
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.max:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.max:member
     package: ExcelScript!
-    summary: 'Aggregate using the maximum value of the data, equivalent to the MAX function.'
+    summary: >-
+      Aggregate using the maximum value of the data, equivalent to the MAX
+      function.
   - name: min
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.min:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.min:member
     package: ExcelScript!
-    summary: 'Aggregate using the minimum value of the data, equivalent to the MIN function.'
+    summary: >-
+      Aggregate using the minimum value of the data, equivalent to the MIN
+      function.
   - name: product
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.product:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.product:member
     package: ExcelScript!
-    summary: 'Aggregate using the product of the data, equivalent to the PRODUCT function.'
+    summary: >-
+      Aggregate using the product of the data, equivalent to the PRODUCT
+      function.
   - name: standardDeviation
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.standardDeviation:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.standardDeviation:member
     package: ExcelScript!
-    summary: 'Aggregate using the standard deviation of the data, equivalent to the STDEV function.'
+    summary: >-
+      Aggregate using the standard deviation of the data, equivalent to the
+      STDEV function.
   - name: standardDeviationP
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.standardDeviationP:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.standardDeviationP:member
     package: ExcelScript!
-    summary: 'Aggregate using the standard deviation of the data, equivalent to the STDEVP function.'
+    summary: >-
+      Aggregate using the standard deviation of the data, equivalent to the
+      STDEVP function.
   - name: sum
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.sum:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.sum:member
     package: ExcelScript!
-    summary: 'Aggregate using the sum of the data, equivalent to the SUM function.'
+    summary: Aggregate using the sum of the data, equivalent to the SUM function.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.unknown:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.unknown:member
     package: ExcelScript!
     summary: Aggregation function is unknown or unsupported.
   - name: variance
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.variance:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.variance:member
     package: ExcelScript!
-    summary: 'Aggregate using the variance of the data, equivalent to the VAR function.'
+    summary: Aggregate using the variance of the data, equivalent to the VAR function.
   - name: varianceP
-    uid: 'ExcelScript!ExcelScript.AggregationFunction.varianceP:member'
+    uid: ExcelScript!ExcelScript.AggregationFunction.varianceP:member
     package: ExcelScript!
-    summary: 'Aggregate using the variance of the data, equivalent to the VARP function.'
+    summary: Aggregate using the variance of the data, equivalent to the VARP function.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.alloweditrange.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.alloweditrange.yml
@@ -1,26 +1,30 @@
 ### YamlMime:TSType
 name: ExcelScript.AllowEditRange
-uid: 'ExcelScript!ExcelScript.AllowEditRange:interface'
+uid: ExcelScript!ExcelScript.AllowEditRange:interface
 package: ExcelScript!
 fullName: ExcelScript.AllowEditRange
 summary: >-
-  Represents an `AllowEditRange` object found in a worksheet. This object works with worksheet protection properties.
-  When worksheet protection is enabled, an `AllowEditRange` object can be used to allow editing of a specific range,
+  Represents an `AllowEditRange` object found in a worksheet. This object works
+  with worksheet protection properties. When worksheet protection is enabled, an
+  `AllowEditRange` object can be used to allow editing of a specific range,
   while maintaining protection on the rest of the worksheet.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#delete:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: >-
-      Deletes the object from the `AllowEditRangeCollection`<!-- -->. Worksheet protection must be disabled or paused
-      for this method to work properly. If worksheet protection is enabled and not paused, this method throws an
+      Deletes the object from the `AllowEditRangeCollection`<!-- -->. Worksheet
+      protection must be disabled or paused for this method to work properly. If
+      worksheet protection is enabled and not paused, this method throws an
       `AccessDenied` error and fails the delete operation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -29,11 +33,12 @@ methods:
         type: void
         description: ''
   - name: getAddress()
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#getAddress:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#getAddress:member(1)
     package: ExcelScript!
     fullName: getAddress()
     summary: Specifies the range associated with the object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,11 +47,12 @@ methods:
         type: string
         description: ''
   - name: getIsPasswordProtected()
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#getIsPasswordProtected:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#getIsPasswordProtected:member(1)
     package: ExcelScript!
     fullName: getIsPasswordProtected()
     summary: Specifies if the object is password protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,11 +61,12 @@ methods:
         type: boolean
         description: ''
   - name: getTitle()
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#getTitle:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#getTitle:member(1)
     package: ExcelScript!
     fullName: getTitle()
     summary: Specifies the title of the object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -68,17 +75,20 @@ methods:
         type: string
         description: ''
   - name: pauseProtection(password)
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#pauseProtection:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#pauseProtection:member(1)
     package: ExcelScript!
     fullName: pauseProtection(password)
     summary: >-
-      Pauses worksheet protection for the object for the user in the current session. This method does nothing if
-      worksheet protection isn't enabled or is already paused. If worksheet protection cannot be paused, this method
-      throws an `UnsupportedOperation` error and fails to pause protection for the object. If the password is incorrect,
-      then this method throws a `BadPassword` error and fails to pause protection for the object. If a password is
-      supplied but the object does not require a password, the inputted password will be ignored and the operation will
-      succeed.
+      Pauses worksheet protection for the object for the user in the current
+      session. This method does nothing if worksheet protection isn't enabled or
+      is already paused. If worksheet protection cannot be paused, this method
+      throws an `UnsupportedOperation` error and fails to pause protection for
+      the object. If the password is incorrect, then this method throws a
+      `BadPassword` error and fails to pause protection for the object. If a
+      password is supplied but the object does not require a password, the
+      inputted password will be ignored and the operation will succeed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,14 +101,16 @@ methods:
         type: void
         description: ''
   - name: setAddress(address)
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#setAddress:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#setAddress:member(1)
     package: ExcelScript!
     fullName: setAddress(address)
     summary: >-
-      Specifies the range associated with the object. Worksheet protection must be disabled or paused for this method to
-      work properly. If worksheet protection is enabled and not paused, this method throws an `AccessDenied` error and
-      fails to set the range.
+      Specifies the range associated with the object. Worksheet protection must
+      be disabled or paused for this method to work properly. If worksheet
+      protection is enabled and not paused, this method throws an `AccessDenied`
+      error and fails to set the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -111,15 +123,17 @@ methods:
         type: void
         description: ''
   - name: setPassword(password)
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#setPassword:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#setPassword:member(1)
     package: ExcelScript!
     fullName: setPassword(password)
     summary: >-
-      Changes the password associated with the object. Setting the password string as empty ("") or `null` will remove
-      password protection from the object. Worksheet protection must be disabled or paused for this method to work
-      properly. If worksheet protection is enabled and not paused, then this method throws an `AccessDenied` error and
-      the set operation fails.
+      Changes the password associated with the object. Setting the password
+      string as empty ("") or `null` will remove password protection from the
+      object. Worksheet protection must be disabled or paused for this method to
+      work properly. If worksheet protection is enabled and not paused, then
+      this method throws an `AccessDenied` error and the set operation fails.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -132,15 +146,18 @@ methods:
         type: void
         description: ''
   - name: setTitle(title)
-    uid: 'ExcelScript!ExcelScript.AllowEditRange#setTitle:member(1)'
+    uid: ExcelScript!ExcelScript.AllowEditRange#setTitle:member(1)
     package: ExcelScript!
     fullName: setTitle(title)
     summary: >-
-      Specifies the title of the object. Worksheet protection must be disabled or paused for this method to work
-      properly. If worksheet protection is enabled and not paused, this method throws an `AccessDenied` error and fails
-      to set the title. If there is already an existing `AllowEditRange` with the same string, or if the string is
-      `null` or empty (""), then this method throws an `InvalidArgument` error and fails to set the title.
+      Specifies the title of the object. Worksheet protection must be disabled
+      or paused for this method to work properly. If worksheet protection is
+      enabled and not paused, this method throws an `AccessDenied` error and
+      fails to set the title. If there is already an existing `AllowEditRange`
+      with the same string, or if the string is `null` or empty (""), then this
+      method throws an `InvalidArgument` error and fails to set the title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.alloweditrangeoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.alloweditrangeoptions.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.AllowEditRangeOptions
-uid: 'ExcelScript!ExcelScript.AllowEditRangeOptions:interface'
+uid: ExcelScript!ExcelScript.AllowEditRangeOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.AllowEditRangeOptions
-summary: The interface used to construct optional fields of the `AllowEditRange` object.
+summary: >-
+  The interface used to construct optional fields of the `AllowEditRange`
+  object.
 remarks: |-
 
 
@@ -31,16 +33,18 @@ remarks: |-
       sheetProtection.protect();
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: password
-    uid: 'ExcelScript!ExcelScript.AllowEditRangeOptions#password:member'
+    uid: ExcelScript!ExcelScript.AllowEditRangeOptions#password:member
     package: ExcelScript!
     fullName: password
     summary: The password associated with the `AllowEditRange`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.application.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.application.yml
@@ -1,28 +1,32 @@
 ### YamlMime:TSType
 name: ExcelScript.Application
-uid: 'ExcelScript!ExcelScript.Application:interface'
+uid: ExcelScript!ExcelScript.Application:interface
 package: ExcelScript!
 fullName: ExcelScript.Application
 summary: Represents the Excel application that manages the workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: calculate(calculationType)
-    uid: 'ExcelScript!ExcelScript.Application#calculate:member(1)'
+    uid: ExcelScript!ExcelScript.Application#calculate:member(1)
     package: ExcelScript!
     fullName: calculate(calculationType)
     summary: Recalculate all currently opened workbooks in Excel.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'calculate(calculationType: CalculationType): void;'
       parameters:
         - id: calculationType
-          description: Specifies the calculation type to use. See `ExcelScript.CalculationType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.CalculationType:enum" />'
+          description: >-
+            Specifies the calculation type to use. See
+            `ExcelScript.CalculationType` for details.
+          type: <xref uid="ExcelScript!ExcelScript.CalculationType:enum" />
       return:
         type: void
         description: |-
@@ -42,11 +46,14 @@ methods:
           }
           ```
   - name: getCalculationEngineVersion()
-    uid: 'ExcelScript!ExcelScript.Application#getCalculationEngineVersion:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getCalculationEngineVersion:member(1)
     package: ExcelScript!
     fullName: getCalculationEngineVersion()
-    summary: Returns the Excel calculation engine version used for the last full recalculation.
+    summary: >-
+      Returns the Excel calculation engine version used for the last full
+      recalculation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,34 +62,40 @@ methods:
         type: number
         description: ''
   - name: getCalculationMode()
-    uid: 'ExcelScript!ExcelScript.Application#getCalculationMode:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getCalculationMode:member(1)
     package: ExcelScript!
     fullName: getCalculationMode()
     summary: >-
-      Returns the calculation mode used in the workbook, as defined by the constants in
-      `ExcelScript.CalculationMode`<!-- -->. Possible values are: `Automatic`<!-- -->, where Excel controls
-      recalculation; `AutomaticExceptTables`<!-- -->, where Excel controls recalculation but ignores changes in tables;
-      `Manual`<!-- -->, where calculation is done when the user requests it.
+      Returns the calculation mode used in the workbook, as defined by the
+      constants in `ExcelScript.CalculationMode`<!-- -->. Possible values are:
+      `Automatic`<!-- -->, where Excel controls recalculation;
+      `AutomaticExceptTables`<!-- -->, where Excel controls recalculation but
+      ignores changes in tables; `Manual`<!-- -->, where calculation is done
+      when the user requests it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCalculationMode(): CalculationMode;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CalculationMode:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.CalculationMode:enum" />
         description: ''
   - name: getCalculationState()
-    uid: 'ExcelScript!ExcelScript.Application#getCalculationState:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getCalculationState:member(1)
     package: ExcelScript!
     fullName: getCalculationState()
-    summary: Returns the calculation state of the application. See `ExcelScript.CalculationState` for details.
+    summary: >-
+      Returns the calculation state of the application. See
+      `ExcelScript.CalculationState` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCalculationState(): CalculationState;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CalculationState:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.CalculationState:enum" />
         description: |-
 
 
@@ -116,26 +129,31 @@ methods:
           }
           ```
   - name: getCultureInfo()
-    uid: 'ExcelScript!ExcelScript.Application#getCultureInfo:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getCultureInfo:member(1)
     package: ExcelScript!
     fullName: getCultureInfo()
     summary: >-
-      Provides information based on current system culture settings. This includes the culture names, number formatting,
-      and other culturally dependent settings.
+      Provides information based on current system culture settings. This
+      includes the culture names, number formatting, and other culturally
+      dependent settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCultureInfo(): CultureInfo;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CultureInfo:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.CultureInfo:interface" />
         description: ''
   - name: getDecimalSeparator()
-    uid: 'ExcelScript!ExcelScript.Application#getDecimalSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getDecimalSeparator:member(1)
     package: ExcelScript!
     fullName: getDecimalSeparator()
-    summary: Gets the string used as the decimal separator for numeric values. This is based on the local Excel settings.
+    summary: >-
+      Gets the string used as the decimal separator for numeric values. This is
+      based on the local Excel settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -144,28 +162,31 @@ methods:
         type: string
         description: ''
   - name: getIterativeCalculation()
-    uid: 'ExcelScript!ExcelScript.Application#getIterativeCalculation:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getIterativeCalculation:member(1)
     package: ExcelScript!
     fullName: getIterativeCalculation()
     summary: >-
-      Returns the iterative calculation settings. In Excel on Windows and Mac, the settings will apply to the Excel
-      Application. In Excel on the web and other platforms, the settings will apply to the active workbook.
+      Returns the iterative calculation settings. In Excel on Windows and Mac,
+      the settings will apply to the Excel Application. In Excel on the web and
+      other platforms, the settings will apply to the active workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getIterativeCalculation(): IterativeCalculation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.IterativeCalculation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.IterativeCalculation:interface" />
         description: ''
   - name: getThousandsSeparator()
-    uid: 'ExcelScript!ExcelScript.Application#getThousandsSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getThousandsSeparator:member(1)
     package: ExcelScript!
     fullName: getThousandsSeparator()
     summary: >-
-      Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on
-      the local Excel settings.
+      Gets the string used to separate groups of digits to the left of the
+      decimal for numeric values. This is based on the local Excel settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,13 +195,14 @@ methods:
         type: string
         description: ''
   - name: getUseSystemSeparators()
-    uid: 'ExcelScript!ExcelScript.Application#getUseSystemSeparators:member(1)'
+    uid: ExcelScript!ExcelScript.Application#getUseSystemSeparators:member(1)
     package: ExcelScript!
     fullName: getUseSystemSeparators()
     summary: >-
-      Specifies if the system separators of Excel are enabled. System separators include the decimal separator and
-      thousands separator.
+      Specifies if the system separators of Excel are enabled. System separators
+      include the decimal separator and thousands separator.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -189,15 +211,18 @@ methods:
         type: boolean
         description: ''
   - name: setCalculationMode(calculationMode)
-    uid: 'ExcelScript!ExcelScript.Application#setCalculationMode:member(1)'
+    uid: ExcelScript!ExcelScript.Application#setCalculationMode:member(1)
     package: ExcelScript!
     fullName: setCalculationMode(calculationMode)
     summary: >-
-      Returns the calculation mode used in the workbook, as defined by the constants in
-      `ExcelScript.CalculationMode`<!-- -->. Possible values are: `Automatic`<!-- -->, where Excel controls
-      recalculation; `AutomaticExceptTables`<!-- -->, where Excel controls recalculation but ignores changes in tables;
-      `Manual`<!-- -->, where calculation is done when the user requests it.
+      Returns the calculation mode used in the workbook, as defined by the
+      constants in `ExcelScript.CalculationMode`<!-- -->. Possible values are:
+      `Automatic`<!-- -->, where Excel controls recalculation;
+      `AutomaticExceptTables`<!-- -->, where Excel controls recalculation but
+      ignores changes in tables; `Manual`<!-- -->, where calculation is done
+      when the user requests it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -205,7 +230,7 @@ methods:
       parameters:
         - id: calculationMode
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.CalculationMode:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.CalculationMode:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadlength.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadlength.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ArrowheadLength
-uid: 'ExcelScript!ExcelScript.ArrowheadLength:enum'
+uid: ExcelScript!ExcelScript.ArrowheadLength:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadLength
 summary: ''
@@ -35,18 +35,19 @@ remarks: |-
     line.setEndArrowheadLength(ExcelScript.ArrowheadLength.long);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: long
-    uid: 'ExcelScript!ExcelScript.ArrowheadLength.long:member'
+    uid: ExcelScript!ExcelScript.ArrowheadLength.long:member
     package: ExcelScript!
     summary: ''
   - name: medium
-    uid: 'ExcelScript!ExcelScript.ArrowheadLength.medium:member'
+    uid: ExcelScript!ExcelScript.ArrowheadLength.medium:member
     package: ExcelScript!
     summary: ''
   - name: short
-    uid: 'ExcelScript!ExcelScript.ArrowheadLength.short:member'
+    uid: ExcelScript!ExcelScript.ArrowheadLength.short:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadstyle.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ArrowheadStyle
-uid: 'ExcelScript!ExcelScript.ArrowheadStyle:enum'
+uid: ExcelScript!ExcelScript.ArrowheadStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadStyle
 summary: ''
@@ -34,30 +34,31 @@ remarks: |-
     line.setEndArrowheadStyle(ExcelScript.ArrowheadStyle.open);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: diamond
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.diamond:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.diamond:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.none:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: open
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.open:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.open:member
     package: ExcelScript!
     summary: ''
   - name: oval
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.oval:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.oval:member
     package: ExcelScript!
     summary: ''
   - name: stealth
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.stealth:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.stealth:member
     package: ExcelScript!
     summary: ''
   - name: triangle
-    uid: 'ExcelScript!ExcelScript.ArrowheadStyle.triangle:member'
+    uid: ExcelScript!ExcelScript.ArrowheadStyle.triangle:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadwidth.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.arrowheadwidth.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ArrowheadWidth
-uid: 'ExcelScript!ExcelScript.ArrowheadWidth:enum'
+uid: ExcelScript!ExcelScript.ArrowheadWidth:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadWidth
 summary: ''
@@ -35,18 +35,19 @@ remarks: |-
     line.setEndArrowheadWidth(ExcelScript.ArrowheadWidth.wide);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: medium
-    uid: 'ExcelScript!ExcelScript.ArrowheadWidth.medium:member'
+    uid: ExcelScript!ExcelScript.ArrowheadWidth.medium:member
     package: ExcelScript!
     summary: ''
   - name: narrow
-    uid: 'ExcelScript!ExcelScript.ArrowheadWidth.narrow:member'
+    uid: ExcelScript!ExcelScript.ArrowheadWidth.narrow:member
     package: ExcelScript!
     summary: ''
   - name: wide
-    uid: 'ExcelScript!ExcelScript.ArrowheadWidth.wide:member'
+    uid: ExcelScript!ExcelScript.ArrowheadWidth.wide:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilltype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilltype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.AutoFillType
-uid: 'ExcelScript!ExcelScript.AutoFillType:enum'
+uid: ExcelScript!ExcelScript.AutoFillType:enum
 package: ExcelScript!
 fullName: ExcelScript.AutoFillType
 summary: The behavior types when AutoFill is used on a range in the workbook.
@@ -26,60 +26,67 @@ remarks: |-
     dataRange.autoFill("C2:C54", ExcelScript.AutoFillType.fillDays);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: fillCopy
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillCopy:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillCopy:member
     package: ExcelScript!
     summary: Populates the adjacent cells with data based on the selected data.
   - name: fillDays
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillDays:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillDays:member
     package: ExcelScript!
     summary: >-
-      A version of "FillSeries" for dates that bases the pattern on either the day of the month or the day of the week,
-      depending on the context.
+      A version of "FillSeries" for dates that bases the pattern on either the
+      day of the month or the day of the week, depending on the context.
   - name: fillDefault
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillDefault:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillDefault:member
     package: ExcelScript!
-    summary: Populates the adjacent cells based on the surrounding data (the standard AutoFill behavior).
+    summary: >-
+      Populates the adjacent cells based on the surrounding data (the standard
+      AutoFill behavior).
   - name: fillFormats
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillFormats:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillFormats:member
     package: ExcelScript!
     summary: Populates the adjacent cells with the selected formats.
   - name: fillMonths
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillMonths:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillMonths:member
     package: ExcelScript!
     summary: A version of "FillSeries" for dates that bases the pattern on the month.
   - name: fillSeries
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillSeries:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillSeries:member
     package: ExcelScript!
-    summary: Populates the adjacent cells with data that follows a pattern in the copied cells.
+    summary: >-
+      Populates the adjacent cells with data that follows a pattern in the
+      copied cells.
   - name: fillValues
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillValues:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillValues:member
     package: ExcelScript!
     summary: Populates the adjacent cells with the selected values.
   - name: fillWeekdays
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillWeekdays:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillWeekdays:member
     package: ExcelScript!
-    summary: A version of "FillSeries" for dates that bases the pattern on the day of the week and only includes weekdays.
+    summary: >-
+      A version of "FillSeries" for dates that bases the pattern on the day of
+      the week and only includes weekdays.
   - name: fillYears
-    uid: 'ExcelScript!ExcelScript.AutoFillType.fillYears:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.fillYears:member
     package: ExcelScript!
     summary: A version of "FillSeries" for dates that bases the pattern on the year.
   - name: flashFill
-    uid: 'ExcelScript!ExcelScript.AutoFillType.flashFill:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.flashFill:member
     package: ExcelScript!
     summary: Populates the adjacent cells by using Excel's Flash Fill feature.
   - name: growthTrend
-    uid: 'ExcelScript!ExcelScript.AutoFillType.growthTrend:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.growthTrend:member
     package: ExcelScript!
     summary: >-
-      A version of "FillSeries" for numbers that fills out the values in the adjacent cells according to a growth trend
-      model.
+      A version of "FillSeries" for numbers that fills out the values in the
+      adjacent cells according to a growth trend model.
   - name: linearTrend
-    uid: 'ExcelScript!ExcelScript.AutoFillType.linearTrend:member'
+    uid: ExcelScript!ExcelScript.AutoFillType.linearTrend:member
     package: ExcelScript!
     summary: >-
-      A version of "FillSeries" for numbers that fills out the values in the adjacent cells according to a linear trend
-      model.
+      A version of "FillSeries" for numbers that fills out the values in the
+      adjacent cells according to a linear trend model.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.autofilter.yml
@@ -1,11 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.AutoFilter
-uid: 'ExcelScript!ExcelScript.AutoFilter:interface'
+uid: ExcelScript!ExcelScript.AutoFilter:interface
 package: ExcelScript!
 fullName: ExcelScript.AutoFilter
 summary: >-
-  Represents the `AutoFilter` object. AutoFilter turns the values in Excel column into specific filters based on the
-  cell contents.
+  Represents the `AutoFilter` object. AutoFilter turns the values in Excel
+  column into specific filters based on the cell contents.
 remarks: |-
 
 
@@ -31,16 +31,20 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'apply(range, columnIndex, criteria)'
-    uid: 'ExcelScript!ExcelScript.AutoFilter#apply:member(1)'
+  - name: apply(range, columnIndex, criteria)
+    uid: ExcelScript!ExcelScript.AutoFilter#apply:member(1)
     package: ExcelScript!
-    fullName: 'apply(range, columnIndex, criteria)'
-    summary: Applies the AutoFilter to a range. This filters the column if column index and filter criteria are specified.
+    fullName: apply(range, columnIndex, criteria)
+    summary: >-
+      Applies the AutoFilter to a range. This filters the column if column index
+      and filter criteria are specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -53,13 +57,13 @@ methods:
       parameters:
         - id: range
           description: The range on which the AutoFilter will apply.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: columnIndex
           description: The zero-based column index to which the AutoFilter is applied.
           type: number
         - id: criteria
           description: The filter criteria.
-          type: '<xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />
       return:
         type: void
         description: |-
@@ -88,11 +92,12 @@ methods:
           }
           ```
   - name: clearColumnCriteria(columnIndex)
-    uid: 'ExcelScript!ExcelScript.AutoFilter#clearColumnCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#clearColumnCriteria:member(1)
     package: ExcelScript!
     fullName: clearColumnCriteria(columnIndex)
     summary: Clears the column filter criteria of the AutoFilter.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -100,19 +105,22 @@ methods:
       parameters:
         - id: columnIndex
           description: >-
-            The zero-based column index, which represents which column filter needs to be cleared. If the index value is
-            not supported (for example, if the value is a negative number, or if the value is greater than the number of
-            available columns in the range), then an `InvalidArgument` error will be thrown.
+            The zero-based column index, which represents which column filter
+            needs to be cleared. If the index value is not supported (for
+            example, if the value is a negative number, or if the value is
+            greater than the number of available columns in the range), then an
+            `InvalidArgument` error will be thrown.
           type: number
       return:
         type: void
         description: ''
   - name: clearCriteria()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#clearCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#clearCriteria:member(1)
     package: ExcelScript!
     fullName: clearCriteria()
     summary: Clears the filter criteria and sort state of the AutoFilter.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -136,24 +144,26 @@ methods:
           }
           ```
   - name: getCriteria()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#getCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#getCriteria:member(1)
     package: ExcelScript!
     fullName: getCriteria()
     summary: An array that holds all the filter criteria in the autofiltered range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCriteria(): FilterCriteria[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />[]
         description: ''
   - name: getEnabled()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#getEnabled:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#getEnabled:member(1)
     package: ExcelScript!
     fullName: getEnabled()
     summary: Specifies if the AutoFilter is enabled.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -162,11 +172,12 @@ methods:
         type: boolean
         description: ''
   - name: getIsDataFiltered()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#getIsDataFiltered:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#getIsDataFiltered:member(1)
     package: ExcelScript!
     fullName: getIsDataFiltered()
     summary: Specifies if the AutoFilter has filter criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -175,26 +186,29 @@ methods:
         type: boolean
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: >-
-      Returns the `Range` object that represents the range to which the AutoFilter applies. If there is no `Range`
-      object associated with the AutoFilter, then this method returns `undefined`<!-- -->.
+      Returns the `Range` object that represents the range to which the
+      AutoFilter applies. If there is no `Range` object associated with the
+      AutoFilter, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: reapply()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#reapply:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#reapply:member(1)
     package: ExcelScript!
     fullName: reapply()
     summary: Applies the specified AutoFilter object currently on the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -203,11 +217,12 @@ methods:
         type: void
         description: ''
   - name: remove()
-    uid: 'ExcelScript!ExcelScript.AutoFilter#remove:member(1)'
+    uid: ExcelScript!ExcelScript.AutoFilter#remove:member(1)
     package: ExcelScript!
     fullName: remove()
     summary: Removes the AutoFilter for the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.basicdatavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.basicdatavalidation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.BasicDataValidation
-uid: 'ExcelScript!ExcelScript.BasicDataValidation:interface'
+uid: ExcelScript!ExcelScript.BasicDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.BasicDataValidation
 summary: Represents the basic type data validation criteria.
@@ -43,55 +43,69 @@ remarks: |-
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: formula1
-    uid: 'ExcelScript!ExcelScript.BasicDataValidation#formula1:member'
+    uid: ExcelScript!ExcelScript.BasicDataValidation#formula1:member
     package: ExcelScript!
     fullName: formula1
     summary: >-
-      Specifies the right-hand operand when the operator property is set to a binary operator such as GreaterThan (the
-      left-hand operand is the value the user tries to enter in the cell). With the ternary operators Between and
-      NotBetween, specifies the lower bound operand. For example, setting formula1 to 10 and operator to GreaterThan
-      means that valid data for the range must be greater than 10. When setting the value, it can be passed in as a
-      number, a range object, or a string formula (where the string is either a stringified number, a cell reference
-      like "=A1", or a formula like "=MIN(A1, B1)"). When retrieving the value, it will always be returned as a string
-      formula, for example: "=10", "=A1", "=SUM(A1:B5)", etc.
+      Specifies the right-hand operand when the operator property is set to a
+      binary operator such as GreaterThan (the left-hand operand is the value
+      the user tries to enter in the cell). With the ternary operators Between
+      and NotBetween, specifies the lower bound operand. For example, setting
+      formula1 to 10 and operator to GreaterThan means that valid data for the
+      range must be greater than 10. When setting the value, it can be passed in
+      as a number, a range object, or a string formula (where the string is
+      either a stringified number, a cell reference like "=A1", or a formula
+      like "=MIN(A1, B1)"). When retrieving the value, it will always be
+      returned as a string formula, for example: "=10", "=A1", "=SUM(A1:B5)",
+      etc.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'formula1: string | number | Range;'
       return:
-        type: 'string | number | <xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: >-
+          string | number | <xref uid="ExcelScript!ExcelScript.Range:interface"
+          />
   - name: formula2
-    uid: 'ExcelScript!ExcelScript.BasicDataValidation#formula2:member'
+    uid: ExcelScript!ExcelScript.BasicDataValidation#formula2:member
     package: ExcelScript!
     fullName: formula2
     summary: >-
-      With the ternary operators Between and NotBetween, specifies the upper bound operand. Is not used with the binary
-      operators, such as GreaterThan. When setting the value, it can be passed in as a number, a range object, or a
-      string formula (where the string is either a stringified number, a cell reference like "=A1", or a formula like
-      "=MIN(A1, B1)"). When retrieving the value, it will always be returned as a string formula, for example: "=10",
-      "=A1", "=SUM(A1:B5)", etc.
+      With the ternary operators Between and NotBetween, specifies the upper
+      bound operand. Is not used with the binary operators, such as GreaterThan.
+      When setting the value, it can be passed in as a number, a range object,
+      or a string formula (where the string is either a stringified number, a
+      cell reference like "=A1", or a formula like "=MIN(A1, B1)"). When
+      retrieving the value, it will always be returned as a string formula, for
+      example: "=10", "=A1", "=SUM(A1:B5)", etc.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'formula2?: string | number | Range;'
       return:
-        type: 'string | number | <xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: >-
+          string | number | <xref uid="ExcelScript!ExcelScript.Range:interface"
+          />
   - name: operator
-    uid: 'ExcelScript!ExcelScript.BasicDataValidation#operator:member'
+    uid: ExcelScript!ExcelScript.BasicDataValidation#operator:member
     package: ExcelScript!
     fullName: operator
     summary: The operator to use for validating the data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator: DataValidationOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationOperator:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationOperator:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.binding.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.binding.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.Binding
-uid: 'ExcelScript!ExcelScript.Binding:interface'
+uid: ExcelScript!ExcelScript.Binding:interface
 package: ExcelScript!
 fullName: ExcelScript.Binding
 summary: Represents an Office.js binding that is defined in the workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Binding#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the binding.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Binding#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Represents the binding identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,37 +39,46 @@ methods:
         type: string
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.Binding#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
-    summary: Returns the range represented by the binding. Will throw an error if the binding is not of the correct type.
+    summary: >-
+      Returns the range represented by the binding. Will throw an error if the
+      binding is not of the correct type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getTable()
-    uid: 'ExcelScript!ExcelScript.Binding#getTable:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#getTable:member(1)
     package: ExcelScript!
     fullName: getTable()
-    summary: Returns the table represented by the binding. Will throw an error if the binding is not of the correct type.
+    summary: >-
+      Returns the table represented by the binding. Will throw an error if the
+      binding is not of the correct type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTable(): Table;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.Binding#getText:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#getText:member(1)
     package: ExcelScript!
     fullName: getText()
-    summary: Returns the text represented by the binding. Will throw an error if the binding is not of the correct type.
+    summary: >-
+      Returns the text represented by the binding. Will throw an error if the
+      binding is not of the correct type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,15 +87,18 @@ methods:
         type: string
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.Binding#getType:member(1)'
+    uid: ExcelScript!ExcelScript.Binding#getType:member(1)
     package: ExcelScript!
     fullName: getType()
-    summary: Returns the type of the binding. See `ExcelScript.BindingType` for details.
+    summary: >-
+      Returns the type of the binding. See `ExcelScript.BindingType` for
+      details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): BindingType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BindingType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.BindingType:enum" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.bindingtype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.bindingtype.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.BindingType
-uid: 'ExcelScript!ExcelScript.BindingType:enum'
+uid: ExcelScript!ExcelScript.BindingType:enum
 package: ExcelScript!
 fullName: ExcelScript.BindingType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: range
-    uid: 'ExcelScript!ExcelScript.BindingType.range:member'
+    uid: ExcelScript!ExcelScript.BindingType.range:member
     package: ExcelScript!
     summary: ''
   - name: table
-    uid: 'ExcelScript!ExcelScript.BindingType.table:member'
+    uid: ExcelScript!ExcelScript.BindingType.table:member
     package: ExcelScript!
     summary: ''
   - name: text
-    uid: 'ExcelScript!ExcelScript.BindingType.text:member'
+    uid: ExcelScript!ExcelScript.BindingType.text:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.borderindex.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.borderindex.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.BorderIndex
-uid: 'ExcelScript!ExcelScript.BorderIndex:enum'
+uid: ExcelScript!ExcelScript.BorderIndex:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderIndex
 summary: ''
@@ -37,38 +37,39 @@ remarks: |-
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: diagonalDown
-    uid: 'ExcelScript!ExcelScript.BorderIndex.diagonalDown:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.diagonalDown:member
     package: ExcelScript!
     summary: ''
   - name: diagonalUp
-    uid: 'ExcelScript!ExcelScript.BorderIndex.diagonalUp:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.diagonalUp:member
     package: ExcelScript!
     summary: ''
   - name: edgeBottom
-    uid: 'ExcelScript!ExcelScript.BorderIndex.edgeBottom:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.edgeBottom:member
     package: ExcelScript!
     summary: ''
   - name: edgeLeft
-    uid: 'ExcelScript!ExcelScript.BorderIndex.edgeLeft:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.edgeLeft:member
     package: ExcelScript!
     summary: ''
   - name: edgeRight
-    uid: 'ExcelScript!ExcelScript.BorderIndex.edgeRight:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.edgeRight:member
     package: ExcelScript!
     summary: ''
   - name: edgeTop
-    uid: 'ExcelScript!ExcelScript.BorderIndex.edgeTop:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.edgeTop:member
     package: ExcelScript!
     summary: ''
   - name: insideHorizontal
-    uid: 'ExcelScript!ExcelScript.BorderIndex.insideHorizontal:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.insideHorizontal:member
     package: ExcelScript!
     summary: ''
   - name: insideVertical
-    uid: 'ExcelScript!ExcelScript.BorderIndex.insideVertical:member'
+    uid: ExcelScript!ExcelScript.BorderIndex.insideVertical:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.borderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.borderlinestyle.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.BorderLineStyle
-uid: 'ExcelScript!ExcelScript.BorderLineStyle:enum'
+uid: ExcelScript!ExcelScript.BorderLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderLineStyle
 summary: ''
@@ -37,38 +37,39 @@ remarks: |-
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: continuous
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.continuous:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.continuous:member
     package: ExcelScript!
     summary: ''
   - name: dash
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.dash:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: dashDot
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.dashDot:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.dashDot:member
     package: ExcelScript!
     summary: ''
   - name: dashDotDot
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.dashDotDot:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.dashDotDot:member
     package: ExcelScript!
     summary: ''
   - name: dot
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.dot:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.dot:member
     package: ExcelScript!
     summary: ''
   - name: double
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.double:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.double:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.none:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: slantDashDot
-    uid: 'ExcelScript!ExcelScript.BorderLineStyle.slantDashDot:member'
+    uid: ExcelScript!ExcelScript.BorderLineStyle.slantDashDot:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.borderweight.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.borderweight.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.BorderWeight
-uid: 'ExcelScript!ExcelScript.BorderWeight:enum'
+uid: ExcelScript!ExcelScript.BorderWeight:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderWeight
 summary: ''
@@ -37,22 +37,23 @@ remarks: |-
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: hairline
-    uid: 'ExcelScript!ExcelScript.BorderWeight.hairline:member'
+    uid: ExcelScript!ExcelScript.BorderWeight.hairline:member
     package: ExcelScript!
     summary: ''
   - name: medium
-    uid: 'ExcelScript!ExcelScript.BorderWeight.medium:member'
+    uid: ExcelScript!ExcelScript.BorderWeight.medium:member
     package: ExcelScript!
     summary: ''
   - name: thick
-    uid: 'ExcelScript!ExcelScript.BorderWeight.thick:member'
+    uid: ExcelScript!ExcelScript.BorderWeight.thick:member
     package: ExcelScript!
     summary: ''
   - name: thin
-    uid: 'ExcelScript!ExcelScript.BorderWeight.thin:member'
+    uid: ExcelScript!ExcelScript.BorderWeight.thin:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.builtinstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.builtinstyle.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.BuiltInStyle
-uid: 'ExcelScript!ExcelScript.BuiltInStyle:enum'
+uid: ExcelScript!ExcelScript.BuiltInStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.BuiltInStyle
 summary: ''
@@ -36,214 +36,215 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: accent1
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent1:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent1:member
     package: ExcelScript!
     summary: ''
   - name: accent1_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent1_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent1_20:member
     package: ExcelScript!
     summary: ''
   - name: accent1_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent1_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent1_40:member
     package: ExcelScript!
     summary: ''
   - name: accent1_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent1_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent1_60:member
     package: ExcelScript!
     summary: ''
   - name: accent2
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent2:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent2:member
     package: ExcelScript!
     summary: ''
   - name: accent2_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent2_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent2_20:member
     package: ExcelScript!
     summary: ''
   - name: accent2_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent2_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent2_40:member
     package: ExcelScript!
     summary: ''
   - name: accent2_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent2_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent2_60:member
     package: ExcelScript!
     summary: ''
   - name: accent3
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent3:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent3:member
     package: ExcelScript!
     summary: ''
   - name: accent3_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent3_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent3_20:member
     package: ExcelScript!
     summary: ''
   - name: accent3_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent3_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent3_40:member
     package: ExcelScript!
     summary: ''
   - name: accent3_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent3_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent3_60:member
     package: ExcelScript!
     summary: ''
   - name: accent4
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent4:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent4:member
     package: ExcelScript!
     summary: ''
   - name: accent4_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent4_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent4_20:member
     package: ExcelScript!
     summary: ''
   - name: accent4_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent4_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent4_40:member
     package: ExcelScript!
     summary: ''
   - name: accent4_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent4_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent4_60:member
     package: ExcelScript!
     summary: ''
   - name: accent5
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent5:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent5:member
     package: ExcelScript!
     summary: ''
   - name: accent5_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent5_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent5_20:member
     package: ExcelScript!
     summary: ''
   - name: accent5_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent5_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent5_40:member
     package: ExcelScript!
     summary: ''
   - name: accent5_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent5_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent5_60:member
     package: ExcelScript!
     summary: ''
   - name: accent6
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent6:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent6:member
     package: ExcelScript!
     summary: ''
   - name: accent6_20
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent6_20:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent6_20:member
     package: ExcelScript!
     summary: ''
   - name: accent6_40
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent6_40:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent6_40:member
     package: ExcelScript!
     summary: ''
   - name: accent6_60
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.accent6_60:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.accent6_60:member
     package: ExcelScript!
     summary: ''
   - name: bad
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.bad:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.bad:member
     package: ExcelScript!
     summary: ''
   - name: calculation
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.calculation:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.calculation:member
     package: ExcelScript!
     summary: ''
   - name: checkCell
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.checkCell:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.checkCell:member
     package: ExcelScript!
     summary: ''
   - name: comma
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.comma:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.comma:member
     package: ExcelScript!
     summary: ''
   - name: currency
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.currency:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.currency:member
     package: ExcelScript!
     summary: ''
   - name: emphasis1
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.emphasis1:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.emphasis1:member
     package: ExcelScript!
     summary: ''
   - name: emphasis2
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.emphasis2:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.emphasis2:member
     package: ExcelScript!
     summary: ''
   - name: emphasis3
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.emphasis3:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.emphasis3:member
     package: ExcelScript!
     summary: ''
   - name: explanatoryText
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.explanatoryText:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.explanatoryText:member
     package: ExcelScript!
     summary: ''
   - name: good
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.good:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.good:member
     package: ExcelScript!
     summary: ''
   - name: heading1
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.heading1:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.heading1:member
     package: ExcelScript!
     summary: ''
   - name: heading2
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.heading2:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.heading2:member
     package: ExcelScript!
     summary: ''
   - name: heading3
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.heading3:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.heading3:member
     package: ExcelScript!
     summary: ''
   - name: heading4
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.heading4:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.heading4:member
     package: ExcelScript!
     summary: ''
   - name: hlink
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.hlink:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.hlink:member
     package: ExcelScript!
     summary: ''
   - name: hlinkTrav
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.hlinkTrav:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.hlinkTrav:member
     package: ExcelScript!
     summary: ''
   - name: input
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.input:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.input:member
     package: ExcelScript!
     summary: ''
   - name: linkedCell
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.linkedCell:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.linkedCell:member
     package: ExcelScript!
     summary: ''
   - name: neutral
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.neutral:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.neutral:member
     package: ExcelScript!
     summary: ''
   - name: normal
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.normal:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.normal:member
     package: ExcelScript!
     summary: ''
   - name: note
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.note:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.note:member
     package: ExcelScript!
     summary: ''
   - name: output
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.output:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.output:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.percent:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.percent:member
     package: ExcelScript!
     summary: ''
   - name: sheetTitle
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.sheetTitle:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.sheetTitle:member
     package: ExcelScript!
     summary: ''
   - name: total
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.total:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.total:member
     package: ExcelScript!
     summary: ''
   - name: warningText
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.warningText:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.warningText:member
     package: ExcelScript!
     summary: ''
   - name: wholeComma
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.wholeComma:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.wholeComma:member
     package: ExcelScript!
     summary: ''
   - name: wholeDollar
-    uid: 'ExcelScript!ExcelScript.BuiltInStyle.wholeDollar:member'
+    uid: ExcelScript!ExcelScript.BuiltInStyle.wholeDollar:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationmode.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationmode.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.CalculationMode
-uid: 'ExcelScript!ExcelScript.CalculationMode:enum'
+uid: ExcelScript!ExcelScript.CalculationMode:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationMode
 summary: ''
@@ -26,20 +26,23 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.CalculationMode.automatic:member'
+    uid: ExcelScript!ExcelScript.CalculationMode.automatic:member
     package: ExcelScript!
     summary: >-
-      The default recalculation behavior where Excel calculates new formula results every time the relevant data is
-      changed.
+      The default recalculation behavior where Excel calculates new formula
+      results every time the relevant data is changed.
   - name: automaticExceptTables
-    uid: 'ExcelScript!ExcelScript.CalculationMode.automaticExceptTables:member'
+    uid: ExcelScript!ExcelScript.CalculationMode.automaticExceptTables:member
     package: ExcelScript!
-    summary: 'Calculates new formula results every time the relevant data is changed, unless the formula is in a data table.'
+    summary: >-
+      Calculates new formula results every time the relevant data is changed,
+      unless the formula is in a data table.
   - name: manual
-    uid: 'ExcelScript!ExcelScript.CalculationMode.manual:member'
+    uid: ExcelScript!ExcelScript.CalculationMode.manual:member
     package: ExcelScript!
     summary: Calculations only occur when the user or add-in requests them.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationstate.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationstate.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.CalculationState
-uid: 'ExcelScript!ExcelScript.CalculationState:enum'
+uid: ExcelScript!ExcelScript.CalculationState:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationState
 summary: Represents the state of calculation across the entire Excel application.
@@ -36,18 +36,21 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: calculating
-    uid: 'ExcelScript!ExcelScript.CalculationState.calculating:member'
+    uid: ExcelScript!ExcelScript.CalculationState.calculating:member
     package: ExcelScript!
     summary: Calculations in progress.
   - name: done
-    uid: 'ExcelScript!ExcelScript.CalculationState.done:member'
+    uid: ExcelScript!ExcelScript.CalculationState.done:member
     package: ExcelScript!
     summary: Calculations complete.
   - name: pending
-    uid: 'ExcelScript!ExcelScript.CalculationState.pending:member'
+    uid: ExcelScript!ExcelScript.CalculationState.pending:member
     package: ExcelScript!
-    summary: 'Changes that trigger calculation have been made, but a recalculation has not yet been performed.'
+    summary: >-
+      Changes that trigger calculation have been made, but a recalculation has
+      not yet been performed.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationtype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.calculationtype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.CalculationType
-uid: 'ExcelScript!ExcelScript.CalculationType:enum'
+uid: ExcelScript!ExcelScript.CalculationType:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationType
 summary: ''
@@ -20,20 +20,23 @@ remarks: |-
     application.calculate(ExcelScript.CalculationType.fullRebuild);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: full
-    uid: 'ExcelScript!ExcelScript.CalculationType.full:member'
+    uid: ExcelScript!ExcelScript.CalculationType.full:member
     package: ExcelScript!
     summary: This will mark all cells as dirty and then recalculate them.
   - name: fullRebuild
-    uid: 'ExcelScript!ExcelScript.CalculationType.fullRebuild:member'
-    package: ExcelScript!
-    summary: 'This will rebuild the full dependency chain, mark all cells as dirty and then recalculate them.'
-  - name: recalculate
-    uid: 'ExcelScript!ExcelScript.CalculationType.recalculate:member'
+    uid: ExcelScript!ExcelScript.CalculationType.fullRebuild:member
     package: ExcelScript!
     summary: >-
-      Recalculates all cells that Excel has marked as dirty, that is, dependents of volatile or changed data, and cells
-      programmatically marked as dirty.
+      This will rebuild the full dependency chain, mark all cells as dirty and
+      then recalculate them.
+  - name: recalculate
+    uid: ExcelScript!ExcelScript.CalculationType.recalculate:member
+    package: ExcelScript!
+    summary: >-
+      Recalculates all cells that Excel has marked as dirty, that is, dependents
+      of volatile or changed data, and cells programmatically marked as dirty.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.cellcontrol.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.cellcontrol.yml
@@ -1,10 +1,11 @@
 ### YamlMime:TSTypeAlias
 name: ExcelScript.CellControl
-uid: 'ExcelScript!ExcelScript.CellControl:type'
+uid: ExcelScript!ExcelScript.CellControl:type
 package: ExcelScript!
 fullName: ExcelScript.CellControl
 summary: Represents an interactable control inside of a cell.
-remarks: ''
+remarks: "\r\n\r\nLearn more about the types in this type alias through the following links. \r\n\r\n[ExcelScript.UnknownCellControl](/javascript/api/office-scripts/excelscript/excelscript.unknowncellcontrol), [ExcelScript.EmptyCellControl](/javascript/api/office-scripts/excelscript/excelscript.emptycellcontrol), [ExcelScript.MixedCellControl](/javascript/api/office-scripts/excelscript/excelscript.mixedcellcontrol), [ExcelScript.CheckboxCellControl](/javascript/api/office-scripts/excelscript/excelscript.checkboxcellcontrol)"
+
 isPreview: false
 isDeprecated: false
 syntax: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.cellcontroltype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.cellcontroltype.yml
@@ -1,28 +1,30 @@
 ### YamlMime:TSEnum
 name: ExcelScript.CellControlType
-uid: 'ExcelScript!ExcelScript.CellControlType:enum'
+uid: ExcelScript!ExcelScript.CellControlType:enum
 package: ExcelScript!
 fullName: ExcelScript.CellControlType
 summary: Represents the type of cell control.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: checkbox
-    uid: 'ExcelScript!ExcelScript.CellControlType.checkbox:member'
+    uid: ExcelScript!ExcelScript.CellControlType.checkbox:member
     package: ExcelScript!
     summary: Type representing a checkbox control.
   - name: empty
-    uid: 'ExcelScript!ExcelScript.CellControlType.empty:member'
+    uid: ExcelScript!ExcelScript.CellControlType.empty:member
     package: ExcelScript!
     summary: Type representing an empty control.
   - name: mixed
-    uid: 'ExcelScript!ExcelScript.CellControlType.mixed:member'
+    uid: ExcelScript!ExcelScript.CellControlType.mixed:member
     package: ExcelScript!
     summary: Type representing a query that results in a mix of control results.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.CellControlType.unknown:member'
+    uid: ExcelScript!ExcelScript.CellControlType.unknown:member
     package: ExcelScript!
     summary: >-
-      Type representing an unknown control. This represents a control that was added in a future version of Excel, and
-      the current version of Excel doesn't know how to display this control.
+      Type representing an unknown control. This represents a control that was
+      added in a future version of Excel, and the current version of Excel
+      doesn't know how to display this control.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.cellvalueconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.CellValueConditionalFormat
-uid: 'ExcelScript!ExcelScript.CellValueConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.CellValueConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.CellValueConditionalFormat
 summary: Represents a cell value conditional format.
@@ -38,42 +38,52 @@ remarks: |-
     format.getFont().setItalic(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.CellValueConditionalFormat#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.CellValueConditionalFormat#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the conditional formats font, fill, borders, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the conditional formats font, fill,
+      borders, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ConditionalRangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface"
+          />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.CellValueConditionalFormat#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.CellValueConditionalFormat#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
     summary: Specifies the rule object on this conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): ConditionalCellValueRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface"
+          />
         description: ''
   - name: setRule(rule)
-    uid: 'ExcelScript!ExcelScript.CellValueConditionalFormat#setRule:member(1)'
+    uid: ExcelScript!ExcelScript.CellValueConditionalFormat#setRule:member(1)
     package: ExcelScript!
     fullName: setRule(rule)
     summary: Specifies the rule object on this conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -81,7 +91,9 @@ methods:
       parameters:
         - id: rule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chart.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chart.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.Chart
-uid: 'ExcelScript!ExcelScript.Chart:interface'
+uid: ExcelScript!ExcelScript.Chart:interface
 package: ExcelScript!
 fullName: ExcelScript.Chart
 summary: Represents a chart object in a workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: activate()
-    uid: 'ExcelScript!ExcelScript.Chart#activate:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#activate:member(1)
     package: ExcelScript!
     fullName: activate()
     summary: Activates the chart in the Excel UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,14 +24,16 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'addChartSeries(name, index)'
-    uid: 'ExcelScript!ExcelScript.Chart#addChartSeries:member(1)'
+  - name: addChartSeries(name, index)
+    uid: ExcelScript!ExcelScript.Chart#addChartSeries:member(1)
     package: ExcelScript!
-    fullName: 'addChartSeries(name, index)'
+    fullName: addChartSeries(name, index)
     summary: >-
-      Add a new series to the collection. The new added series is not visible until values, x-axis values, or bubble
-      sizes for it are set (depending on chart type).
+      Add a new series to the collection. The new added series is not visible
+      until values, x-axis values, or bubble sizes for it are set (depending on
+      chart type).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,7 +46,7 @@ methods:
           description: Optional. Index value of the series to be added. Zero-indexed.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartSeries:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartSeries:interface" />
         description: |-
 
 
@@ -78,11 +82,12 @@ methods:
           }
           ```
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Chart#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,24 +96,28 @@ methods:
         type: void
         description: ''
   - name: getAxes()
-    uid: 'ExcelScript!ExcelScript.Chart#getAxes:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getAxes:member(1)
     package: ExcelScript!
     fullName: getAxes()
     summary: Represents chart axes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAxes(): ChartAxes;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxes:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxes:interface" />
         description: ''
   - name: getCategoryLabelLevel()
-    uid: 'ExcelScript!ExcelScript.Chart#getCategoryLabelLevel:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getCategoryLabelLevel:member(1)
     package: ExcelScript!
     fullName: getCategoryLabelLevel()
-    summary: 'Specifies a chart category label level enumeration constant, referring to the level of the source category labels.'
+    summary: >-
+      Specifies a chart category label level enumeration constant, referring to
+      the level of the source category labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -117,78 +126,84 @@ methods:
         type: number
         description: ''
   - name: getChartType()
-    uid: 'ExcelScript!ExcelScript.Chart#getChartType:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getChartType:member(1)
     package: ExcelScript!
     fullName: getChartType()
     summary: Specifies the type of the chart. See `ExcelScript.ChartType` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getChartType(): ChartType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartType:enum" />
         description: ''
   - name: getDataLabels()
-    uid: 'ExcelScript!ExcelScript.Chart#getDataLabels:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getDataLabels:member(1)
     package: ExcelScript!
     fullName: getDataLabels()
     summary: Represents the data labels on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataLabels(): ChartDataLabels;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabels:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabels:interface" />
         description: ''
   - name: getDataTable()
-    uid: 'ExcelScript!ExcelScript.Chart#getDataTable:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getDataTable:member(1)
     package: ExcelScript!
     fullName: getDataTable()
     summary: >-
-      Gets the data table on the chart. If the chart doesn't allow a data table, then this method returns
-      `undefined`<!-- -->.
+      Gets the data table on the chart. If the chart doesn't allow a data table,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataTable(): ChartDataTable;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataTable:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataTable:interface" />
         description: ''
   - name: getDisplayBlanksAs()
-    uid: 'ExcelScript!ExcelScript.Chart#getDisplayBlanksAs:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getDisplayBlanksAs:member(1)
     package: ExcelScript!
     fullName: getDisplayBlanksAs()
     summary: Specifies the way that blank cells are plotted on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDisplayBlanksAs(): ChartDisplayBlanksAs;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum" />
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.Chart#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Encapsulates the format properties for the chart area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartAreaFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAreaFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAreaFormat:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.Chart#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Specifies the height, in points, of the chart object.'
+    summary: Specifies the height, in points, of the chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,11 +212,12 @@ methods:
         type: number
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Chart#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: The unique ID of chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -209,14 +225,16 @@ methods:
       return:
         type: string
         description: ''
-  - name: 'getImage(width, height, fittingMode)'
-    uid: 'ExcelScript!ExcelScript.Chart#getImage:member(1)'
+  - name: getImage(width, height, fittingMode)
+    uid: ExcelScript!ExcelScript.Chart#getImage:member(1)
     package: ExcelScript!
-    fullName: 'getImage(width, height, fittingMode)'
+    fullName: getImage(width, height, fittingMode)
     summary: >-
-      Renders the chart as a Base64-encoded image by scaling the chart to fit the specified dimensions. The aspect ratio
-      is preserved as part of the resizing.
+      Renders the chart as a Base64-encoded image by scaling the chart to fit
+      the specified dimensions. The aspect ratio is preserved as part of the
+      resizing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -234,8 +252,10 @@ methods:
           description: Optional. The desired height of the resulting image.
           type: number
         - id: fittingMode
-          description: Optional. The method used to scale the chart to the specified dimensions (if both height and width are set).
-          type: '<xref uid="ExcelScript!ExcelScript.ImageFittingMode:enum" />'
+          description: >-
+            Optional. The method used to scale the chart to the specified
+            dimensions (if both height and width are set).
+          type: <xref uid="ExcelScript!ExcelScript.ImageFittingMode:enum" />
       return:
         type: string
         description: |-
@@ -266,11 +286,14 @@ methods:
           }
           ```
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.Chart#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
-    summary: 'The distance, in points, from the left side of the chart to the worksheet origin.'
+    summary: >-
+      The distance, in points, from the left side of the chart to the worksheet
+      origin.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -279,24 +302,26 @@ methods:
         type: number
         description: ''
   - name: getLegend()
-    uid: 'ExcelScript!ExcelScript.Chart#getLegend:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getLegend:member(1)
     package: ExcelScript!
     fullName: getLegend()
     summary: Represents the legend for the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLegend(): ChartLegend;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLegend:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLegend:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Chart#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of a chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -305,43 +330,46 @@ methods:
         type: string
         description: ''
   - name: getPivotOptions()
-    uid: 'ExcelScript!ExcelScript.Chart#getPivotOptions:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getPivotOptions:member(1)
     package: ExcelScript!
     fullName: getPivotOptions()
     summary: Encapsulates the options for a pivot chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPivotOptions(): ChartPivotOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPivotOptions:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPivotOptions:interface" />
         description: ''
   - name: getPlotArea()
-    uid: 'ExcelScript!ExcelScript.Chart#getPlotArea:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getPlotArea:member(1)
     package: ExcelScript!
     fullName: getPlotArea()
     summary: Represents the plot area for the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPlotArea(): ChartPlotArea;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPlotArea:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPlotArea:interface" />
         description: ''
   - name: getPlotBy()
-    uid: 'ExcelScript!ExcelScript.Chart#getPlotBy:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getPlotBy:member(1)
     package: ExcelScript!
     fullName: getPlotBy()
     summary: Specifies the way columns or rows are used as data series on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPlotBy(): ChartPlotBy;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPlotBy:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPlotBy:enum" />
         description: |-
 
 
@@ -369,11 +397,14 @@ methods:
           }
           ```
   - name: getPlotVisibleOnly()
-    uid: 'ExcelScript!ExcelScript.Chart#getPlotVisibleOnly:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getPlotVisibleOnly:member(1)
     package: ExcelScript!
     fullName: getPlotVisibleOnly()
-    summary: True if only visible cells are plotted. False if both visible and hidden cells are plotted.
+    summary: >-
+      True if only visible cells are plotted. False if both visible and hidden
+      cells are plotted.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -382,17 +413,18 @@ methods:
         type: boolean
         description: ''
   - name: getSeries()
-    uid: 'ExcelScript!ExcelScript.Chart#getSeries:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getSeries:member(1)
     package: ExcelScript!
     fullName: getSeries()
     summary: Represents either a single series or collection of series in the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSeries(): ChartSeries[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartSeries:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ChartSeries:interface" />[]
         description: |-
 
 
@@ -418,11 +450,14 @@ methods:
           }
           ```
   - name: getSeriesNameLevel()
-    uid: 'ExcelScript!ExcelScript.Chart#getSeriesNameLevel:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getSeriesNameLevel:member(1)
     package: ExcelScript!
     fullName: getSeriesNameLevel()
-    summary: 'Specifies a chart series name level enumeration constant, referring to the level of the source series names.'
+    summary: >-
+      Specifies a chart series name level enumeration constant, referring to the
+      level of the source series names.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -431,11 +466,12 @@ methods:
         type: number
         description: ''
   - name: getShowAllFieldButtons()
-    uid: 'ExcelScript!ExcelScript.Chart#getShowAllFieldButtons:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getShowAllFieldButtons:member(1)
     package: ExcelScript!
     fullName: getShowAllFieldButtons()
     summary: Specifies whether to display all field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -444,14 +480,16 @@ methods:
         type: boolean
         description: ''
   - name: getShowDataLabelsOverMaximum()
-    uid: 'ExcelScript!ExcelScript.Chart#getShowDataLabelsOverMaximum:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getShowDataLabelsOverMaximum:member(1)
     package: ExcelScript!
     fullName: getShowDataLabelsOverMaximum()
     summary: >-
-      Specifies whether to show the data labels when the value is greater than the maximum value on the value axis. If
-      the value axis becomes smaller than the size of the data points, you can use this property to set whether to show
-      the data labels. This property applies to 2-D charts only.
+      Specifies whether to show the data labels when the value is greater than
+      the maximum value on the value axis. If the value axis becomes smaller
+      than the size of the data points, you can use this property to set whether
+      to show the data labels. This property applies to 2-D charts only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -460,11 +498,12 @@ methods:
         type: boolean
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.Chart#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
     summary: Specifies the chart style for the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -473,28 +512,30 @@ methods:
         type: number
         description: ''
   - name: getTitle()
-    uid: 'ExcelScript!ExcelScript.Chart#getTitle:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getTitle:member(1)
     package: ExcelScript!
     fullName: getTitle()
     summary: >-
-      Represents the title of the specified chart, including the text, visibility, position, and formatting of the
-      title.
+      Represents the title of the specified chart, including the text,
+      visibility, position, and formatting of the title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTitle(): ChartTitle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTitle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTitle:interface" />
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.Chart#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Specifies the distance, in points, from the top edge of the object to the top of row 1 (on a worksheet) or the top
-      of the chart area (on a chart).
+      Specifies the distance, in points, from the top edge of the object to the
+      top of row 1 (on a worksheet) or the top of the chart area (on a chart).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -503,11 +544,12 @@ methods:
         type: number
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.Chart#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Specifies the width, in points, of the chart object.'
+    summary: Specifies the width, in points, of the chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -516,24 +558,28 @@ methods:
         type: number
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.Chart#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: The worksheet containing the current chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: setCategoryLabelLevel(categoryLabelLevel)
-    uid: 'ExcelScript!ExcelScript.Chart#setCategoryLabelLevel:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setCategoryLabelLevel:member(1)
     package: ExcelScript!
     fullName: setCategoryLabelLevel(categoryLabelLevel)
-    summary: 'Specifies a chart category label level enumeration constant, referring to the level of the source category labels.'
+    summary: >-
+      Specifies a chart category label level enumeration constant, referring to
+      the level of the source category labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -546,11 +592,12 @@ methods:
         type: void
         description: ''
   - name: setChartType(chartType)
-    uid: 'ExcelScript!ExcelScript.Chart#setChartType:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setChartType:member(1)
     package: ExcelScript!
     fullName: setChartType(chartType)
     summary: Specifies the type of the chart. See `ExcelScript.ChartType` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -558,16 +605,17 @@ methods:
       parameters:
         - id: chartType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartType:enum" />
       return:
         type: void
         description: ''
-  - name: 'setData(sourceData, seriesBy)'
-    uid: 'ExcelScript!ExcelScript.Chart#setData:member(1)'
+  - name: setData(sourceData, seriesBy)
+    uid: ExcelScript!ExcelScript.Chart#setData:member(1)
     package: ExcelScript!
-    fullName: 'setData(sourceData, seriesBy)'
+    fullName: setData(sourceData, seriesBy)
     summary: Resets the source data for the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -575,21 +623,23 @@ methods:
       parameters:
         - id: sourceData
           description: The range object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         - id: seriesBy
           description: >-
-            Specifies the way columns or rows are used as data series on the chart. Can be one of the following: Auto
-            (default), Rows, and Columns. See `ExcelScript.ChartSeriesBy` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesBy:enum" />'
+            Specifies the way columns or rows are used as data series on the
+            chart. Can be one of the following: Auto (default), Rows, and
+            Columns. See `ExcelScript.ChartSeriesBy` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartSeriesBy:enum" />
       return:
         type: void
         description: ''
   - name: setDisplayBlanksAs(displayBlanksAs)
-    uid: 'ExcelScript!ExcelScript.Chart#setDisplayBlanksAs:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setDisplayBlanksAs:member(1)
     package: ExcelScript!
     fullName: setDisplayBlanksAs(displayBlanksAs)
     summary: Specifies the way that blank cells are plotted on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -597,16 +647,17 @@ methods:
       parameters:
         - id: displayBlanksAs
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum" />
       return:
         type: void
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.Chart#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
-    summary: 'Specifies the height, in points, of the chart object.'
+    summary: Specifies the height, in points, of the chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -619,11 +670,14 @@ methods:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.Chart#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
-    summary: 'The distance, in points, from the left side of the chart to the worksheet origin.'
+    summary: >-
+      The distance, in points, from the left side of the chart to the worksheet
+      origin.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -636,11 +690,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.Chart#setName:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of a chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -675,11 +730,12 @@ methods:
           }
           ```
   - name: setPlotBy(plotBy)
-    uid: 'ExcelScript!ExcelScript.Chart#setPlotBy:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setPlotBy:member(1)
     package: ExcelScript!
     fullName: setPlotBy(plotBy)
     summary: Specifies the way columns or rows are used as data series on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -687,7 +743,7 @@ methods:
       parameters:
         - id: plotBy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartPlotBy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartPlotBy:enum" />
       return:
         type: void
         description: |-
@@ -717,11 +773,14 @@ methods:
           }
           ```
   - name: setPlotVisibleOnly(plotVisibleOnly)
-    uid: 'ExcelScript!ExcelScript.Chart#setPlotVisibleOnly:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setPlotVisibleOnly:member(1)
     package: ExcelScript!
     fullName: setPlotVisibleOnly(plotVisibleOnly)
-    summary: True if only visible cells are plotted. False if both visible and hidden cells are plotted.
+    summary: >-
+      True if only visible cells are plotted. False if both visible and hidden
+      cells are plotted.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -733,12 +792,13 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'setPosition(startCell, endCell)'
-    uid: 'ExcelScript!ExcelScript.Chart#setPosition:member(1)'
+  - name: setPosition(startCell, endCell)
+    uid: ExcelScript!ExcelScript.Chart#setPosition:member(1)
     package: ExcelScript!
-    fullName: 'setPosition(startCell, endCell)'
+    fullName: setPosition(startCell, endCell)
     summary: Positions the chart relative to cells on the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -746,14 +806,15 @@ methods:
       parameters:
         - id: startCell
           description: >-
-            The start cell. This is where the chart will be moved to. The start cell is the top-left or top-right cell,
-            depending on the user's right-to-left display settings.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The start cell. This is where the chart will be moved to. The start
+            cell is the top-left or top-right cell, depending on the user's
+            right-to-left display settings.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: endCell
           description: >-
-            Optional. The end cell. If specified, the chart's width and height will be set to fully cover up this
-            cell/range.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            Optional. The end cell. If specified, the chart's width and height
+            will be set to fully cover up this cell/range.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: |-
@@ -777,11 +838,14 @@ methods:
           }
           ```
   - name: setSeriesNameLevel(seriesNameLevel)
-    uid: 'ExcelScript!ExcelScript.Chart#setSeriesNameLevel:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setSeriesNameLevel:member(1)
     package: ExcelScript!
     fullName: setSeriesNameLevel(seriesNameLevel)
-    summary: 'Specifies a chart series name level enumeration constant, referring to the level of the source series names.'
+    summary: >-
+      Specifies a chart series name level enumeration constant, referring to the
+      level of the source series names.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -794,11 +858,12 @@ methods:
         type: void
         description: ''
   - name: setShowAllFieldButtons(showAllFieldButtons)
-    uid: 'ExcelScript!ExcelScript.Chart#setShowAllFieldButtons:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setShowAllFieldButtons:member(1)
     package: ExcelScript!
     fullName: setShowAllFieldButtons(showAllFieldButtons)
     summary: Specifies whether to display all field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -811,14 +876,16 @@ methods:
         type: void
         description: ''
   - name: setShowDataLabelsOverMaximum(showDataLabelsOverMaximum)
-    uid: 'ExcelScript!ExcelScript.Chart#setShowDataLabelsOverMaximum:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setShowDataLabelsOverMaximum:member(1)
     package: ExcelScript!
     fullName: setShowDataLabelsOverMaximum(showDataLabelsOverMaximum)
     summary: >-
-      Specifies whether to show the data labels when the value is greater than the maximum value on the value axis. If
-      the value axis becomes smaller than the size of the data points, you can use this property to set whether to show
-      the data labels. This property applies to 2-D charts only.
+      Specifies whether to show the data labels when the value is greater than
+      the maximum value on the value axis. If the value axis becomes smaller
+      than the size of the data points, you can use this property to set whether
+      to show the data labels. This property applies to 2-D charts only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -831,11 +898,12 @@ methods:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.Chart#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
     summary: Specifies the chart style for the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -848,13 +916,14 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.Chart#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Specifies the distance, in points, from the top edge of the object to the top of row 1 (on a worksheet) or the top
-      of the chart area (on a chart).
+      Specifies the distance, in points, from the top edge of the object to the
+      top of row 1 (on a worksheet) or the top of the chart area (on a chart).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -867,11 +936,12 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.Chart#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Chart#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
-    summary: 'Specifies the width, in points, of the chart object.'
+    summary: Specifies the width, in points, of the chart object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartareaformat.yml
@@ -1,72 +1,84 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAreaFormat
-uid: 'ExcelScript!ExcelScript.ChartAreaFormat:interface'
+uid: ExcelScript!ExcelScript.ChartAreaFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAreaFormat
 summary: Encapsulates the format properties for the overall chart area.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format of chart area, which includes color, linestyle, and weight.'
+    summary: >-
+      Represents the border format of chart area, which includes color,
+      linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getColorScheme()
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#getColorScheme:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#getColorScheme:member(1)
     package: ExcelScript!
     fullName: getColorScheme()
     summary: Specifies the color scheme of the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getColorScheme(): ChartColorScheme;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartColorScheme:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartColorScheme:enum" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of an object, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of an object, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes (font name, font size, color, etc.) for the current object.'
+    summary: >-
+      Represents the font attributes (font name, font size, color, etc.) for the
+      current object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''
   - name: getRoundedCorners()
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#getRoundedCorners:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#getRoundedCorners:member(1)
     package: ExcelScript!
     fullName: getRoundedCorners()
     summary: Specifies if the chart area of the chart has rounded corners.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +87,12 @@ methods:
         type: boolean
         description: ''
   - name: setColorScheme(colorScheme)
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#setColorScheme:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#setColorScheme:member(1)
     package: ExcelScript!
     fullName: setColorScheme(colorScheme)
     summary: Specifies the color scheme of the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -87,16 +100,17 @@ methods:
       parameters:
         - id: colorScheme
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartColorScheme:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartColorScheme:enum" />
       return:
         type: void
         description: ''
   - name: setRoundedCorners(roundedCorners)
-    uid: 'ExcelScript!ExcelScript.ChartAreaFormat#setRoundedCorners:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAreaFormat#setRoundedCorners:member(1)
     package: ExcelScript!
     fullName: setRoundedCorners(roundedCorners)
     summary: Specifies if the chart area of the chart has rounded corners.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxes.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxes.yml
@@ -1,70 +1,79 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAxes
-uid: 'ExcelScript!ExcelScript.ChartAxes:interface'
+uid: ExcelScript!ExcelScript.ChartAxes:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxes
 summary: Represents the chart axes.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCategoryAxis()
-    uid: 'ExcelScript!ExcelScript.ChartAxes#getCategoryAxis:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxes#getCategoryAxis:member(1)
     package: ExcelScript!
     fullName: getCategoryAxis()
     summary: Represents the category axis in a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCategoryAxis(): ChartAxis;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />
         description: ''
-  - name: 'getChartAxis(type, group)'
-    uid: 'ExcelScript!ExcelScript.ChartAxes#getChartAxis:member(1)'
+  - name: getChartAxis(type, group)
+    uid: ExcelScript!ExcelScript.ChartAxes#getChartAxis:member(1)
     package: ExcelScript!
-    fullName: 'getChartAxis(type, group)'
+    fullName: getChartAxis(type, group)
     summary: Returns the specific axis identified by type and group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getChartAxis(type: ChartAxisType, group?: ChartAxisGroup): ChartAxis;'
       parameters:
         - id: type
-          description: Specifies the axis type. See `ExcelScript.ChartAxisType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisType:enum" />'
+          description: >-
+            Specifies the axis type. See `ExcelScript.ChartAxisType` for
+            details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisType:enum" />
         - id: group
-          description: Optional. Specifies the axis group. See `ExcelScript.ChartAxisGroup` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />'
+          description: >-
+            Optional. Specifies the axis group. See `ExcelScript.ChartAxisGroup`
+            for details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />
         description: ''
   - name: getSeriesAxis()
-    uid: 'ExcelScript!ExcelScript.ChartAxes#getSeriesAxis:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxes#getSeriesAxis:member(1)
     package: ExcelScript!
     fullName: getSeriesAxis()
     summary: Represents the series axis of a 3-D chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSeriesAxis(): ChartAxis;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />
         description: ''
   - name: getValueAxis()
-    uid: 'ExcelScript!ExcelScript.ChartAxes#getValueAxis:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxes#getValueAxis:member(1)
     package: ExcelScript!
     fullName: getValueAxis()
     summary: Represents the value axis in an axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValueAxis(): ChartAxis;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxis:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxis.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxis.yml
@@ -1,76 +1,84 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAxis
-uid: 'ExcelScript!ExcelScript.ChartAxis:interface'
+uid: ExcelScript!ExcelScript.ChartAxis:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxis
 summary: Represents a single axis in a chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getAlignment:member(1)
     package: ExcelScript!
     fullName: getAlignment()
     summary: >-
-      Specifies the alignment for the specified axis tick label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      detail.
+      Specifies the alignment for the specified axis tick label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for detail.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAlignment(): ChartTickLabelAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTickLabelAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTickLabelAlignment:enum" />
         description: ''
   - name: getAxisGroup()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getAxisGroup:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getAxisGroup:member(1)
     package: ExcelScript!
     fullName: getAxisGroup()
-    summary: Specifies the group for the specified axis. See `ExcelScript.ChartAxisGroup` for details.
+    summary: >-
+      Specifies the group for the specified axis. See
+      `ExcelScript.ChartAxisGroup` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAxisGroup(): ChartAxisGroup;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />
         description: ''
   - name: getBaseTimeUnit()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getBaseTimeUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getBaseTimeUnit:member(1)
     package: ExcelScript!
     fullName: getBaseTimeUnit()
     summary: Specifies the base unit for the specified category axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBaseTimeUnit(): ChartAxisTimeUnit;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
         description: ''
   - name: getCategoryType()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getCategoryType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getCategoryType:member(1)
     package: ExcelScript!
     fullName: getCategoryType()
     summary: Specifies the category axis type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCategoryType(): ChartAxisCategoryType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisCategoryType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisCategoryType:enum" />
         description: ''
   - name: getCustomDisplayUnit()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getCustomDisplayUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getCustomDisplayUnit:member(1)
     package: ExcelScript!
     fullName: getCustomDisplayUnit()
     summary: >-
-      Specifies the custom axis display unit value. To set this property, please use the `SetCustomDisplayUnit(double)`
-      method.
+      Specifies the custom axis display unit value. To set this property, please
+      use the `SetCustomDisplayUnit(double)` method.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,37 +87,46 @@ methods:
         type: number
         description: ''
   - name: getDisplayUnit()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getDisplayUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getDisplayUnit:member(1)
     package: ExcelScript!
     fullName: getDisplayUnit()
-    summary: Represents the axis display unit. See `ExcelScript.ChartAxisDisplayUnit` for details.
+    summary: >-
+      Represents the axis display unit. See `ExcelScript.ChartAxisDisplayUnit`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDisplayUnit(): ChartAxisDisplayUnit;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum" />
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Represents the formatting of a chart object, which includes line and font formatting.'
+    summary: >-
+      Represents the formatting of a chart object, which includes line and font
+      formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartAxisFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisFormat:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Specifies the height, in points, of the chart axis. Returns `null` if the axis is not visible.'
+    summary: >-
+      Specifies the height, in points, of the chart axis. Returns `null` if the
+      axis is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -118,11 +135,12 @@ methods:
         type: number
         description: ''
   - name: getIsBetweenCategories()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getIsBetweenCategories:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getIsBetweenCategories:member(1)
     package: ExcelScript!
     fullName: getIsBetweenCategories()
     summary: Specifies if the value axis crosses the category axis between categories.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -131,13 +149,14 @@ methods:
         type: boolean
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Specifies the distance, in points, from the left edge of the axis to the left of chart area. Returns `null` if the
-      axis is not visible.
+      Specifies the distance, in points, from the left edge of the axis to the
+      left of chart area. Returns `null` if the axis is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -146,13 +165,14 @@ methods:
         type: number
         description: ''
   - name: getLinkNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: getLinkNumberFormat()
     summary: >-
-      Specifies if the number format is linked to the cells. If `true`<!-- -->, the number format will change in the
-      labels when it changes in the cells.
+      Specifies if the number format is linked to the cells. If `true`<!-- -->,
+      the number format will change in the labels when it changes in the cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -161,11 +181,12 @@ methods:
         type: boolean
         description: ''
   - name: getLogBase()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getLogBase:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getLogBase:member(1)
     package: ExcelScript!
     fullName: getLogBase()
     summary: Specifies the base of the logarithm when using logarithmic scales.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,52 +195,60 @@ methods:
         type: number
         description: ''
   - name: getMajorGridlines()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMajorGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMajorGridlines:member(1)
     package: ExcelScript!
     fullName: getMajorGridlines()
-    summary: Returns an object that represents the major gridlines for the specified axis.
+    summary: >-
+      Returns an object that represents the major gridlines for the specified
+      axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMajorGridlines(): ChartGridlines;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGridlines:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGridlines:interface" />
         description: ''
   - name: getMajorTickMark()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMajorTickMark:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMajorTickMark:member(1)
     package: ExcelScript!
     fullName: getMajorTickMark()
-    summary: Specifies the type of major tick mark for the specified axis. See `ExcelScript.ChartAxisTickMark` for details.
+    summary: >-
+      Specifies the type of major tick mark for the specified axis. See
+      `ExcelScript.ChartAxisTickMark` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMajorTickMark(): ChartAxisTickMark;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />
         description: ''
   - name: getMajorTimeUnitScale()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMajorTimeUnitScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMajorTimeUnitScale:member(1)
     package: ExcelScript!
     fullName: getMajorTimeUnitScale()
     summary: >-
-      Specifies the major unit scale value for the category axis when the `categoryType` property is set to
-      `dateAxis`<!-- -->.
+      Specifies the major unit scale value for the category axis when the
+      `categoryType` property is set to `dateAxis`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMajorTimeUnitScale(): ChartAxisTimeUnit;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
         description: ''
   - name: getMajorUnit()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMajorUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMajorUnit:member(1)
     package: ExcelScript!
     fullName: getMajorUnit()
     summary: Specifies the interval between two major tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -228,11 +257,12 @@ methods:
         type: number
         description: ''
   - name: getMaximum()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMaximum:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMaximum:member(1)
     package: ExcelScript!
     fullName: getMaximum()
     summary: Specifies the maximum value on the value axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -241,11 +271,12 @@ methods:
         type: number
         description: ''
   - name: getMinimum()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMinimum:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMinimum:member(1)
     package: ExcelScript!
     fullName: getMinimum()
     summary: Specifies the minimum value on the value axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -254,52 +285,60 @@ methods:
         type: number
         description: ''
   - name: getMinorGridlines()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMinorGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMinorGridlines:member(1)
     package: ExcelScript!
     fullName: getMinorGridlines()
-    summary: Returns an object that represents the minor gridlines for the specified axis.
+    summary: >-
+      Returns an object that represents the minor gridlines for the specified
+      axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMinorGridlines(): ChartGridlines;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGridlines:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGridlines:interface" />
         description: ''
   - name: getMinorTickMark()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMinorTickMark:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMinorTickMark:member(1)
     package: ExcelScript!
     fullName: getMinorTickMark()
-    summary: Specifies the type of minor tick mark for the specified axis. See `ExcelScript.ChartAxisTickMark` for details.
+    summary: >-
+      Specifies the type of minor tick mark for the specified axis. See
+      `ExcelScript.ChartAxisTickMark` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMinorTickMark(): ChartAxisTickMark;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />
         description: ''
   - name: getMinorTimeUnitScale()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMinorTimeUnitScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMinorTimeUnitScale:member(1)
     package: ExcelScript!
     fullName: getMinorTimeUnitScale()
     summary: >-
-      Specifies the minor unit scale value for the category axis when the `categoryType` property is set to
-      `dateAxis`<!-- -->.
+      Specifies the minor unit scale value for the category axis when the
+      `categoryType` property is set to `dateAxis`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMinorTimeUnitScale(): ChartAxisTimeUnit;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
         description: ''
   - name: getMinorUnit()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMinorUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMinorUnit:member(1)
     package: ExcelScript!
     fullName: getMinorUnit()
     summary: Specifies the interval between two minor tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -308,11 +347,12 @@ methods:
         type: number
         description: ''
   - name: getMultiLevel()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getMultiLevel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getMultiLevel:member(1)
     package: ExcelScript!
     fullName: getMultiLevel()
     summary: Specifies if an axis is multilevel.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -321,11 +361,12 @@ methods:
         type: boolean
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: Specifies the format code for the axis tick label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -334,13 +375,15 @@ methods:
         type: string
         description: ''
   - name: getOffset()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getOffset:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getOffset:member(1)
     package: ExcelScript!
     fullName: getOffset()
     summary: >-
-      Specifies the distance between the levels of labels, and the distance between the first level and the axis line.
-      The value should be an integer from 0 to 1000.
+      Specifies the distance between the levels of labels, and the distance
+      between the first level and the axis line. The value should be an integer
+      from 0 to 1000.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -349,28 +392,30 @@ methods:
         type: number
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: >-
-      Specifies the specified axis position where the other axis crosses. See `ExcelScript.ChartAxisPosition` for
-      details.
+      Specifies the specified axis position where the other axis crosses. See
+      `ExcelScript.ChartAxisPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartAxisPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisPosition:enum" />
         description: ''
   - name: getPositionAt()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getPositionAt:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getPositionAt:member(1)
     package: ExcelScript!
     fullName: getPositionAt()
     summary: >-
-      Specifies the axis position where the other axis crosses. You should use the `SetPositionAt(double)` method to set
-      this property.
+      Specifies the axis position where the other axis crosses. You should use
+      the `SetPositionAt(double)` method to set this property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -379,11 +424,12 @@ methods:
         type: number
         description: ''
   - name: getReversePlotOrder()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getReversePlotOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getReversePlotOrder:member(1)
     package: ExcelScript!
     fullName: getReversePlotOrder()
     summary: Specifies if Excel plots data points from last to first.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -392,24 +438,28 @@ methods:
         type: boolean
         description: ''
   - name: getScaleType()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getScaleType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getScaleType:member(1)
     package: ExcelScript!
     fullName: getScaleType()
-    summary: Specifies the value axis scale type. See `ExcelScript.ChartAxisScaleType` for details.
+    summary: >-
+      Specifies the value axis scale type. See `ExcelScript.ChartAxisScaleType`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getScaleType(): ChartAxisScaleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisScaleType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisScaleType:enum" />
         description: ''
   - name: getShowDisplayUnitLabel()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getShowDisplayUnitLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getShowDisplayUnitLabel:member(1)
     package: ExcelScript!
     fullName: getShowDisplayUnitLabel()
     summary: Specifies if the axis display unit label is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -418,13 +468,15 @@ methods:
         type: boolean
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Specifies the angle to which the text is oriented for the chart axis tick label. The value should either be an
-      integer from -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart axis tick
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -433,26 +485,30 @@ methods:
         type: number
         description: ''
   - name: getTickLabelPosition()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTickLabelPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTickLabelPosition:member(1)
     package: ExcelScript!
     fullName: getTickLabelPosition()
     summary: >-
-      Specifies the position of tick-mark labels on the specified axis. See `ExcelScript.ChartAxisTickLabelPosition` for
-      details.
+      Specifies the position of tick-mark labels on the specified axis. See
+      `ExcelScript.ChartAxisTickLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTickLabelPosition(): ChartAxisTickLabelPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum" />
         description: ''
   - name: getTickLabelSpacing()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTickLabelSpacing:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTickLabelSpacing:member(1)
     package: ExcelScript!
     fullName: getTickLabelSpacing()
-    summary: Specifies the number of categories or series between tick-mark labels. Can be a value from 1 through 31999.
+    summary: >-
+      Specifies the number of categories or series between tick-mark labels. Can
+      be a value from 1 through 31999.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -461,11 +517,12 @@ methods:
         type: number
         description: ''
   - name: getTickMarkSpacing()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTickMarkSpacing:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTickMarkSpacing:member(1)
     package: ExcelScript!
     fullName: getTickMarkSpacing()
     summary: Specifies the number of categories or series between tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -474,26 +531,28 @@ methods:
         type: number
         description: ''
   - name: getTitle()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTitle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTitle:member(1)
     package: ExcelScript!
     fullName: getTitle()
     summary: Represents the axis title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTitle(): ChartAxisTitle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTitle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTitle:interface" />
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Specifies the distance, in points, from the top edge of the axis to the top of chart area. Returns `null` if the
-      axis is not visible.
+      Specifies the distance, in points, from the top edge of the axis to the
+      top of chart area. Returns `null` if the axis is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -502,24 +561,26 @@ methods:
         type: number
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: Specifies the axis type. See `ExcelScript.ChartAxisType` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ChartAxisType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisType:enum" />
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the axis is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -528,11 +589,14 @@ methods:
         type: boolean
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartAxis#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Specifies the width, in points, of the chart axis. Returns `null` if the axis is not visible.'
+    summary: >-
+      Specifies the width, in points, of the chart axis. Returns `null` if the
+      axis is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -541,13 +605,14 @@ methods:
         type: number
         description: ''
   - name: setAlignment(alignment)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setAlignment:member(1)
     package: ExcelScript!
     fullName: setAlignment(alignment)
     summary: >-
-      Specifies the alignment for the specified axis tick label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      detail.
+      Specifies the alignment for the specified axis tick label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for detail.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -555,16 +620,17 @@ methods:
       parameters:
         - id: alignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTickLabelAlignment:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartTickLabelAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setBaseTimeUnit(baseTimeUnit)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setBaseTimeUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setBaseTimeUnit:member(1)
     package: ExcelScript!
     fullName: setBaseTimeUnit(baseTimeUnit)
     summary: Specifies the base unit for the specified category axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -572,16 +638,17 @@ methods:
       parameters:
         - id: baseTimeUnit
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
       return:
         type: void
         description: ''
   - name: setCategoryNames(sourceData)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setCategoryNames:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setCategoryNames:member(1)
     package: ExcelScript!
     fullName: setCategoryNames(sourceData)
     summary: Sets all the category names for the specified axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -589,16 +656,17 @@ methods:
       parameters:
         - id: sourceData
           description: The `Range` object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
       return:
         type: void
         description: ''
   - name: setCategoryType(categoryType)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setCategoryType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setCategoryType:member(1)
     package: ExcelScript!
     fullName: setCategoryType(categoryType)
     summary: Specifies the category axis type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -606,16 +674,17 @@ methods:
       parameters:
         - id: categoryType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisCategoryType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisCategoryType:enum" />
       return:
         type: void
         description: ''
   - name: setCustomDisplayUnit(value)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setCustomDisplayUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setCustomDisplayUnit:member(1)
     package: ExcelScript!
     fullName: setCustomDisplayUnit(value)
     summary: Sets the axis display unit to a custom value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -628,11 +697,14 @@ methods:
         type: void
         description: ''
   - name: setDisplayUnit(displayUnit)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setDisplayUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setDisplayUnit:member(1)
     package: ExcelScript!
     fullName: setDisplayUnit(displayUnit)
-    summary: Represents the axis display unit. See `ExcelScript.ChartAxisDisplayUnit` for details.
+    summary: >-
+      Represents the axis display unit. See `ExcelScript.ChartAxisDisplayUnit`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -640,16 +712,17 @@ methods:
       parameters:
         - id: displayUnit
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum" />
       return:
         type: void
         description: ''
   - name: setIsBetweenCategories(isBetweenCategories)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setIsBetweenCategories:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setIsBetweenCategories:member(1)
     package: ExcelScript!
     fullName: setIsBetweenCategories(isBetweenCategories)
     summary: Specifies if the value axis crosses the category axis between categories.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -662,13 +735,14 @@ methods:
         type: void
         description: ''
   - name: setLinkNumberFormat(linkNumberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: setLinkNumberFormat(linkNumberFormat)
     summary: >-
-      Specifies if the number format is linked to the cells. If `true`<!-- -->, the number format will change in the
-      labels when it changes in the cells.
+      Specifies if the number format is linked to the cells. If `true`<!-- -->,
+      the number format will change in the labels when it changes in the cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -681,11 +755,12 @@ methods:
         type: void
         description: ''
   - name: setLogBase(logBase)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setLogBase:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setLogBase:member(1)
     package: ExcelScript!
     fullName: setLogBase(logBase)
     summary: Specifies the base of the logarithm when using logarithmic scales.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -698,11 +773,14 @@ methods:
         type: void
         description: ''
   - name: setMajorTickMark(majorTickMark)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMajorTickMark:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMajorTickMark:member(1)
     package: ExcelScript!
     fullName: setMajorTickMark(majorTickMark)
-    summary: Specifies the type of major tick mark for the specified axis. See `ExcelScript.ChartAxisTickMark` for details.
+    summary: >-
+      Specifies the type of major tick mark for the specified axis. See
+      `ExcelScript.ChartAxisTickMark` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -710,18 +788,19 @@ methods:
       parameters:
         - id: majorTickMark
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />
       return:
         type: void
         description: ''
   - name: setMajorTimeUnitScale(majorTimeUnitScale)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMajorTimeUnitScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMajorTimeUnitScale:member(1)
     package: ExcelScript!
     fullName: setMajorTimeUnitScale(majorTimeUnitScale)
     summary: >-
-      Specifies the major unit scale value for the category axis when the `categoryType` property is set to
-      `dateAxis`<!-- -->.
+      Specifies the major unit scale value for the category axis when the
+      `categoryType` property is set to `dateAxis`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -729,16 +808,17 @@ methods:
       parameters:
         - id: majorTimeUnitScale
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
       return:
         type: void
         description: ''
   - name: setMajorUnit(majorUnit)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMajorUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMajorUnit:member(1)
     package: ExcelScript!
     fullName: setMajorUnit(majorUnit)
     summary: Specifies the interval between two major tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -751,11 +831,12 @@ methods:
         type: void
         description: ''
   - name: setMaximum(maximum)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMaximum:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMaximum:member(1)
     package: ExcelScript!
     fullName: setMaximum(maximum)
     summary: Specifies the maximum value on the value axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -768,11 +849,12 @@ methods:
         type: void
         description: ''
   - name: setMinimum(minimum)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMinimum:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMinimum:member(1)
     package: ExcelScript!
     fullName: setMinimum(minimum)
     summary: Specifies the minimum value on the value axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -785,11 +867,14 @@ methods:
         type: void
         description: ''
   - name: setMinorTickMark(minorTickMark)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMinorTickMark:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMinorTickMark:member(1)
     package: ExcelScript!
     fullName: setMinorTickMark(minorTickMark)
-    summary: Specifies the type of minor tick mark for the specified axis. See `ExcelScript.ChartAxisTickMark` for details.
+    summary: >-
+      Specifies the type of minor tick mark for the specified axis. See
+      `ExcelScript.ChartAxisTickMark` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -797,18 +882,19 @@ methods:
       parameters:
         - id: minorTickMark
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisTickMark:enum" />
       return:
         type: void
         description: ''
   - name: setMinorTimeUnitScale(minorTimeUnitScale)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMinorTimeUnitScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMinorTimeUnitScale:member(1)
     package: ExcelScript!
     fullName: setMinorTimeUnitScale(minorTimeUnitScale)
     summary: >-
-      Specifies the minor unit scale value for the category axis when the `categoryType` property is set to
-      `dateAxis`<!-- -->.
+      Specifies the minor unit scale value for the category axis when the
+      `categoryType` property is set to `dateAxis`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -816,16 +902,17 @@ methods:
       parameters:
         - id: minorTimeUnitScale
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisTimeUnit:enum" />
       return:
         type: void
         description: ''
   - name: setMinorUnit(minorUnit)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMinorUnit:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMinorUnit:member(1)
     package: ExcelScript!
     fullName: setMinorUnit(minorUnit)
     summary: Specifies the interval between two minor tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -838,11 +925,12 @@ methods:
         type: void
         description: ''
   - name: setMultiLevel(multiLevel)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setMultiLevel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setMultiLevel:member(1)
     package: ExcelScript!
     fullName: setMultiLevel(multiLevel)
     summary: Specifies if an axis is multilevel.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -855,11 +943,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: Specifies the format code for the axis tick label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -872,13 +961,15 @@ methods:
         type: void
         description: ''
   - name: setOffset(offset)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setOffset:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setOffset:member(1)
     package: ExcelScript!
     fullName: setOffset(offset)
     summary: >-
-      Specifies the distance between the levels of labels, and the distance between the first level and the axis line.
-      The value should be an integer from 0 to 1000.
+      Specifies the distance between the levels of labels, and the distance
+      between the first level and the axis line. The value should be an integer
+      from 0 to 1000.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -891,13 +982,14 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: >-
-      Specifies the specified axis position where the other axis crosses. See `ExcelScript.ChartAxisPosition` for
-      details.
+      Specifies the specified axis position where the other axis crosses. See
+      `ExcelScript.ChartAxisPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -905,16 +997,17 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisPosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisPosition:enum" />
       return:
         type: void
         description: ''
   - name: setPositionAt(value)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setPositionAt:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setPositionAt:member(1)
     package: ExcelScript!
     fullName: setPositionAt(value)
     summary: Sets the specified axis position where the other axis crosses.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -927,11 +1020,12 @@ methods:
         type: void
         description: ''
   - name: setReversePlotOrder(reversePlotOrder)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setReversePlotOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setReversePlotOrder:member(1)
     package: ExcelScript!
     fullName: setReversePlotOrder(reversePlotOrder)
     summary: Specifies if Excel plots data points from last to first.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -944,11 +1038,14 @@ methods:
         type: void
         description: ''
   - name: setScaleType(scaleType)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setScaleType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setScaleType:member(1)
     package: ExcelScript!
     fullName: setScaleType(scaleType)
-    summary: Specifies the value axis scale type. See `ExcelScript.ChartAxisScaleType` for details.
+    summary: >-
+      Specifies the value axis scale type. See `ExcelScript.ChartAxisScaleType`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -956,16 +1053,17 @@ methods:
       parameters:
         - id: scaleType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisScaleType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisScaleType:enum" />
       return:
         type: void
         description: ''
   - name: setShowDisplayUnitLabel(showDisplayUnitLabel)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setShowDisplayUnitLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setShowDisplayUnitLabel:member(1)
     package: ExcelScript!
     fullName: setShowDisplayUnitLabel(showDisplayUnitLabel)
     summary: Specifies if the axis display unit label is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -978,13 +1076,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Specifies the angle to which the text is oriented for the chart axis tick label. The value should either be an
-      integer from -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart axis tick
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -997,13 +1097,14 @@ methods:
         type: void
         description: ''
   - name: setTickLabelPosition(tickLabelPosition)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setTickLabelPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setTickLabelPosition:member(1)
     package: ExcelScript!
     fullName: setTickLabelPosition(tickLabelPosition)
     summary: >-
-      Specifies the position of tick-mark labels on the specified axis. See `ExcelScript.ChartAxisTickLabelPosition` for
-      details.
+      Specifies the position of tick-mark labels on the specified axis. See
+      `ExcelScript.ChartAxisTickLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1014,16 +1115,21 @@ methods:
       parameters:
         - id: tickLabelPosition
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum"
+            />
       return:
         type: void
         description: ''
   - name: setTickLabelSpacing(tickLabelSpacing)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setTickLabelSpacing:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setTickLabelSpacing:member(1)
     package: ExcelScript!
     fullName: setTickLabelSpacing(tickLabelSpacing)
-    summary: Specifies the number of categories or series between tick-mark labels. Can be a value from 1 through 31999.
+    summary: >-
+      Specifies the number of categories or series between tick-mark labels. Can
+      be a value from 1 through 31999.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1036,11 +1142,12 @@ methods:
         type: void
         description: ''
   - name: setTickMarkSpacing(tickMarkSpacing)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setTickMarkSpacing:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setTickMarkSpacing:member(1)
     package: ExcelScript!
     fullName: setTickMarkSpacing(tickMarkSpacing)
     summary: Specifies the number of categories or series between tick marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1053,11 +1160,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartAxis#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxis#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the axis is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxiscategorytype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxiscategorytype.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisCategoryType
-uid: 'ExcelScript!ExcelScript.ChartAxisCategoryType:enum'
+uid: ExcelScript!ExcelScript.ChartAxisCategoryType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisCategoryType
 summary: Specifies the type of the category axis.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartAxisCategoryType.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartAxisCategoryType.automatic:member
     package: ExcelScript!
     summary: Excel controls the axis type.
   - name: dateAxis
-    uid: 'ExcelScript!ExcelScript.ChartAxisCategoryType.dateAxis:member'
+    uid: ExcelScript!ExcelScript.ChartAxisCategoryType.dateAxis:member
     package: ExcelScript!
     summary: Axis groups data on a time scale.
   - name: textAxis
-    uid: 'ExcelScript!ExcelScript.ChartAxisCategoryType.textAxis:member'
+    uid: ExcelScript!ExcelScript.ChartAxisCategoryType.textAxis:member
     package: ExcelScript!
     summary: Axis groups data by an arbitrary set of categories.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisdisplayunit.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisdisplayunit.yml
@@ -1,54 +1,57 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisDisplayUnit
-uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum'
+uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisDisplayUnit
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: billions
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.billions:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.billions:member
     package: ExcelScript!
     summary: This will set the axis in units of billions.
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.custom:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.custom:member
     package: ExcelScript!
     summary: This will set the axis in units of custom value.
   - name: hundredMillions
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundredMillions:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundredMillions:member
     package: ExcelScript!
     summary: This will set the axis in units of hundreds of millions.
   - name: hundreds
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundreds:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundreds:member
     package: ExcelScript!
     summary: This will set the axis in units of hundreds.
   - name: hundredThousands
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundredThousands:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.hundredThousands:member
     package: ExcelScript!
     summary: This will set the axis in units of hundreds of thousands.
   - name: millions
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.millions:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.millions:member
     package: ExcelScript!
     summary: This will set the axis in units of millions.
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.none:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.none:member
     package: ExcelScript!
-    summary: 'Default option. This will reset display unit to the axis, and set unit label invisible.'
+    summary: >-
+      Default option. This will reset display unit to the axis, and set unit
+      label invisible.
   - name: tenMillions
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.tenMillions:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.tenMillions:member
     package: ExcelScript!
     summary: This will set the axis in units of tens of millions.
   - name: tenThousands
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.tenThousands:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.tenThousands:member
     package: ExcelScript!
     summary: This will set the axis in units of tens of thousands.
   - name: thousands
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.thousands:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.thousands:member
     package: ExcelScript!
     summary: This will set the axis in units of thousands.
   - name: trillions
-    uid: 'ExcelScript!ExcelScript.ChartAxisDisplayUnit.trillions:member'
+    uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit.trillions:member
     package: ExcelScript!
     summary: This will set the axis in units of trillions.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisformat.yml
@@ -1,50 +1,56 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAxisFormat
-uid: 'ExcelScript!ExcelScript.ChartAxisFormat:interface'
+uid: ExcelScript!ExcelScript.ChartAxisFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisFormat
 summary: Encapsulates the format properties for the chart axis.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartAxisFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Specifies chart fill formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartAxisFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Specifies the font attributes (font name, font size, color, etc.) for a chart axis element.'
+    summary: >-
+      Specifies the font attributes (font name, font size, color, etc.) for a
+      chart axis element.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartAxisFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Specifies chart line formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisgroup.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisgroup.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisGroup
-uid: 'ExcelScript!ExcelScript.ChartAxisGroup:enum'
+uid: ExcelScript!ExcelScript.ChartAxisGroup:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisGroup
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: primary
-    uid: 'ExcelScript!ExcelScript.ChartAxisGroup.primary:member'
+    uid: ExcelScript!ExcelScript.ChartAxisGroup.primary:member
     package: ExcelScript!
     summary: ''
   - name: secondary
-    uid: 'ExcelScript!ExcelScript.ChartAxisGroup.secondary:member'
+    uid: ExcelScript!ExcelScript.ChartAxisGroup.secondary:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisposition.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisPosition
-uid: 'ExcelScript!ExcelScript.ChartAxisPosition:enum'
+uid: ExcelScript!ExcelScript.ChartAxisPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisPosition
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartAxisPosition.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartAxisPosition.automatic:member
     package: ExcelScript!
     summary: ''
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ChartAxisPosition.custom:member'
+    uid: ExcelScript!ExcelScript.ChartAxisPosition.custom:member
     package: ExcelScript!
     summary: ''
   - name: maximum
-    uid: 'ExcelScript!ExcelScript.ChartAxisPosition.maximum:member'
+    uid: ExcelScript!ExcelScript.ChartAxisPosition.maximum:member
     package: ExcelScript!
     summary: ''
   - name: minimum
-    uid: 'ExcelScript!ExcelScript.ChartAxisPosition.minimum:member'
+    uid: ExcelScript!ExcelScript.ChartAxisPosition.minimum:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisscaletype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisscaletype.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisScaleType
-uid: 'ExcelScript!ExcelScript.ChartAxisScaleType:enum'
+uid: ExcelScript!ExcelScript.ChartAxisScaleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisScaleType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: linear
-    uid: 'ExcelScript!ExcelScript.ChartAxisScaleType.linear:member'
+    uid: ExcelScript!ExcelScript.ChartAxisScaleType.linear:member
     package: ExcelScript!
     summary: ''
   - name: logarithmic
-    uid: 'ExcelScript!ExcelScript.ChartAxisScaleType.logarithmic:member'
+    uid: ExcelScript!ExcelScript.ChartAxisScaleType.logarithmic:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisticklabelposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxisticklabelposition.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisTickLabelPosition
-uid: 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum'
+uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTickLabelPosition
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: high
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition.high:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition.high:member
     package: ExcelScript!
     summary: ''
   - name: low
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition.low:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition.low:member
     package: ExcelScript!
     summary: ''
   - name: nextToAxis
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition.nextToAxis:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition.nextToAxis:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickLabelPosition.none:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition.none:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistickmark.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistickmark.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisTickMark
-uid: 'ExcelScript!ExcelScript.ChartAxisTickMark:enum'
+uid: ExcelScript!ExcelScript.ChartAxisTickMark:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTickMark
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: cross
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickMark.cross:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickMark.cross:member
     package: ExcelScript!
     summary: ''
   - name: inside
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickMark.inside:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickMark.inside:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickMark.none:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickMark.none:member
     package: ExcelScript!
     summary: ''
   - name: outside
-    uid: 'ExcelScript!ExcelScript.ChartAxisTickMark.outside:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTickMark.outside:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistimeunit.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistimeunit.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisTimeUnit
-uid: 'ExcelScript!ExcelScript.ChartAxisTimeUnit:enum'
+uid: ExcelScript!ExcelScript.ChartAxisTimeUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTimeUnit
 summary: Specifies the unit of time for chart axes and data series.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: days
-    uid: 'ExcelScript!ExcelScript.ChartAxisTimeUnit.days:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTimeUnit.days:member
     package: ExcelScript!
     summary: ''
   - name: months
-    uid: 'ExcelScript!ExcelScript.ChartAxisTimeUnit.months:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTimeUnit.months:member
     package: ExcelScript!
     summary: ''
   - name: years
-    uid: 'ExcelScript!ExcelScript.ChartAxisTimeUnit.years:member'
+    uid: ExcelScript!ExcelScript.ChartAxisTimeUnit.years:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistitle.yml
@@ -1,33 +1,36 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAxisTitle
-uid: 'ExcelScript!ExcelScript.ChartAxisTitle:interface'
+uid: ExcelScript!ExcelScript.ChartAxisTitle:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTitle
 summary: Represents the title of a chart axis.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Specifies the formatting of the chart axis title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartAxisTitleFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisTitleFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisTitleFormat:interface" />
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#getText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: Specifies the axis title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,13 +39,15 @@ methods:
         type: string
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Specifies the angle to which the text is oriented for the chart axis title. The value should either be an integer
-      from -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart axis
+      title. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -51,11 +56,12 @@ methods:
         type: number
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the axis title is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,11 +70,14 @@ methods:
         type: boolean
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: A string value that represents the formula of chart axis title using A1-style notation.
+    summary: >-
+      A string value that represents the formula of chart axis title using
+      A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -81,11 +90,12 @@ methods:
         type: void
         description: ''
   - name: setText(text)
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#setText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#setText:member(1)
     package: ExcelScript!
     fullName: setText(text)
     summary: Specifies the axis title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -98,13 +108,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Specifies the angle to which the text is oriented for the chart axis title. The value should either be an integer
-      from -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart axis
+      title. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -117,11 +129,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitle#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitle#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the axis title is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistitleformat.yml
@@ -1,52 +1,58 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartAxisTitleFormat
-uid: 'ExcelScript!ExcelScript.ChartAxisTitleFormat:interface'
+uid: ExcelScript!ExcelScript.ChartAxisTitleFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTitleFormat
 summary: Represents the chart axis title formatting.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitleFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitleFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Specifies the chart axis title''s border format, which includes color, linestyle, and weight.'
+    summary: >-
+      Specifies the chart axis title's border format, which includes color,
+      linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitleFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitleFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Specifies the chart axis title's fill formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartAxisTitleFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartAxisTitleFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
     summary: >-
-      Specifies the chart axis title's font attributes, such as font name, font size, or color, of the chart axis title
-      object.
+      Specifies the chart axis title's font attributes, such as font name, font
+      size, or color, of the chart axis title object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartaxistype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartAxisType
-uid: 'ExcelScript!ExcelScript.ChartAxisType:enum'
+uid: ExcelScript!ExcelScript.ChartAxisType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: category
-    uid: 'ExcelScript!ExcelScript.ChartAxisType.category:member'
+    uid: ExcelScript!ExcelScript.ChartAxisType.category:member
     package: ExcelScript!
     summary: Axis displays categories.
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ChartAxisType.invalid:member'
+    uid: ExcelScript!ExcelScript.ChartAxisType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: series
-    uid: 'ExcelScript!ExcelScript.ChartAxisType.series:member'
+    uid: ExcelScript!ExcelScript.ChartAxisType.series:member
     package: ExcelScript!
     summary: Axis displays data series.
   - name: value
-    uid: 'ExcelScript!ExcelScript.ChartAxisType.value:member'
+    uid: ExcelScript!ExcelScript.ChartAxisType.value:member
     package: ExcelScript!
     summary: Axis displays values.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartbinoptions.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartBinOptions
-uid: 'ExcelScript!ExcelScript.ChartBinOptions:interface'
+uid: ExcelScript!ExcelScript.ChartBinOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBinOptions
 summary: Encapsulates the bin options for histogram charts and pareto charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAllowOverflow()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getAllowOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getAllowOverflow:member(1)
     package: ExcelScript!
     fullName: getAllowOverflow()
     summary: Specifies if bin overflow is enabled in a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,14 @@ methods:
         type: boolean
         description: ''
   - name: getAllowUnderflow()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getAllowUnderflow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getAllowUnderflow:member(1)
     package: ExcelScript!
     fullName: getAllowUnderflow()
-    summary: Specifies if bin underflow is enabled in a histogram chart or pareto chart.
+    summary: >-
+      Specifies if bin underflow is enabled in a histogram chart or pareto
+      chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +41,12 @@ methods:
         type: boolean
         description: ''
   - name: getCount()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getCount:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getCount:member(1)
     package: ExcelScript!
     fullName: getCount()
     summary: Specifies the bin count of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +55,12 @@ methods:
         type: number
         description: ''
   - name: getOverflowValue()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getOverflowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getOverflowValue:member(1)
     package: ExcelScript!
     fullName: getOverflowValue()
     summary: Specifies the bin overflow value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,24 +69,26 @@ methods:
         type: number
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: Specifies the bin's type for a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ChartBinType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBinType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBinType:enum" />
         description: ''
   - name: getUnderflowValue()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getUnderflowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getUnderflowValue:member(1)
     package: ExcelScript!
     fullName: getUnderflowValue()
     summary: Specifies the bin underflow value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +97,12 @@ methods:
         type: number
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: Specifies the bin width value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,11 +111,12 @@ methods:
         type: number
         description: ''
   - name: setAllowOverflow(allowOverflow)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setAllowOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setAllowOverflow:member(1)
     package: ExcelScript!
     fullName: setAllowOverflow(allowOverflow)
     summary: Specifies if bin overflow is enabled in a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -118,11 +129,14 @@ methods:
         type: void
         description: ''
   - name: setAllowUnderflow(allowUnderflow)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setAllowUnderflow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setAllowUnderflow:member(1)
     package: ExcelScript!
     fullName: setAllowUnderflow(allowUnderflow)
-    summary: Specifies if bin underflow is enabled in a histogram chart or pareto chart.
+    summary: >-
+      Specifies if bin underflow is enabled in a histogram chart or pareto
+      chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,11 +149,12 @@ methods:
         type: void
         description: ''
   - name: setCount(count)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setCount:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setCount:member(1)
     package: ExcelScript!
     fullName: setCount(count)
     summary: Specifies the bin count of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -152,11 +167,12 @@ methods:
         type: void
         description: ''
   - name: setOverflowValue(overflowValue)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setOverflowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setOverflowValue:member(1)
     package: ExcelScript!
     fullName: setOverflowValue(overflowValue)
     summary: Specifies the bin overflow value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -169,11 +185,12 @@ methods:
         type: void
         description: ''
   - name: setType(type)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setType:member(1)
     package: ExcelScript!
     fullName: setType(type)
     summary: Specifies the bin's type for a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -181,16 +198,17 @@ methods:
       parameters:
         - id: type
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartBinType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartBinType:enum" />
       return:
         type: void
         description: ''
   - name: setUnderflowValue(underflowValue)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setUnderflowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setUnderflowValue:member(1)
     package: ExcelScript!
     fullName: setUnderflowValue(underflowValue)
     summary: Specifies the bin underflow value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -203,11 +221,12 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.ChartBinOptions#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBinOptions#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
     summary: Specifies the bin width value of a histogram chart or pareto chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartbintype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartbintype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartBinType
-uid: 'ExcelScript!ExcelScript.ChartBinType:enum'
+uid: ExcelScript!ExcelScript.ChartBinType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartBinType
 summary: Specifies the bin type of a histogram chart or pareto chart series.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: auto
-    uid: 'ExcelScript!ExcelScript.ChartBinType.auto:member'
+    uid: ExcelScript!ExcelScript.ChartBinType.auto:member
     package: ExcelScript!
     summary: ''
   - name: binCount
-    uid: 'ExcelScript!ExcelScript.ChartBinType.binCount:member'
+    uid: ExcelScript!ExcelScript.ChartBinType.binCount:member
     package: ExcelScript!
     summary: ''
   - name: binWidth
-    uid: 'ExcelScript!ExcelScript.ChartBinType.binWidth:member'
+    uid: ExcelScript!ExcelScript.ChartBinType.binWidth:member
     package: ExcelScript!
     summary: ''
   - name: category
-    uid: 'ExcelScript!ExcelScript.ChartBinType.category:member'
+    uid: ExcelScript!ExcelScript.ChartBinType.category:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartborder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartborder.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartBorder
-uid: 'ExcelScript!ExcelScript.ChartBorder:interface'
+uid: ExcelScript!ExcelScript.ChartBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBorder
 summary: Represents the border formatting of a chart element.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ChartBorder#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clear the border format of a chart element.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ChartBorder#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: HTML color code representing the color of borders in the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,24 +39,28 @@ methods:
         type: string
         description: ''
   - name: getLineStyle()
-    uid: 'ExcelScript!ExcelScript.ChartBorder#getLineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#getLineStyle:member(1)
     package: ExcelScript!
     fullName: getLineStyle()
-    summary: Represents the line style of the border. See `ExcelScript.ChartLineStyle` for details.
+    summary: >-
+      Represents the line style of the border. See `ExcelScript.ChartLineStyle`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLineStyle(): ChartLineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />
         description: ''
   - name: getWeight()
-    uid: 'ExcelScript!ExcelScript.ChartBorder#getWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#getWeight:member(1)
     package: ExcelScript!
     fullName: getWeight()
-    summary: 'Represents weight of the border, in points.'
+    summary: Represents weight of the border, in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +69,12 @@ methods:
         type: number
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ChartBorder#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: HTML color code representing the color of borders in the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,11 +87,14 @@ methods:
         type: void
         description: ''
   - name: setLineStyle(lineStyle)
-    uid: 'ExcelScript!ExcelScript.ChartBorder#setLineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#setLineStyle:member(1)
     package: ExcelScript!
     fullName: setLineStyle(lineStyle)
-    summary: Represents the line style of the border. See `ExcelScript.ChartLineStyle` for details.
+    summary: >-
+      Represents the line style of the border. See `ExcelScript.ChartLineStyle`
+      for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,16 +102,17 @@ methods:
       parameters:
         - id: lineStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />
       return:
         type: void
         description: ''
   - name: setWeight(weight)
-    uid: 'ExcelScript!ExcelScript.ChartBorder#setWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBorder#setWeight:member(1)
     package: ExcelScript!
     fullName: setWeight(weight)
-    summary: 'Represents weight of the border, in points.'
+    summary: Represents weight of the border, in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartboxquartilecalculation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartboxquartilecalculation.yml
@@ -1,18 +1,21 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartBoxQuartileCalculation
-uid: 'ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum'
+uid: ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartBoxQuartileCalculation
-summary: Represents the quartile calculation type of chart series layout. Only applies to a box and whisker chart.
+summary: >-
+  Represents the quartile calculation type of chart series layout. Only applies
+  to a box and whisker chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: exclusive
-    uid: 'ExcelScript!ExcelScript.ChartBoxQuartileCalculation.exclusive:member'
+    uid: ExcelScript!ExcelScript.ChartBoxQuartileCalculation.exclusive:member
     package: ExcelScript!
     summary: ''
   - name: inclusive
-    uid: 'ExcelScript!ExcelScript.ChartBoxQuartileCalculation.inclusive:member'
+    uid: ExcelScript!ExcelScript.ChartBoxQuartileCalculation.inclusive:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartboxwhiskeroptions.yml
@@ -1,33 +1,40 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartBoxwhiskerOptions
-uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface'
+uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBoxwhiskerOptions
 summary: Represents the properties of a box and whisker chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getQuartileCalculation()
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getQuartileCalculation:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getQuartileCalculation:member(1)
     package: ExcelScript!
     fullName: getQuartileCalculation()
     summary: Specifies if the quartile calculation type of a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getQuartileCalculation(): ChartBoxQuartileCalculation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum"
+          />
         description: ''
   - name: getShowInnerPoints()
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowInnerPoints:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowInnerPoints:member(1)
     package: ExcelScript!
     fullName: getShowInnerPoints()
     summary: Specifies if inner points are shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +43,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowMeanLine()
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowMeanLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowMeanLine:member(1)
     package: ExcelScript!
     fullName: getShowMeanLine()
     summary: Specifies if the mean line is shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowMeanMarker()
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowMeanMarker:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowMeanMarker:member(1)
     package: ExcelScript!
     fullName: getShowMeanMarker()
     summary: Specifies if the mean marker is shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,13 @@ methods:
         type: boolean
         description: ''
   - name: getShowOutlierPoints()
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowOutlierPoints:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#getShowOutlierPoints:member(1)
     package: ExcelScript!
     fullName: getShowOutlierPoints()
     summary: Specifies if outlier points are shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +86,13 @@ methods:
         type: boolean
         description: ''
   - name: setQuartileCalculation(quartileCalculation)
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setQuartileCalculation:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setQuartileCalculation:member(1)
     package: ExcelScript!
     fullName: setQuartileCalculation(quartileCalculation)
     summary: Specifies if the quartile calculation type of a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,16 +103,20 @@ methods:
       parameters:
         - id: quartileCalculation
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartBoxQuartileCalculation:enum"
+            />
       return:
         type: void
         description: ''
   - name: setShowInnerPoints(showInnerPoints)
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowInnerPoints:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowInnerPoints:member(1)
     package: ExcelScript!
     fullName: setShowInnerPoints(showInnerPoints)
     summary: Specifies if inner points are shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -112,11 +129,12 @@ methods:
         type: void
         description: ''
   - name: setShowMeanLine(showMeanLine)
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowMeanLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowMeanLine:member(1)
     package: ExcelScript!
     fullName: setShowMeanLine(showMeanLine)
     summary: Specifies if the mean line is shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -129,11 +147,12 @@ methods:
         type: void
         description: ''
   - name: setShowMeanMarker(showMeanMarker)
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowMeanMarker:member(1)'
+    uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowMeanMarker:member(1)
     package: ExcelScript!
     fullName: setShowMeanMarker(showMeanMarker)
     summary: Specifies if the mean marker is shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -146,11 +165,13 @@ methods:
         type: void
         description: ''
   - name: setShowOutlierPoints(showOutlierPoints)
-    uid: 'ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowOutlierPoints:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartBoxwhiskerOptions#setShowOutlierPoints:member(1)
     package: ExcelScript!
     fullName: setShowOutlierPoints(showOutlierPoints)
     summary: Specifies if outlier points are shown in a box and whisker chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartcolorscheme.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartcolorscheme.yml
@@ -1,78 +1,79 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartColorScheme
-uid: 'ExcelScript!ExcelScript.ChartColorScheme:enum'
+uid: ExcelScript!ExcelScript.ChartColorScheme:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartColorScheme
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: colorfulPalette1
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette1:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette1:member
     package: ExcelScript!
     summary: ''
   - name: colorfulPalette2
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette2:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette2:member
     package: ExcelScript!
     summary: ''
   - name: colorfulPalette3
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette3:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette3:member
     package: ExcelScript!
     summary: ''
   - name: colorfulPalette4
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette4:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.colorfulPalette4:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette1
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette1:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette1:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette10
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette10:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette10:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette11
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette11:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette11:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette12
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette12:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette12:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette13
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette13:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette13:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette2
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette2:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette2:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette3
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette3:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette3:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette4
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette4:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette4:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette5
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette5:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette5:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette6
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette6:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette6:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette7
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette7:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette7:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette8
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette8:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette8:member
     package: ExcelScript!
     summary: ''
   - name: monochromaticPalette9
-    uid: 'ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette9:member'
+    uid: ExcelScript!ExcelScript.ChartColorScheme.monochromaticPalette9:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabel.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataLabel
-uid: 'ExcelScript!ExcelScript.ChartDataLabel:interface'
+uid: ExcelScript!ExcelScript.ChartDataLabel:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabel
 summary: Represents the data label of a chart point.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAutoText()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getAutoText:member(1)
     package: ExcelScript!
     fullName: getAutoText()
-    summary: Specifies if the data label automatically generates appropriate text based on context.
+    summary: >-
+      Specifies if the data label automatically generates appropriate text based
+      on context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,28 @@ methods:
         type: boolean
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Represents the format of chart data label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartDataLabelFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelFormat:interface" />
         description: ''
   - name: getFormula()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getFormula:member(1)
     package: ExcelScript!
     fullName: getFormula()
-    summary: String value that represents the formula of chart data label using A1-style notation.
+    summary: >-
+      String value that represents the formula of chart data label using
+      A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,26 +57,31 @@ methods:
         type: string
         description: ''
   - name: getGeometricShapeType()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: getGeometricShapeType()
     summary: >-
-      Specifies the geometric shape type of the data label. See `ExcelScript.GeometricShapeType` for more details. Value
-      is `null` if the data label is not a geometric shape.
+      Specifies the geometric shape type of the data label. See
+      `ExcelScript.GeometricShapeType` for more details. Value is `null` if the
+      data label is not a geometric shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGeometricShapeType(): GeometricShapeType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Returns the height, in points, of the chart data label. Value is `null` if the chart data label is not visible.'
+    summary: >-
+      Returns the height, in points, of the chart data label. Value is `null` if
+      the chart data label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,28 +90,34 @@ methods:
         type: number
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
     summary: >-
-      Represents the horizontal alignment for chart data label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      details. This property is valid only when `TextOrientation` of data label is -90, 90, or 180.
+      Represents the horizontal alignment for chart data label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when `TextOrientation` of data label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): ChartTextHorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum"
+          />
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Represents the distance, in points, from the left edge of chart data label to the left edge of chart area. Value
-      is `null` if the chart data label is not visible.
+      Represents the distance, in points, from the left edge of chart data label
+      to the left edge of chart area. Value is `null` if the chart data label is
+      not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -107,13 +126,14 @@ methods:
         type: number
         description: ''
   - name: getLinkNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: getLinkNumberFormat()
     summary: >-
-      Specifies if the number format is linked to the cells (so that the number format changes in the labels when it
-      changes in the cells).
+      Specifies if the number format is linked to the cells (so that the number
+      format changes in the labels when it changes in the cells).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -122,11 +142,12 @@ methods:
         type: boolean
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: String value that represents the format code for data label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,24 +156,28 @@ methods:
         type: string
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
-    summary: Value that represents the position of the data label. See `ExcelScript.ChartDataLabelPosition` for details.
+    summary: >-
+      Value that represents the position of the data label. See
+      `ExcelScript.ChartDataLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartDataLabelPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />
         description: ''
   - name: getSeparator()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getSeparator:member(1)
     package: ExcelScript!
     fullName: getSeparator()
     summary: String representing the separator used for the data label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -161,15 +186,18 @@ methods:
         type: string
         description: ''
   - name: getShowAsStickyCallout()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowAsStickyCallout:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowAsStickyCallout:member(1)
     package: ExcelScript!
     fullName: getShowAsStickyCallout()
     summary: >-
-      Gets a value that indicates whether the data labels are shown as a callout with the tail anchor attached to the
-      data point. If `true`<!-- -->, the callout is one of the following values: "AccentCallout1", "AccentCallout2",
-      "BorderCallout1", "BorderCallout2", "WedgeRectCallout", "WedgeRRectCallout" or "WedgeEllipseCallout". See
-      Excel.GeometricShapeType for more details.
+      Gets a value that indicates whether the data labels are shown as a callout
+      with the tail anchor attached to the data point. If `true`<!-- -->, the
+      callout is one of the following values: "AccentCallout1",
+      "AccentCallout2", "BorderCallout1", "BorderCallout2", "WedgeRectCallout",
+      "WedgeRRectCallout" or "WedgeEllipseCallout". See Excel.GeometricShapeType
+      for more details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -178,11 +206,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowBubbleSize()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowBubbleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowBubbleSize:member(1)
     package: ExcelScript!
     fullName: getShowBubbleSize()
     summary: Specifies if the data label bubble size is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -191,11 +220,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowCategoryName()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowCategoryName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowCategoryName:member(1)
     package: ExcelScript!
     fullName: getShowCategoryName()
     summary: Specifies if the data label category name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -204,11 +234,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowLegendKey()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowLegendKey:member(1)
     package: ExcelScript!
     fullName: getShowLegendKey()
     summary: Specifies if the data label legend key is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -217,11 +248,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowPercentage()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowPercentage:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowPercentage:member(1)
     package: ExcelScript!
     fullName: getShowPercentage()
     summary: Specifies if the data label percentage is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -230,11 +262,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowSeriesName()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowSeriesName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowSeriesName:member(1)
     package: ExcelScript!
     fullName: getShowSeriesName()
     summary: Specifies if the data label series name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -243,11 +276,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowValue()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getShowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getShowValue:member(1)
     package: ExcelScript!
     fullName: getShowValue()
     summary: Specifies if the data label value is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -255,47 +289,57 @@ methods:
       return:
         type: boolean
         description: ''
-  - name: 'getSubstring(start, length)'
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getSubstring:member(1)'
+  - name: getSubstring(start, length)
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getSubstring:member(1)
     package: ExcelScript!
-    fullName: 'getSubstring(start, length)'
-    summary: Returns a substring of the data label. The line break character '<!-- -->\\<!-- -->n' counts as one character.
+    fullName: getSubstring(start, length)
+    summary: >-
+      Returns a substring of the data label. The line break character '<!--
+      -->\\<!-- -->n' counts as one character.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSubstring(start: number, length?: number): ChartFormatString;'
       parameters:
         - id: start
-          description: The zero-based starting character position of a substring in the data label.
+          description: >-
+            The zero-based starting character position of a substring in the
+            data label.
           type: number
         - id: length
           description: >-
-            Optional. The number of characters in the substring. If length is omitted, all the characters from start to
-            the end of the data label are retrieved.
+            Optional. The number of characters in the substring. If length is
+            omitted, all the characters from start to the end of the data label
+            are retrieved.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFormatString:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFormatString:interface" />
         description: ''
   - name: getTailAnchor()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getTailAnchor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getTailAnchor:member(1)
     package: ExcelScript!
     fullName: getTailAnchor()
-    summary: Returns the tail anchor of the data label which is shown as a sticky callout.
+    summary: >-
+      Returns the tail anchor of the data label which is shown as a sticky
+      callout.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTailAnchor(): ChartDataLabelAnchor;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelAnchor:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelAnchor:interface" />
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: String representing the text of the data label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -304,13 +348,15 @@ methods:
         type: string
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Represents the angle to which the text is oriented for the chart data label. The value should either be an integer
-      from -90 to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for the chart data
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -319,13 +365,15 @@ methods:
         type: number
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Represents the distance, in points, from the top edge of chart data label to the top of chart area. Value is
-      `null` if the chart data label is not visible.
+      Represents the distance, in points, from the top edge of chart data label
+      to the top of chart area. Value is `null` if the chart data label is not
+      visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -334,26 +382,31 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
     summary: >-
-      Represents the vertical alignment of chart data label. See `ExcelScript.ChartTextVerticalAlignment` for details.
-      This property is valid only when `TextOrientation` of data label is 0.
+      Represents the vertical alignment of chart data label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of data label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): ChartTextVerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Returns the width, in points, of the chart data label. Value is `null` if the chart data label is not visible.'
+    summary: >-
+      Returns the width, in points, of the chart data label. Value is `null` if
+      the chart data label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -362,11 +415,14 @@ methods:
         type: number
         description: ''
   - name: setAutoText(autoText)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setAutoText:member(1)
     package: ExcelScript!
     fullName: setAutoText(autoText)
-    summary: Specifies if the data label automatically generates appropriate text based on context.
+    summary: >-
+      Specifies if the data label automatically generates appropriate text based
+      on context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -379,11 +435,14 @@ methods:
         type: void
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: String value that represents the formula of chart data label using A1-style notation.
+    summary: >-
+      String value that represents the formula of chart data label using
+      A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -396,13 +455,15 @@ methods:
         type: void
         description: ''
   - name: setGeometricShapeType(geometricShapeType)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: setGeometricShapeType(geometricShapeType)
     summary: >-
-      Specifies the geometric shape type of the data label. See `ExcelScript.GeometricShapeType` for more details. Value
-      is `null` if the data label is not a geometric shape.
+      Specifies the geometric shape type of the data label. See
+      `ExcelScript.GeometricShapeType` for more details. Value is `null` if the
+      data label is not a geometric shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -410,16 +471,17 @@ methods:
       parameters:
         - id: geometricShapeType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
       return:
         type: void
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
     summary: Sets the height of the data label in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -432,13 +494,15 @@ methods:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
     summary: >-
-      Represents the horizontal alignment for chart data label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      details. This property is valid only when `TextOrientation` of data label is -90, 90, or 180.
+      Represents the horizontal alignment for chart data label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when `TextOrientation` of data label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -449,18 +513,22 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      Represents the distance, in points, from the left edge of chart data label to the left edge of chart area. Value
-      is `null` if the chart data label is not visible.
+      Represents the distance, in points, from the left edge of chart data label
+      to the left edge of chart area. Value is `null` if the chart data label is
+      not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -473,13 +541,14 @@ methods:
         type: void
         description: ''
   - name: setLinkNumberFormat(linkNumberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: setLinkNumberFormat(linkNumberFormat)
     summary: >-
-      Specifies if the number format is linked to the cells (so that the number format changes in the labels when it
-      changes in the cells).
+      Specifies if the number format is linked to the cells (so that the number
+      format changes in the labels when it changes in the cells).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -492,11 +561,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: String value that represents the format code for data label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -509,11 +579,14 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
-    summary: Value that represents the position of the data label. See `ExcelScript.ChartDataLabelPosition` for details.
+    summary: >-
+      Value that represents the position of the data label. See
+      `ExcelScript.ChartDataLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -521,16 +594,17 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />
       return:
         type: void
         description: ''
   - name: setSeparator(separator)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setSeparator:member(1)
     package: ExcelScript!
     fullName: setSeparator(separator)
     summary: String representing the separator used for the data label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -543,11 +617,12 @@ methods:
         type: void
         description: ''
   - name: setShowBubbleSize(showBubbleSize)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowBubbleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowBubbleSize:member(1)
     package: ExcelScript!
     fullName: setShowBubbleSize(showBubbleSize)
     summary: Specifies if the data label bubble size is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -560,11 +635,12 @@ methods:
         type: void
         description: ''
   - name: setShowCategoryName(showCategoryName)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowCategoryName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowCategoryName:member(1)
     package: ExcelScript!
     fullName: setShowCategoryName(showCategoryName)
     summary: Specifies if the data label category name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -577,11 +653,12 @@ methods:
         type: void
         description: ''
   - name: setShowLegendKey(showLegendKey)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowLegendKey:member(1)
     package: ExcelScript!
     fullName: setShowLegendKey(showLegendKey)
     summary: Specifies if the data label legend key is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -594,11 +671,12 @@ methods:
         type: void
         description: ''
   - name: setShowPercentage(showPercentage)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowPercentage:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowPercentage:member(1)
     package: ExcelScript!
     fullName: setShowPercentage(showPercentage)
     summary: Specifies if the data label percentage is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -611,11 +689,12 @@ methods:
         type: void
         description: ''
   - name: setShowSeriesName(showSeriesName)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowSeriesName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowSeriesName:member(1)
     package: ExcelScript!
     fullName: setShowSeriesName(showSeriesName)
     summary: Specifies if the data label series name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -628,11 +707,12 @@ methods:
         type: void
         description: ''
   - name: setShowValue(showValue)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setShowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setShowValue:member(1)
     package: ExcelScript!
     fullName: setShowValue(showValue)
     summary: Specifies if the data label value is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -645,11 +725,12 @@ methods:
         type: void
         description: ''
   - name: setText(text)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setText:member(1)
     package: ExcelScript!
     fullName: setText(text)
     summary: String representing the text of the data label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -662,13 +743,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Represents the angle to which the text is oriented for the chart data label. The value should either be an integer
-      from -90 to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for the chart data
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -681,13 +764,15 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Represents the distance, in points, from the top edge of chart data label to the top of chart area. Value is
-      `null` if the chart data label is not visible.
+      Represents the distance, in points, from the top edge of chart data label
+      to the top of chart area. Value is `null` if the chart data label is not
+      visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -700,13 +785,15 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
     summary: >-
-      Represents the vertical alignment of chart data label. See `ExcelScript.ChartTextVerticalAlignment` for details.
-      This property is valid only when `TextOrientation` of data label is 0.
+      Represents the vertical alignment of chart data label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of data label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -717,16 +804,19 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum"
+            />
       return:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabel#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabel#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
     summary: Sets the width of the data label in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelanchor.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelanchor.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataLabelAnchor
-uid: 'ExcelScript!ExcelScript.ChartDataLabelAnchor:interface'
+uid: ExcelScript!ExcelScript.ChartDataLabelAnchor:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelAnchor
 summary: Represents the chart data label anchor.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelAnchor#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelAnchor#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Represents the distance, in points, from the anchor to the left edge of the chart data label. Note that when
-      getting the value, it may differ slightly from the set value.
+      Represents the distance, in points, from the anchor to the left edge of
+      the chart data label. Note that when getting the value, it may differ
+      slightly from the set value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,13 +28,15 @@ methods:
         type: number
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelAnchor#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelAnchor#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Represents the distance, in points, from the anchor to the top edge of the chart data label. Note that when
-      getting the value, it may differ slightly from the set value.
+      Represents the distance, in points, from the anchor to the top edge of the
+      chart data label. Note that when getting the value, it may differ slightly
+      from the set value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,13 +45,15 @@ methods:
         type: number
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelAnchor#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelAnchor#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      Represents the distance, in points, from the anchor to the left edge of the chart data label. Note that when
-      getting the value, it may differ slightly from the set value.
+      Represents the distance, in points, from the anchor to the left edge of
+      the chart data label. Note that when getting the value, it may differ
+      slightly from the set value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -59,13 +66,15 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelAnchor#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelAnchor#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Represents the distance, in points, from the anchor to the top edge of the chart data label. Note that when
-      getting the value, it may differ slightly from the set value.
+      Represents the distance, in points, from the anchor to the top edge of the
+      chart data label. Note that when getting the value, it may differ slightly
+      from the set value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelformat.yml
@@ -1,50 +1,56 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataLabelFormat
-uid: 'ExcelScript!ExcelScript.ChartDataLabelFormat:interface'
+uid: ExcelScript!ExcelScript.ChartDataLabelFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelFormat
 summary: Encapsulates the format properties for the chart data labels.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format, which includes color, linestyle, and weight.'
+    summary: Represents the border format, which includes color, linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Represents the fill format of the current chart data label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabelFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes (such as font name, font size, and color) for a chart data label.'
+    summary: >-
+      Represents the font attributes (such as font name, font size, and color)
+      for a chart data label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabelposition.yml
@@ -1,58 +1,59 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartDataLabelPosition
-uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition:enum'
+uid: ExcelScript!ExcelScript.ChartDataLabelPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelPosition
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bestFit
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.bestFit:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.bestFit:member
     package: ExcelScript!
     summary: ''
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.bottom:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.bottom:member
     package: ExcelScript!
     summary: ''
   - name: callout
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.callout:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.callout:member
     package: ExcelScript!
     summary: ''
   - name: center
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.center:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.center:member
     package: ExcelScript!
     summary: ''
   - name: insideBase
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.insideBase:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.insideBase:member
     package: ExcelScript!
     summary: ''
   - name: insideEnd
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.insideEnd:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.insideEnd:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.invalid:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.invalid:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.left:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.left:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.none:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.none:member
     package: ExcelScript!
     summary: ''
   - name: outsideEnd
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.outsideEnd:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.outsideEnd:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.right:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.right:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ChartDataLabelPosition.top:member'
+    uid: ExcelScript!ExcelScript.ChartDataLabelPosition.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatalabels.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataLabels
-uid: 'ExcelScript!ExcelScript.ChartDataLabels:interface'
+uid: ExcelScript!ExcelScript.ChartDataLabels:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabels
 summary: Represents a collection of all the data labels on a chart point.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAutoText()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getAutoText:member(1)
     package: ExcelScript!
     fullName: getAutoText()
-    summary: Specifies if data labels automatically generate appropriate text based on context.
+    summary: >-
+      Specifies if data labels automatically generate appropriate text based on
+      context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,69 +27,80 @@ methods:
         type: boolean
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Specifies the format of chart data labels, which includes fill and font formatting.'
+    summary: >-
+      Specifies the format of chart data labels, which includes fill and font
+      formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartDataLabelFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelFormat:interface" />
         description: ''
   - name: getGeometricShapeType()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: getGeometricShapeType()
     summary: >-
-      Specifies the geometric shape type of the data labels. See `ExcelScript.GeometricShapeType` for more details.
-      Value is `null` if the data labels are not geometric shapes.
+      Specifies the geometric shape type of the data labels. See
+      `ExcelScript.GeometricShapeType` for more details. Value is `null` if the
+      data labels are not geometric shapes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGeometricShapeType(): GeometricShapeType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
     summary: >-
-      Specifies the horizontal alignment for chart data label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      details. This property is valid only when the `TextOrientation` of data label is 0.
+      Specifies the horizontal alignment for chart data label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when the `TextOrientation` of data label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): ChartTextHorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum"
+          />
         description: ''
   - name: getLeaderLines()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getLeaderLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getLeaderLines:member(1)
     package: ExcelScript!
     fullName: getLeaderLines()
     summary: Gets an object that represents the leader lines of the data labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLeaderLines(): ChartLeaderLines;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLeaderLines:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLeaderLines:interface" />
         description: ''
   - name: getLinkNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: getLinkNumberFormat()
     summary: >-
-      Specifies if the number format is linked to the cells. If `true`<!-- -->, the number format will change in the
-      labels when it changes in the cells.
+      Specifies if the number format is linked to the cells. If `true`<!-- -->,
+      the number format will change in the labels when it changes in the cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -94,11 +109,12 @@ methods:
         type: boolean
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: Specifies the format code for data labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -107,24 +123,28 @@ methods:
         type: string
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
-    summary: Value that represents the position of the data label. See `ExcelScript.ChartDataLabelPosition` for details.
+    summary: >-
+      Value that represents the position of the data label. See
+      `ExcelScript.ChartDataLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartDataLabelPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />
         description: ''
   - name: getSeparator()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getSeparator:member(1)
     package: ExcelScript!
     fullName: getSeparator()
     summary: String representing the separator used for the data labels on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -133,15 +153,18 @@ methods:
         type: string
         description: ''
   - name: getShowAsStickyCallout()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowAsStickyCallout:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowAsStickyCallout:member(1)
     package: ExcelScript!
     fullName: getShowAsStickyCallout()
     summary: >-
-      Gets a value that indicates whether the data labels are shown as a callout with the tail anchor attached to the
-      data point. If `true`<!-- -->, the callout is one of the following values: "AccentCallout1", "AccentCallout2",
-      "BorderCallout1", "BorderCallout2", "WedgeRectCallout", "WedgeRRectCallout" or "WedgeEllipseCallout". See
-      Excel.GeometricShapeType for more details.
+      Gets a value that indicates whether the data labels are shown as a callout
+      with the tail anchor attached to the data point. If `true`<!-- -->, the
+      callout is one of the following values: "AccentCallout1",
+      "AccentCallout2", "BorderCallout1", "BorderCallout2", "WedgeRectCallout",
+      "WedgeRRectCallout" or "WedgeEllipseCallout". See Excel.GeometricShapeType
+      for more details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -150,11 +173,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowBubbleSize()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowBubbleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowBubbleSize:member(1)
     package: ExcelScript!
     fullName: getShowBubbleSize()
     summary: Specifies if the data label bubble size is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -163,11 +187,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowCategoryName()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowCategoryName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowCategoryName:member(1)
     package: ExcelScript!
     fullName: getShowCategoryName()
     summary: Specifies if the data label category name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -176,13 +201,15 @@ methods:
         type: boolean
         description: ''
   - name: getShowLeaderLines()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowLeaderLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowLeaderLines:member(1)
     package: ExcelScript!
     fullName: getShowLeaderLines()
     summary: >-
-      Specifies a value that indicates whether leader lines are displayed for the data labels. `true` if leader lines
-      are shown; otherwise, `false`<!-- -->.
+      Specifies a value that indicates whether leader lines are displayed for
+      the data labels. `true` if leader lines are shown; otherwise, `false`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -191,11 +218,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowLegendKey()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowLegendKey:member(1)
     package: ExcelScript!
     fullName: getShowLegendKey()
     summary: Specifies if the data label legend key is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -204,11 +232,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowPercentage()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowPercentage:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowPercentage:member(1)
     package: ExcelScript!
     fullName: getShowPercentage()
     summary: Specifies if the data label percentage is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -217,11 +246,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowSeriesName()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowSeriesName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowSeriesName:member(1)
     package: ExcelScript!
     fullName: getShowSeriesName()
     summary: Specifies if the data label series name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -230,11 +260,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowValue()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getShowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getShowValue:member(1)
     package: ExcelScript!
     fullName: getShowValue()
     summary: Specifies if the data label value is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -243,13 +274,15 @@ methods:
         type: boolean
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Represents the angle to which the text is oriented for data labels. The value should either be an integer from -90
-      to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for data labels. The
+      value should either be an integer from -90 to 90 or the integer 180 for
+      vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -258,26 +291,31 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
     summary: >-
-      Represents the vertical alignment of chart data label. See `ExcelScript.ChartTextVerticalAlignment` for details.
-      This property is valid only when `TextOrientation` of the data label is -90, 90, or 180.
+      Represents the vertical alignment of chart data label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of the data label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): ChartTextVerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />
         description: ''
   - name: setAutoText(autoText)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setAutoText:member(1)
     package: ExcelScript!
     fullName: setAutoText(autoText)
-    summary: Specifies if data labels automatically generate appropriate text based on context.
+    summary: >-
+      Specifies if data labels automatically generate appropriate text based on
+      context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -290,13 +328,15 @@ methods:
         type: void
         description: ''
   - name: setGeometricShapeType(geometricShapeType)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: setGeometricShapeType(geometricShapeType)
     summary: >-
-      Specifies the geometric shape type of the data labels. See `ExcelScript.GeometricShapeType` for more details.
-      Value is `null` if the data labels are not geometric shapes.
+      Specifies the geometric shape type of the data labels. See
+      `ExcelScript.GeometricShapeType` for more details. Value is `null` if the
+      data labels are not geometric shapes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -304,18 +344,20 @@ methods:
       parameters:
         - id: geometricShapeType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
       return:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
     summary: >-
-      Specifies the horizontal alignment for chart data label. See `ExcelScript.ChartTextHorizontalAlignment` for
-      details. This property is valid only when the `TextOrientation` of data label is 0.
+      Specifies the horizontal alignment for chart data label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when the `TextOrientation` of data label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -326,18 +368,21 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setLinkNumberFormat(linkNumberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: setLinkNumberFormat(linkNumberFormat)
     summary: >-
-      Specifies if the number format is linked to the cells. If `true`<!-- -->, the number format will change in the
-      labels when it changes in the cells.
+      Specifies if the number format is linked to the cells. If `true`<!-- -->,
+      the number format will change in the labels when it changes in the cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -350,11 +395,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: Specifies the format code for data labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -367,11 +413,14 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
-    summary: Value that represents the position of the data label. See `ExcelScript.ChartDataLabelPosition` for details.
+    summary: >-
+      Value that represents the position of the data label. See
+      `ExcelScript.ChartDataLabelPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -379,16 +428,17 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartDataLabelPosition:enum" />
       return:
         type: void
         description: ''
   - name: setSeparator(separator)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setSeparator:member(1)
     package: ExcelScript!
     fullName: setSeparator(separator)
     summary: String representing the separator used for the data labels on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -401,11 +451,12 @@ methods:
         type: void
         description: ''
   - name: setShowBubbleSize(showBubbleSize)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowBubbleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowBubbleSize:member(1)
     package: ExcelScript!
     fullName: setShowBubbleSize(showBubbleSize)
     summary: Specifies if the data label bubble size is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -418,11 +469,12 @@ methods:
         type: void
         description: ''
   - name: setShowCategoryName(showCategoryName)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowCategoryName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowCategoryName:member(1)
     package: ExcelScript!
     fullName: setShowCategoryName(showCategoryName)
     summary: Specifies if the data label category name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -435,13 +487,15 @@ methods:
         type: void
         description: ''
   - name: setShowLeaderLines(showLeaderLines)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowLeaderLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowLeaderLines:member(1)
     package: ExcelScript!
     fullName: setShowLeaderLines(showLeaderLines)
     summary: >-
-      Specifies a value that indicates whether leader lines are displayed for the data labels. `true` if leader lines
-      are shown; otherwise, `false`<!-- -->.
+      Specifies a value that indicates whether leader lines are displayed for
+      the data labels. `true` if leader lines are shown; otherwise, `false`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -454,11 +508,12 @@ methods:
         type: void
         description: ''
   - name: setShowLegendKey(showLegendKey)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowLegendKey:member(1)
     package: ExcelScript!
     fullName: setShowLegendKey(showLegendKey)
     summary: Specifies if the data label legend key is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -471,11 +526,12 @@ methods:
         type: void
         description: ''
   - name: setShowPercentage(showPercentage)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowPercentage:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowPercentage:member(1)
     package: ExcelScript!
     fullName: setShowPercentage(showPercentage)
     summary: Specifies if the data label percentage is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -488,11 +544,12 @@ methods:
         type: void
         description: ''
   - name: setShowSeriesName(showSeriesName)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowSeriesName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowSeriesName:member(1)
     package: ExcelScript!
     fullName: setShowSeriesName(showSeriesName)
     summary: Specifies if the data label series name is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -505,11 +562,12 @@ methods:
         type: void
         description: ''
   - name: setShowValue(showValue)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setShowValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setShowValue:member(1)
     package: ExcelScript!
     fullName: setShowValue(showValue)
     summary: Specifies if the data label value is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -522,13 +580,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Represents the angle to which the text is oriented for data labels. The value should either be an integer from -90
-      to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for data labels. The
+      value should either be an integer from -90 to 90 or the integer 180 for
+      vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -541,13 +601,15 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartDataLabels#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataLabels#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
     summary: >-
-      Represents the vertical alignment of chart data label. See `ExcelScript.ChartTextVerticalAlignment` for details.
-      This property is valid only when `TextOrientation` of the data label is -90, 90, or 180.
+      Represents the vertical alignment of chart data label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of the data label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -558,7 +620,9 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatasourcetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatasourcetype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartDataSourceType
-uid: 'ExcelScript!ExcelScript.ChartDataSourceType:enum'
+uid: ExcelScript!ExcelScript.ChartDataSourceType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDataSourceType
 summary: Specifies the data source type of the chart series.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: externalRange
-    uid: 'ExcelScript!ExcelScript.ChartDataSourceType.externalRange:member'
+    uid: ExcelScript!ExcelScript.ChartDataSourceType.externalRange:member
     package: ExcelScript!
     summary: The data source type of the chart series is an external range.
   - name: list
-    uid: 'ExcelScript!ExcelScript.ChartDataSourceType.list:member'
+    uid: ExcelScript!ExcelScript.ChartDataSourceType.list:member
     package: ExcelScript!
     summary: The data source type of the chart series is a list.
   - name: localRange
-    uid: 'ExcelScript!ExcelScript.ChartDataSourceType.localRange:member'
+    uid: ExcelScript!ExcelScript.ChartDataSourceType.localRange:member
     package: ExcelScript!
     summary: The data source type of the chart series is a local range.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.ChartDataSourceType.unknown:member'
+    uid: ExcelScript!ExcelScript.ChartDataSourceType.unknown:member
     package: ExcelScript!
     summary: The data source type of the chart series is unknown or unsupported.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatatable.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatatable.yml
@@ -1,33 +1,38 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataTable
-uid: 'ExcelScript!ExcelScript.ChartDataTable:interface'
+uid: ExcelScript!ExcelScript.ChartDataTable:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataTable
 summary: Represents the data table object of a chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Represents the format of a chart data table, which includes fill, font, and border format.'
+    summary: >-
+      Represents the format of a chart data table, which includes fill, font,
+      and border format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartDataTableFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataTableFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataTableFormat:interface" />
         description: ''
   - name: getShowHorizontalBorder()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getShowHorizontalBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getShowHorizontalBorder:member(1)
     package: ExcelScript!
     fullName: getShowHorizontalBorder()
     summary: Specifies whether to display the horizontal border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +41,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowLegendKey()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getShowLegendKey:member(1)
     package: ExcelScript!
     fullName: getShowLegendKey()
     summary: Specifies whether to show the legend key of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +55,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowOutlineBorder()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getShowOutlineBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getShowOutlineBorder:member(1)
     package: ExcelScript!
     fullName: getShowOutlineBorder()
     summary: Specifies whether to display the outline border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +69,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowVerticalBorder()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getShowVerticalBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getShowVerticalBorder:member(1)
     package: ExcelScript!
     fullName: getShowVerticalBorder()
     summary: Specifies whether to display the vertical border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +83,12 @@ methods:
         type: boolean
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies whether to show the data table of the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +97,12 @@ methods:
         type: boolean
         description: ''
   - name: setShowHorizontalBorder(showHorizontalBorder)
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#setShowHorizontalBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#setShowHorizontalBorder:member(1)
     package: ExcelScript!
     fullName: setShowHorizontalBorder(showHorizontalBorder)
     summary: Specifies whether to display the horizontal border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -105,11 +115,12 @@ methods:
         type: void
         description: ''
   - name: setShowLegendKey(showLegendKey)
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#setShowLegendKey:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#setShowLegendKey:member(1)
     package: ExcelScript!
     fullName: setShowLegendKey(showLegendKey)
     summary: Specifies whether to show the legend key of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -122,11 +133,12 @@ methods:
         type: void
         description: ''
   - name: setShowOutlineBorder(showOutlineBorder)
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#setShowOutlineBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#setShowOutlineBorder:member(1)
     package: ExcelScript!
     fullName: setShowOutlineBorder(showOutlineBorder)
     summary: Specifies whether to display the outline border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -139,11 +151,12 @@ methods:
         type: void
         description: ''
   - name: setShowVerticalBorder(showVerticalBorder)
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#setShowVerticalBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#setShowVerticalBorder:member(1)
     package: ExcelScript!
     fullName: setShowVerticalBorder(showVerticalBorder)
     summary: Specifies whether to display the vertical border of the data table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -156,11 +169,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartDataTable#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTable#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies whether to show the data table of the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatatableformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdatatableformat.yml
@@ -1,50 +1,60 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartDataTableFormat
-uid: 'ExcelScript!ExcelScript.ChartDataTableFormat:interface'
+uid: ExcelScript!ExcelScript.ChartDataTableFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataTableFormat
 summary: Represents the format of a chart data table.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartDataTableFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTableFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format of chart data table, which includes color, line style, and weight.'
+    summary: >-
+      Represents the border format of chart data table, which includes color,
+      line style, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartDataTableFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTableFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of an object, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of an object, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartDataTableFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartDataTableFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes (such as font name, font size, and color) for the current object.'
+    summary: >-
+      Represents the font attributes (such as font name, font size, and color)
+      for the current object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdisplayblanksas.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartdisplayblanksas.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartDisplayBlanksAs
-uid: 'ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum'
+uid: ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDisplayBlanksAs
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: interplotted
-    uid: 'ExcelScript!ExcelScript.ChartDisplayBlanksAs.interplotted:member'
+    uid: ExcelScript!ExcelScript.ChartDisplayBlanksAs.interplotted:member
     package: ExcelScript!
     summary: ''
   - name: notPlotted
-    uid: 'ExcelScript!ExcelScript.ChartDisplayBlanksAs.notPlotted:member'
+    uid: ExcelScript!ExcelScript.ChartDisplayBlanksAs.notPlotted:member
     package: ExcelScript!
     summary: ''
   - name: zero
-    uid: 'ExcelScript!ExcelScript.ChartDisplayBlanksAs.zero:member'
+    uid: ExcelScript!ExcelScript.ChartDisplayBlanksAs.zero:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbars.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartErrorBars
-uid: 'ExcelScript!ExcelScript.ChartErrorBars:interface'
+uid: ExcelScript!ExcelScript.ChartErrorBars:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBars
 summary: This object represents the attributes for a chart's error bars.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getEndStyleCap()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#getEndStyleCap:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#getEndStyleCap:member(1)
     package: ExcelScript!
     fullName: getEndStyleCap()
     summary: Specifies if error bars have an end style cap.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,50 +25,54 @@ methods:
         type: boolean
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Specifies the formatting type of the error bars.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartErrorBarsFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBarsFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartErrorBarsFormat:interface" />
         description: ''
   - name: getInclude()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#getInclude:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#getInclude:member(1)
     package: ExcelScript!
     fullName: getInclude()
     summary: Specifies which parts of the error bars to include.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getInclude(): ChartErrorBarsInclude;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBarsInclude:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartErrorBarsInclude:enum" />
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: The type of range marked by the error bars.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ChartErrorBarsType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBarsType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartErrorBarsType:enum" />
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies whether the error bars are displayed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +81,12 @@ methods:
         type: boolean
         description: ''
   - name: setEndStyleCap(endStyleCap)
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#setEndStyleCap:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#setEndStyleCap:member(1)
     package: ExcelScript!
     fullName: setEndStyleCap(endStyleCap)
     summary: Specifies if error bars have an end style cap.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -92,11 +99,12 @@ methods:
         type: void
         description: ''
   - name: setInclude(include)
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#setInclude:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#setInclude:member(1)
     package: ExcelScript!
     fullName: setInclude(include)
     summary: Specifies which parts of the error bars to include.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -104,16 +112,17 @@ methods:
       parameters:
         - id: include
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBarsInclude:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartErrorBarsInclude:enum" />
       return:
         type: void
         description: ''
   - name: setType(type)
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#setType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#setType:member(1)
     package: ExcelScript!
     fullName: setType(type)
     summary: The type of range marked by the error bars.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -121,16 +130,17 @@ methods:
       parameters:
         - id: type
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBarsType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartErrorBarsType:enum" />
       return:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartErrorBars#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBars#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies whether the error bars are displayed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarsformat.yml
@@ -1,24 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartErrorBarsFormat
-uid: 'ExcelScript!ExcelScript.ChartErrorBarsFormat:interface'
+uid: ExcelScript!ExcelScript.ChartErrorBarsFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsFormat
 summary: Encapsulates the format properties for chart error bars.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Represents the chart line formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarsinclude.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarsinclude.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartErrorBarsInclude
-uid: 'ExcelScript!ExcelScript.ChartErrorBarsInclude:enum'
+uid: ExcelScript!ExcelScript.ChartErrorBarsInclude:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsInclude
 summary: Represents which parts of the error bar to include.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: both
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsInclude.both:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsInclude.both:member
     package: ExcelScript!
     summary: ''
   - name: minusValues
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsInclude.minusValues:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsInclude.minusValues:member
     package: ExcelScript!
     summary: ''
   - name: plusValues
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsInclude.plusValues:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsInclude.plusValues:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarstype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charterrorbarstype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartErrorBarsType
-uid: 'ExcelScript!ExcelScript.ChartErrorBarsType:enum'
+uid: ExcelScript!ExcelScript.ChartErrorBarsType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsType
 summary: Represents the range type for error bars.
@@ -29,26 +29,27 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsType.custom:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsType.custom:member
     package: ExcelScript!
     summary: ''
   - name: fixedValue
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsType.fixedValue:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsType.fixedValue:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsType.percent:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsType.percent:member
     package: ExcelScript!
     summary: ''
   - name: stDev
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsType.stDev:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsType.stDev:member
     package: ExcelScript!
     summary: ''
   - name: stError
-    uid: 'ExcelScript!ExcelScript.ChartErrorBarsType.stError:member'
+    uid: ExcelScript!ExcelScript.ChartErrorBarsType.stError:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartfill.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartfill.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartFill
-uid: 'ExcelScript!ExcelScript.ChartFill:interface'
+uid: ExcelScript!ExcelScript.ChartFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartFill
 summary: Represents the fill formatting for a chart element.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ChartFill#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFill#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clears the fill color of a chart element.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getSolidColor()
-    uid: 'ExcelScript!ExcelScript.ChartFill#getSolidColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFill#getSolidColor:member(1)
     package: ExcelScript!
     fullName: getSolidColor()
     summary: Gets the uniform color fill formatting of a chart element.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: string
         description: ''
   - name: setSolidColor(color)
-    uid: 'ExcelScript!ExcelScript.ChartFill#setSolidColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFill#setSolidColor:member(1)
     package: ExcelScript!
     fullName: setSolidColor(color)
     summary: Sets the fill formatting of a chart element to a uniform color.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -48,8 +52,9 @@ methods:
       parameters:
         - id: color
           description: >-
-            HTML color code representing the color of the background, in the form \#RRGGBB (e.g., "FFA500") or as a
-            named HTML color (e.g., "orange").
+            HTML color code representing the color of the background, in the
+            form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
+            "orange").
           type: string
       return:
         type: void

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartfont.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartfont.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartFont
-uid: 'ExcelScript!ExcelScript.ChartFont:interface'
+uid: ExcelScript!ExcelScript.ChartFont:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartFont
-summary: 'This object represents the font attributes (such as font name, font size, and color) for a chart object.'
+summary: >-
+  This object represents the font attributes (such as font name, font size, and
+  color) for a chart object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBold()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getBold:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getBold:member(1)
     package: ExcelScript!
     fullName: getBold()
     summary: Represents the bold status of font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +27,14 @@ methods:
         type: boolean
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +43,12 @@ methods:
         type: string
         description: ''
   - name: getItalic()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getItalic:member(1)
     package: ExcelScript!
     fullName: getItalic()
     summary: Represents the italic status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getName:member(1)
     package: ExcelScript!
     fullName: getName()
-    summary: 'Font name (e.g., "Calibri")'
+    summary: Font name (e.g., "Calibri")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,12 @@ methods:
         type: string
         description: ''
   - name: getSize()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getSize:member(1)
     package: ExcelScript!
     fullName: getSize()
-    summary: 'Size of the font (e.g., 11)'
+    summary: Size of the font (e.g., 11)
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,24 +85,28 @@ methods:
         type: number
         description: ''
   - name: getUnderline()
-    uid: 'ExcelScript!ExcelScript.ChartFont#getUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#getUnderline:member(1)
     package: ExcelScript!
     fullName: getUnderline()
-    summary: Type of underline applied to the font. See `ExcelScript.ChartUnderlineStyle` for details.
+    summary: >-
+      Type of underline applied to the font. See
+      `ExcelScript.ChartUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getUnderline(): ChartUnderlineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartUnderlineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartUnderlineStyle:enum" />
         description: ''
   - name: setBold(bold)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setBold:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setBold:member(1)
     package: ExcelScript!
     fullName: setBold(bold)
     summary: Represents the bold status of font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -105,11 +119,14 @@ methods:
         type: void
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -122,11 +139,12 @@ methods:
         type: void
         description: ''
   - name: setItalic(italic)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setItalic:member(1)
     package: ExcelScript!
     fullName: setItalic(italic)
     summary: Represents the italic status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -139,11 +157,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
-    summary: 'Font name (e.g., "Calibri")'
+    summary: Font name (e.g., "Calibri")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -156,11 +175,12 @@ methods:
         type: void
         description: ''
   - name: setSize(size)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setSize:member(1)
     package: ExcelScript!
     fullName: setSize(size)
-    summary: 'Size of the font (e.g., 11)'
+    summary: Size of the font (e.g., 11)
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -173,11 +193,14 @@ methods:
         type: void
         description: ''
   - name: setUnderline(underline)
-    uid: 'ExcelScript!ExcelScript.ChartFont#setUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFont#setUnderline:member(1)
     package: ExcelScript!
     fullName: setUnderline(underline)
-    summary: Type of underline applied to the font. See `ExcelScript.ChartUnderlineStyle` for details.
+    summary: >-
+      Type of underline applied to the font. See
+      `ExcelScript.ChartUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -185,7 +208,7 @@ methods:
       parameters:
         - id: underline
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartUnderlineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartUnderlineStyle:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartformatstring.yml
@@ -1,26 +1,30 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartFormatString
-uid: 'ExcelScript!ExcelScript.ChartFormatString:interface'
+uid: ExcelScript!ExcelScript.ChartFormatString:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartFormatString
 summary: >-
-  Represents the substring in chart related objects that contain text, like a `ChartTitle` object or `ChartAxisTitle`
-  object.
+  Represents the substring in chart related objects that contain text, like a
+  `ChartTitle` object or `ChartAxisTitle` object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartFormatString#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartFormatString#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes, such as font name, font size, and color of a chart characters object.'
+    summary: >-
+      Represents the font attributes, such as font name, font size, and color of
+      a chart characters object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgradientstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgradientstyle.yml
@@ -1,18 +1,21 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartGradientStyle
-uid: 'ExcelScript!ExcelScript.ChartGradientStyle:enum'
+uid: ExcelScript!ExcelScript.ChartGradientStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartGradientStyle
-summary: Represents the gradient style of a chart series. This is only applicable for region map charts.
+summary: >-
+  Represents the gradient style of a chart series. This is only applicable for
+  region map charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: threePhaseColor
-    uid: 'ExcelScript!ExcelScript.ChartGradientStyle.threePhaseColor:member'
+    uid: ExcelScript!ExcelScript.ChartGradientStyle.threePhaseColor:member
     package: ExcelScript!
     summary: ''
   - name: twoPhaseColor
-    uid: 'ExcelScript!ExcelScript.ChartGradientStyle.twoPhaseColor:member'
+    uid: ExcelScript!ExcelScript.ChartGradientStyle.twoPhaseColor:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgradientstyletype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgradientstyletype.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartGradientStyleType
-uid: 'ExcelScript!ExcelScript.ChartGradientStyleType:enum'
+uid: ExcelScript!ExcelScript.ChartGradientStyleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartGradientStyleType
-summary: Represents the gradient style type of a chart series. This is only applicable for region map charts.
+summary: >-
+  Represents the gradient style type of a chart series. This is only applicable
+  for region map charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: extremeValue
-    uid: 'ExcelScript!ExcelScript.ChartGradientStyleType.extremeValue:member'
+    uid: ExcelScript!ExcelScript.ChartGradientStyleType.extremeValue:member
     package: ExcelScript!
     summary: ''
   - name: number
-    uid: 'ExcelScript!ExcelScript.ChartGradientStyleType.number:member'
+    uid: ExcelScript!ExcelScript.ChartGradientStyleType.number:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.ChartGradientStyleType.percent:member'
+    uid: ExcelScript!ExcelScript.ChartGradientStyleType.percent:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgridlines.yml
@@ -1,33 +1,36 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartGridlines
-uid: 'ExcelScript!ExcelScript.ChartGridlines:interface'
+uid: ExcelScript!ExcelScript.ChartGridlines:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartGridlines
 summary: Represents major or minor gridlines on a chart axis.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartGridlines#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartGridlines#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Represents the formatting of chart gridlines.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartGridlinesFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGridlinesFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGridlinesFormat:interface" />
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartGridlines#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartGridlines#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the axis gridlines are visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: boolean
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartGridlines#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartGridlines#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the axis gridlines are visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartgridlinesformat.yml
@@ -1,24 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartGridlinesFormat
-uid: 'ExcelScript!ExcelScript.ChartGridlinesFormat:interface'
+uid: ExcelScript!ExcelScript.ChartGridlinesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartGridlinesFormat
 summary: Encapsulates the format properties for chart gridlines.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartGridlinesFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartGridlinesFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Represents chart line formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartleaderlines.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartleaderlines.yml
@@ -1,24 +1,28 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLeaderLines
-uid: 'ExcelScript!ExcelScript.ChartLeaderLines:interface'
+uid: ExcelScript!ExcelScript.ChartLeaderLines:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLeaderLines
 summary: Gets an object that represents the formatting of chart leader lines.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartLeaderLines#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLeaderLines#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Represents the formatting of leader lines of data labels in a series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartLeaderLinesFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface"
+          />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartleaderlinesformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartleaderlinesformat.yml
@@ -1,24 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLeaderLinesFormat
-uid: 'ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface'
+uid: ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLeaderLinesFormat
 summary: Encapsulates the format properties for leader lines.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartLeaderLinesFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLeaderLinesFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Gets an object that represents the line formatting of chart leader lines.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegend.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegend.yml
@@ -1,33 +1,40 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLegend
-uid: 'ExcelScript!ExcelScript.ChartLegend:interface'
+uid: ExcelScript!ExcelScript.ChartLegend:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegend
 summary: Represents the legend in a chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Represents the formatting of a chart legend, which includes fill and font formatting.'
+    summary: >-
+      Represents the formatting of a chart legend, which includes fill and font
+      formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartLegendFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLegendFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLegendFormat:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Specifies the height, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the height, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +43,14 @@ methods:
         type: number
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
-    summary: 'Specifies the left value, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the left value, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,24 +59,28 @@ methods:
         type: number
         description: ''
   - name: getLegendEntries()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getLegendEntries:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getLegendEntries:member(1)
     package: ExcelScript!
     fullName: getLegendEntries()
     summary: Represents a collection of legendEntries in the legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLegendEntries(): ChartLegendEntry[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLegendEntry:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLegendEntry:interface" />[]
         description: ''
   - name: getOverlay()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getOverlay:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getOverlay:member(1)
     package: ExcelScript!
     fullName: getOverlay()
-    summary: Specifies if the chart legend should overlap with the main body of the chart.
+    summary: >-
+      Specifies if the chart legend should overlap with the main body of the
+      chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,24 +89,28 @@ methods:
         type: boolean
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
-    summary: Specifies the position of the legend on the chart. See `ExcelScript.ChartLegendPosition` for details.
+    summary: >-
+      Specifies the position of the legend on the chart. See
+      `ExcelScript.ChartLegendPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartLegendPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLegendPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLegendPosition:enum" />
         description: ''
   - name: getShowShadow()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getShowShadow:member(1)
     package: ExcelScript!
     fullName: getShowShadow()
     summary: Specifies if the legend has a shadow on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,11 +119,12 @@ methods:
         type: boolean
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: Specifies the top of a chart legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -114,11 +133,12 @@ methods:
         type: number
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the chart legend is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,11 +147,14 @@ methods:
         type: boolean
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartLegend#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Specifies the width, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the width, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,11 +163,14 @@ methods:
         type: number
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
-    summary: 'Specifies the height, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the height, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,11 +183,14 @@ methods:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
-    summary: 'Specifies the left value, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the left value, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,11 +203,14 @@ methods:
         type: void
         description: ''
   - name: setOverlay(overlay)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setOverlay:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setOverlay:member(1)
     package: ExcelScript!
     fullName: setOverlay(overlay)
-    summary: Specifies if the chart legend should overlap with the main body of the chart.
+    summary: >-
+      Specifies if the chart legend should overlap with the main body of the
+      chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -191,11 +223,14 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
-    summary: Specifies the position of the legend on the chart. See `ExcelScript.ChartLegendPosition` for details.
+    summary: >-
+      Specifies the position of the legend on the chart. See
+      `ExcelScript.ChartLegendPosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -203,16 +238,17 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartLegendPosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartLegendPosition:enum" />
       return:
         type: void
         description: ''
   - name: setShowShadow(showShadow)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setShowShadow:member(1)
     package: ExcelScript!
     fullName: setShowShadow(showShadow)
     summary: Specifies if the legend has a shadow on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -225,11 +261,12 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: Specifies the top of a chart legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -242,11 +279,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the chart legend is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -259,11 +297,14 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.ChartLegend#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegend#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
-    summary: 'Specifies the width, in points, of the legend on the chart. Value is `null` if the legend is not visible.'
+    summary: >-
+      Specifies the width, in points, of the legend on the chart. Value is
+      `null` if the legend is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendentry.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLegendEntry
-uid: 'ExcelScript!ExcelScript.ChartLegendEntry:interface'
+uid: ExcelScript!ExcelScript.ChartLegendEntry:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendEntry
 summary: Represents the legend entry in `legendEntryCollection`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
     summary: Specifies the height of the legend entry on the chart legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: number
         description: ''
   - name: getIndex()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getIndex:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getIndex:member(1)
     package: ExcelScript!
     fullName: getIndex()
     summary: Specifies the index of the legend entry in the chart legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: number
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: Specifies the left value of a chart legend entry.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +53,12 @@ methods:
         type: number
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: Specifies the top of a chart legend entry.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +67,12 @@ methods:
         type: number
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Represents the visibility of a chart legend entry.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +81,12 @@ methods:
         type: boolean
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: Represents the width of the legend entry on the chart Legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +95,12 @@ methods:
         type: number
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartLegendEntry#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendEntry#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Represents the visibility of a chart legend entry.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendformat.yml
@@ -1,50 +1,58 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLegendFormat
-uid: 'ExcelScript!ExcelScript.ChartLegendFormat:interface'
+uid: ExcelScript!ExcelScript.ChartLegendFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendFormat
 summary: Encapsulates the format properties of a chart legend.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartLegendFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format, which includes color, linestyle, and weight.'
+    summary: Represents the border format, which includes color, linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartLegendFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of an object, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of an object, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartLegendFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLegendFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes such as font name, font size, and color of a chart legend.'
+    summary: >-
+      Represents the font attributes such as font name, font size, and color of
+      a chart legend.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlegendposition.yml
@@ -1,38 +1,39 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartLegendPosition
-uid: 'ExcelScript!ExcelScript.ChartLegendPosition:enum'
+uid: ExcelScript!ExcelScript.ChartLegendPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendPosition
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.bottom:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.bottom:member
     package: ExcelScript!
     summary: ''
   - name: corner
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.corner:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.corner:member
     package: ExcelScript!
     summary: ''
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.custom:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.custom:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.invalid:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.invalid:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.left:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.right:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.right:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ChartLegendPosition.top:member'
+    uid: ExcelScript!ExcelScript.ChartLegendPosition.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlineformat.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartLineFormat
-uid: 'ExcelScript!ExcelScript.ChartLineFormat:interface'
+uid: ExcelScript!ExcelScript.ChartLineFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLineFormat
 summary: Encapsulates the formatting options for line elements.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clears the line format of a chart element.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: HTML color code representing the color of lines in the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,24 +39,26 @@ methods:
         type: string
         description: ''
   - name: getLineStyle()
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#getLineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#getLineStyle:member(1)
     package: ExcelScript!
     fullName: getLineStyle()
     summary: Represents the line style. See `ExcelScript.ChartLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLineStyle(): ChartLineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />
         description: ''
   - name: getWeight()
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#getWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#getWeight:member(1)
     package: ExcelScript!
     fullName: getWeight()
-    summary: 'Represents weight of the line, in points.'
+    summary: Represents weight of the line, in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +67,12 @@ methods:
         type: number
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: HTML color code representing the color of lines in the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,11 +85,12 @@ methods:
         type: void
         description: ''
   - name: setLineStyle(lineStyle)
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#setLineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#setLineStyle:member(1)
     package: ExcelScript!
     fullName: setLineStyle(lineStyle)
     summary: Represents the line style. See `ExcelScript.ChartLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,16 +98,17 @@ methods:
       parameters:
         - id: lineStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartLineStyle:enum" />
       return:
         type: void
         description: ''
   - name: setWeight(weight)
-    uid: 'ExcelScript!ExcelScript.ChartLineFormat#setWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartLineFormat#setWeight:member(1)
     package: ExcelScript!
     fullName: setWeight(weight)
-    summary: 'Represents weight of the line, in points.'
+    summary: Represents weight of the line, in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartlinestyle.yml
@@ -1,54 +1,55 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartLineStyle
-uid: 'ExcelScript!ExcelScript.ChartLineStyle:enum'
+uid: ExcelScript!ExcelScript.ChartLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartLineStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.automatic:member
     package: ExcelScript!
     summary: ''
   - name: continuous
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.continuous:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.continuous:member
     package: ExcelScript!
     summary: ''
   - name: dash
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.dash:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: dashDot
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.dashDot:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.dashDot:member
     package: ExcelScript!
     summary: ''
   - name: dashDotDot
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.dashDotDot:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.dashDotDot:member
     package: ExcelScript!
     summary: ''
   - name: dot
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.dot:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.dot:member
     package: ExcelScript!
     summary: ''
   - name: grey25
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.grey25:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.grey25:member
     package: ExcelScript!
     summary: ''
   - name: grey50
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.grey50:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.grey50:member
     package: ExcelScript!
     summary: ''
   - name: grey75
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.grey75:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.grey75:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.none:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: roundDot
-    uid: 'ExcelScript!ExcelScript.ChartLineStyle.roundDot:member'
+    uid: ExcelScript!ExcelScript.ChartLineStyle.roundDot:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmaparealevel.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmaparealevel.yml
@@ -1,42 +1,45 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartMapAreaLevel
-uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel:enum'
+uid: ExcelScript!ExcelScript.ChartMapAreaLevel:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartMapAreaLevel
-summary: Represents the mapping level of a chart series. This only applies to region map charts.
+summary: >-
+  Represents the mapping level of a chart series. This only applies to region
+  map charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.automatic:member
     package: ExcelScript!
     summary: ''
   - name: city
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.city:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.city:member
     package: ExcelScript!
     summary: ''
   - name: continent
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.continent:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.continent:member
     package: ExcelScript!
     summary: ''
   - name: country
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.country:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.country:member
     package: ExcelScript!
     summary: ''
   - name: county
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.county:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.county:member
     package: ExcelScript!
     summary: ''
   - name: dataOnly
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.dataOnly:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.dataOnly:member
     package: ExcelScript!
     summary: ''
   - name: state
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.state:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.state:member
     package: ExcelScript!
     summary: ''
   - name: world
-    uid: 'ExcelScript!ExcelScript.ChartMapAreaLevel.world:member'
+    uid: ExcelScript!ExcelScript.ChartMapAreaLevel.world:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmaplabelstrategy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmaplabelstrategy.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartMapLabelStrategy
-uid: 'ExcelScript!ExcelScript.ChartMapLabelStrategy:enum'
+uid: ExcelScript!ExcelScript.ChartMapLabelStrategy:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartMapLabelStrategy
-summary: Represents the region level of a chart series layout. This only applies to region map charts.
+summary: >-
+  Represents the region level of a chart series layout. This only applies to
+  region map charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bestFit
-    uid: 'ExcelScript!ExcelScript.ChartMapLabelStrategy.bestFit:member'
+    uid: ExcelScript!ExcelScript.ChartMapLabelStrategy.bestFit:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartMapLabelStrategy.none:member'
+    uid: ExcelScript!ExcelScript.ChartMapLabelStrategy.none:member
     package: ExcelScript!
     summary: ''
   - name: showAll
-    uid: 'ExcelScript!ExcelScript.ChartMapLabelStrategy.showAll:member'
+    uid: ExcelScript!ExcelScript.ChartMapLabelStrategy.showAll:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmapoptions.yml
@@ -1,59 +1,64 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartMapOptions
-uid: 'ExcelScript!ExcelScript.ChartMapOptions:interface'
+uid: ExcelScript!ExcelScript.ChartMapOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartMapOptions
 summary: Encapsulates the properties for a region map chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLabelStrategy()
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#getLabelStrategy:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#getLabelStrategy:member(1)
     package: ExcelScript!
     fullName: getLabelStrategy()
     summary: Specifies the series map labels strategy of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLabelStrategy(): ChartMapLabelStrategy;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMapLabelStrategy:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMapLabelStrategy:enum" />
         description: ''
   - name: getLevel()
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#getLevel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#getLevel:member(1)
     package: ExcelScript!
     fullName: getLevel()
     summary: Specifies the series mapping level of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLevel(): ChartMapAreaLevel;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMapAreaLevel:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMapAreaLevel:enum" />
         description: ''
   - name: getProjectionType()
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#getProjectionType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#getProjectionType:member(1)
     package: ExcelScript!
     fullName: getProjectionType()
     summary: Specifies the series projection type of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getProjectionType(): ChartMapProjectionType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMapProjectionType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMapProjectionType:enum" />
         description: ''
   - name: setLabelStrategy(labelStrategy)
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#setLabelStrategy:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#setLabelStrategy:member(1)
     package: ExcelScript!
     fullName: setLabelStrategy(labelStrategy)
     summary: Specifies the series map labels strategy of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,16 +66,17 @@ methods:
       parameters:
         - id: labelStrategy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartMapLabelStrategy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartMapLabelStrategy:enum" />
       return:
         type: void
         description: ''
   - name: setLevel(level)
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#setLevel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#setLevel:member(1)
     package: ExcelScript!
     fullName: setLevel(level)
     summary: Specifies the series mapping level of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -78,16 +84,17 @@ methods:
       parameters:
         - id: level
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartMapAreaLevel:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartMapAreaLevel:enum" />
       return:
         type: void
         description: ''
   - name: setProjectionType(projectionType)
-    uid: 'ExcelScript!ExcelScript.ChartMapOptions#setProjectionType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartMapOptions#setProjectionType:member(1)
     package: ExcelScript!
     fullName: setProjectionType(projectionType)
     summary: Specifies the series projection type of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -95,7 +102,7 @@ methods:
       parameters:
         - id: projectionType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartMapProjectionType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartMapProjectionType:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmapprojectiontype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmapprojectiontype.yml
@@ -1,30 +1,33 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartMapProjectionType
-uid: 'ExcelScript!ExcelScript.ChartMapProjectionType:enum'
+uid: ExcelScript!ExcelScript.ChartMapProjectionType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartMapProjectionType
-summary: Represents the region projection type of a chart series layout. This only applies to region map charts.
+summary: >-
+  Represents the region projection type of a chart series layout. This only
+  applies to region map charts.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: albers
-    uid: 'ExcelScript!ExcelScript.ChartMapProjectionType.albers:member'
+    uid: ExcelScript!ExcelScript.ChartMapProjectionType.albers:member
     package: ExcelScript!
     summary: ''
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartMapProjectionType.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartMapProjectionType.automatic:member
     package: ExcelScript!
     summary: ''
   - name: mercator
-    uid: 'ExcelScript!ExcelScript.ChartMapProjectionType.mercator:member'
+    uid: ExcelScript!ExcelScript.ChartMapProjectionType.mercator:member
     package: ExcelScript!
     summary: ''
   - name: miller
-    uid: 'ExcelScript!ExcelScript.ChartMapProjectionType.miller:member'
+    uid: ExcelScript!ExcelScript.ChartMapProjectionType.miller:member
     package: ExcelScript!
     summary: ''
   - name: robinson
-    uid: 'ExcelScript!ExcelScript.ChartMapProjectionType.robinson:member'
+    uid: ExcelScript!ExcelScript.ChartMapProjectionType.robinson:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmarkerstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartmarkerstyle.yml
@@ -1,62 +1,63 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartMarkerStyle
-uid: 'ExcelScript!ExcelScript.ChartMarkerStyle:enum'
+uid: ExcelScript!ExcelScript.ChartMarkerStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartMarkerStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.automatic:member
     package: ExcelScript!
     summary: ''
   - name: circle
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.circle:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.circle:member
     package: ExcelScript!
     summary: ''
   - name: dash
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.dash:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: diamond
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.diamond:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.diamond:member
     package: ExcelScript!
     summary: ''
   - name: dot
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.dot:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.dot:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.invalid:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.invalid:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.none:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: picture
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.picture:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.picture:member
     package: ExcelScript!
     summary: ''
   - name: plus
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.plus:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.plus:member
     package: ExcelScript!
     summary: ''
   - name: square
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.square:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.square:member
     package: ExcelScript!
     summary: ''
   - name: star
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.star:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.star:member
     package: ExcelScript!
     summary: ''
   - name: triangle
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.triangle:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.triangle:member
     package: ExcelScript!
     summary: ''
   - name: x
-    uid: 'ExcelScript!ExcelScript.ChartMarkerStyle.x:member'
+    uid: ExcelScript!ExcelScript.ChartMarkerStyle.x:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartparentlabelstrategy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartparentlabelstrategy.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartParentLabelStrategy
-uid: 'ExcelScript!ExcelScript.ChartParentLabelStrategy:enum'
+uid: ExcelScript!ExcelScript.ChartParentLabelStrategy:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartParentLabelStrategy
-summary: Represents the parent label strategy of the chart series layout. This only applies to treemap charts
+summary: >-
+  Represents the parent label strategy of the chart series layout. This only
+  applies to treemap charts
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: banner
-    uid: 'ExcelScript!ExcelScript.ChartParentLabelStrategy.banner:member'
+    uid: ExcelScript!ExcelScript.ChartParentLabelStrategy.banner:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartParentLabelStrategy.none:member'
+    uid: ExcelScript!ExcelScript.ChartParentLabelStrategy.none:member
     package: ExcelScript!
     summary: ''
   - name: overlapping
-    uid: 'ExcelScript!ExcelScript.ChartParentLabelStrategy.overlapping:member'
+    uid: ExcelScript!ExcelScript.ChartParentLabelStrategy.overlapping:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpivotoptions.yml
@@ -1,23 +1,27 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartPivotOptions
-uid: 'ExcelScript!ExcelScript.ChartPivotOptions:interface'
+uid: ExcelScript!ExcelScript.ChartPivotOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPivotOptions
 summary: Encapsulates the options for the pivot chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getShowAxisFieldButtons()
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#getShowAxisFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#getShowAxisFieldButtons:member(1)
     package: ExcelScript!
     fullName: getShowAxisFieldButtons()
     summary: >-
-      Specifies whether to display the axis field buttons on a PivotChart. The `showAxisFieldButtons` property
-      corresponds to the "Show Axis Field Buttons" command on the "Field Buttons" drop-down list of the "Analyze" tab,
-      which is available when a PivotChart is selected.
+      Specifies whether to display the axis field buttons on a PivotChart. The
+      `showAxisFieldButtons` property corresponds to the "Show Axis Field
+      Buttons" command on the "Field Buttons" drop-down list of the "Analyze"
+      tab, which is available when a PivotChart is selected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -26,11 +30,13 @@ methods:
         type: boolean
         description: ''
   - name: getShowLegendFieldButtons()
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#getShowLegendFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#getShowLegendFieldButtons:member(1)
     package: ExcelScript!
     fullName: getShowLegendFieldButtons()
     summary: Specifies whether to display the legend field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -39,11 +45,15 @@ methods:
         type: boolean
         description: ''
   - name: getShowReportFilterFieldButtons()
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#getShowReportFilterFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#getShowReportFilterFieldButtons:member(1)
     package: ExcelScript!
     fullName: getShowReportFilterFieldButtons()
-    summary: Specifies whether to display the report filter field buttons on a PivotChart.
+    summary: >-
+      Specifies whether to display the report filter field buttons on a
+      PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -52,11 +62,13 @@ methods:
         type: boolean
         description: ''
   - name: getShowValueFieldButtons()
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#getShowValueFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#getShowValueFieldButtons:member(1)
     package: ExcelScript!
     fullName: getShowValueFieldButtons()
     summary: Specifies whether to display the show value field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -65,14 +77,17 @@ methods:
         type: boolean
         description: ''
   - name: setShowAxisFieldButtons(showAxisFieldButtons)
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#setShowAxisFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#setShowAxisFieldButtons:member(1)
     package: ExcelScript!
     fullName: setShowAxisFieldButtons(showAxisFieldButtons)
     summary: >-
-      Specifies whether to display the axis field buttons on a PivotChart. The `showAxisFieldButtons` property
-      corresponds to the "Show Axis Field Buttons" command on the "Field Buttons" drop-down list of the "Analyze" tab,
-      which is available when a PivotChart is selected.
+      Specifies whether to display the axis field buttons on a PivotChart. The
+      `showAxisFieldButtons` property corresponds to the "Show Axis Field
+      Buttons" command on the "Field Buttons" drop-down list of the "Analyze"
+      tab, which is available when a PivotChart is selected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -85,11 +100,13 @@ methods:
         type: void
         description: ''
   - name: setShowLegendFieldButtons(showLegendFieldButtons)
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#setShowLegendFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#setShowLegendFieldButtons:member(1)
     package: ExcelScript!
     fullName: setShowLegendFieldButtons(showLegendFieldButtons)
     summary: Specifies whether to display the legend field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -102,11 +119,15 @@ methods:
         type: void
         description: ''
   - name: setShowReportFilterFieldButtons(showReportFilterFieldButtons)
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#setShowReportFilterFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#setShowReportFilterFieldButtons:member(1)
     package: ExcelScript!
     fullName: setShowReportFilterFieldButtons(showReportFilterFieldButtons)
-    summary: Specifies whether to display the report filter field buttons on a PivotChart.
+    summary: >-
+      Specifies whether to display the report filter field buttons on a
+      PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -122,11 +143,13 @@ methods:
         type: void
         description: ''
   - name: setShowValueFieldButtons(showValueFieldButtons)
-    uid: 'ExcelScript!ExcelScript.ChartPivotOptions#setShowValueFieldButtons:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartPivotOptions#setShowValueFieldButtons:member(1)
     package: ExcelScript!
     fullName: setShowValueFieldButtons(showValueFieldButtons)
     summary: Specifies whether to display the show value field buttons on a PivotChart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotarea.yml
@@ -1,33 +1,36 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartPlotArea
-uid: 'ExcelScript!ExcelScript.ChartPlotArea:interface'
+uid: ExcelScript!ExcelScript.ChartPlotArea:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotArea
 summary: This object represents the attributes for a chart plot area.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Specifies the formatting of a chart plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartPlotAreaFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPlotAreaFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPlotAreaFormat:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
     summary: Specifies the height value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: number
         description: ''
   - name: getInsideHeight()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getInsideHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getInsideHeight:member(1)
     package: ExcelScript!
     fullName: getInsideHeight()
     summary: Specifies the inside height value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +53,12 @@ methods:
         type: number
         description: ''
   - name: getInsideLeft()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getInsideLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getInsideLeft:member(1)
     package: ExcelScript!
     fullName: getInsideLeft()
     summary: Specifies the inside left value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +67,12 @@ methods:
         type: number
         description: ''
   - name: getInsideTop()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getInsideTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getInsideTop:member(1)
     package: ExcelScript!
     fullName: getInsideTop()
     summary: Specifies the inside top value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +81,12 @@ methods:
         type: number
         description: ''
   - name: getInsideWidth()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getInsideWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getInsideWidth:member(1)
     package: ExcelScript!
     fullName: getInsideWidth()
     summary: Specifies the inside width value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +95,12 @@ methods:
         type: number
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: Specifies the left value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,24 +109,26 @@ methods:
         type: number
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: Specifies the position of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartPlotAreaPosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPlotAreaPosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPlotAreaPosition:enum" />
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: Specifies the top value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,11 +137,12 @@ methods:
         type: number
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: Specifies the width value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,11 +151,12 @@ methods:
         type: number
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
     summary: Specifies the height value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,11 +169,12 @@ methods:
         type: void
         description: ''
   - name: setInsideHeight(insideHeight)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setInsideHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setInsideHeight:member(1)
     package: ExcelScript!
     fullName: setInsideHeight(insideHeight)
     summary: Specifies the inside height value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,11 +187,12 @@ methods:
         type: void
         description: ''
   - name: setInsideLeft(insideLeft)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setInsideLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setInsideLeft:member(1)
     package: ExcelScript!
     fullName: setInsideLeft(insideLeft)
     summary: Specifies the inside left value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -191,11 +205,12 @@ methods:
         type: void
         description: ''
   - name: setInsideTop(insideTop)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setInsideTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setInsideTop:member(1)
     package: ExcelScript!
     fullName: setInsideTop(insideTop)
     summary: Specifies the inside top value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -208,11 +223,12 @@ methods:
         type: void
         description: ''
   - name: setInsideWidth(insideWidth)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setInsideWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setInsideWidth:member(1)
     package: ExcelScript!
     fullName: setInsideWidth(insideWidth)
     summary: Specifies the inside width value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -225,11 +241,12 @@ methods:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: Specifies the left value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -242,11 +259,12 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: Specifies the position of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -254,16 +272,17 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartPlotAreaPosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartPlotAreaPosition:enum" />
       return:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: Specifies the top value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -276,11 +295,12 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.ChartPlotArea#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotArea#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
     summary: Specifies the width value of a plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotareaformat.yml
@@ -1,37 +1,42 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartPlotAreaFormat
-uid: 'ExcelScript!ExcelScript.ChartPlotAreaFormat:interface'
+uid: ExcelScript!ExcelScript.ChartPlotAreaFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotAreaFormat
 summary: Represents the format properties for a chart plot area.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartPlotAreaFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotAreaFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
     summary: Specifies the border attributes of a chart plot area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartPlotAreaFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPlotAreaFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Specifies the fill format of an object, which includes background formatting information.'
+    summary: >-
+      Specifies the fill format of an object, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotareaposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotareaposition.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartPlotAreaPosition
-uid: 'ExcelScript!ExcelScript.ChartPlotAreaPosition:enum'
+uid: ExcelScript!ExcelScript.ChartPlotAreaPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotAreaPosition
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartPlotAreaPosition.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartPlotAreaPosition.automatic:member
     package: ExcelScript!
     summary: ''
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ChartPlotAreaPosition.custom:member'
+    uid: ExcelScript!ExcelScript.ChartPlotAreaPosition.custom:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotby.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartplotby.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartPlotBy
-uid: 'ExcelScript!ExcelScript.ChartPlotBy:enum'
+uid: ExcelScript!ExcelScript.ChartPlotBy:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotBy
 summary: ''
@@ -30,14 +30,15 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: columns
-    uid: 'ExcelScript!ExcelScript.ChartPlotBy.columns:member'
+    uid: ExcelScript!ExcelScript.ChartPlotBy.columns:member
     package: ExcelScript!
     summary: ''
   - name: rows
-    uid: 'ExcelScript!ExcelScript.ChartPlotBy.rows:member'
+    uid: ExcelScript!ExcelScript.ChartPlotBy.rows:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpoint.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpoint.yml
@@ -1,46 +1,52 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartPoint
-uid: 'ExcelScript!ExcelScript.ChartPoint:interface'
+uid: ExcelScript!ExcelScript.ChartPoint:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPoint
 summary: Represents a point of a series in a chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getDataLabel()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getDataLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getDataLabel:member(1)
     package: ExcelScript!
     fullName: getDataLabel()
     summary: Returns the data label of a chart point.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataLabel(): ChartDataLabel;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabel:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabel:interface" />
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Encapsulates the format properties chart point.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartPointFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPointFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPointFormat:interface" />
         description: ''
   - name: getHasDataLabel()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getHasDataLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getHasDataLabel:member(1)
     package: ExcelScript!
     fullName: getHasDataLabel()
-    summary: Represents whether a data point has a data label. Not applicable for surface charts.
+    summary: >-
+      Represents whether a data point has a data label. Not applicable for
+      surface charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +55,14 @@ methods:
         type: boolean
         description: ''
   - name: getMarkerBackgroundColor()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getMarkerBackgroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getMarkerBackgroundColor:member(1)
     package: ExcelScript!
     fullName: getMarkerBackgroundColor()
-    summary: 'HTML color code representation of the marker background color of a data point (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the marker background color of a data
+      point (e.g., \#FF0000 represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,14 @@ methods:
         type: string
         description: ''
   - name: getMarkerForegroundColor()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getMarkerForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getMarkerForegroundColor:member(1)
     package: ExcelScript!
     fullName: getMarkerForegroundColor()
-    summary: 'HTML color code representation of the marker foreground color of a data point (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the marker foreground color of a data
+      point (e.g., \#FF0000 represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,13 +87,15 @@ methods:
         type: string
         description: ''
   - name: getMarkerSize()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getMarkerSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getMarkerSize:member(1)
     package: ExcelScript!
     fullName: getMarkerSize()
     summary: >-
-      Represents marker size of a data point. The supported size range is 2 to 72. This method returns an
-      InvalidArgument error if it's set with a size outside of the supported range.
+      Represents marker size of a data point. The supported size range is 2 to
+      72. This method returns an InvalidArgument error if it's set with a size
+      outside of the supported range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,24 +104,28 @@ methods:
         type: number
         description: ''
   - name: getMarkerStyle()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getMarkerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getMarkerStyle:member(1)
     package: ExcelScript!
     fullName: getMarkerStyle()
-    summary: Represents marker style of a chart data point. See `ExcelScript.ChartMarkerStyle` for details.
+    summary: >-
+      Represents marker style of a chart data point. See
+      `ExcelScript.ChartMarkerStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMarkerStyle(): ChartMarkerStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />
         description: ''
   - name: getValue()
-    uid: 'ExcelScript!ExcelScript.ChartPoint#getValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#getValue:member(1)
     package: ExcelScript!
     fullName: getValue()
     summary: Returns the value of a chart point.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,11 +134,14 @@ methods:
         type: number
         description: ''
   - name: setHasDataLabel(hasDataLabel)
-    uid: 'ExcelScript!ExcelScript.ChartPoint#setHasDataLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#setHasDataLabel:member(1)
     package: ExcelScript!
     fullName: setHasDataLabel(hasDataLabel)
-    summary: Represents whether a data point has a data label. Not applicable for surface charts.
+    summary: >-
+      Represents whether a data point has a data label. Not applicable for
+      surface charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -133,11 +154,14 @@ methods:
         type: void
         description: ''
   - name: setMarkerBackgroundColor(markerBackgroundColor)
-    uid: 'ExcelScript!ExcelScript.ChartPoint#setMarkerBackgroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#setMarkerBackgroundColor:member(1)
     package: ExcelScript!
     fullName: setMarkerBackgroundColor(markerBackgroundColor)
-    summary: 'HTML color code representation of the marker background color of a data point (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the marker background color of a data
+      point (e.g., \#FF0000 represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -150,11 +174,14 @@ methods:
         type: void
         description: ''
   - name: setMarkerForegroundColor(markerForegroundColor)
-    uid: 'ExcelScript!ExcelScript.ChartPoint#setMarkerForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#setMarkerForegroundColor:member(1)
     package: ExcelScript!
     fullName: setMarkerForegroundColor(markerForegroundColor)
-    summary: 'HTML color code representation of the marker foreground color of a data point (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the marker foreground color of a data
+      point (e.g., \#FF0000 represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -167,13 +194,15 @@ methods:
         type: void
         description: ''
   - name: setMarkerSize(markerSize)
-    uid: 'ExcelScript!ExcelScript.ChartPoint#setMarkerSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#setMarkerSize:member(1)
     package: ExcelScript!
     fullName: setMarkerSize(markerSize)
     summary: >-
-      Represents marker size of a data point. The supported size range is 2 to 72. This method returns an
-      InvalidArgument error if it's set with a size outside of the supported range.
+      Represents marker size of a data point. The supported size range is 2 to
+      72. This method returns an InvalidArgument error if it's set with a size
+      outside of the supported range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -186,11 +215,14 @@ methods:
         type: void
         description: ''
   - name: setMarkerStyle(markerStyle)
-    uid: 'ExcelScript!ExcelScript.ChartPoint#setMarkerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPoint#setMarkerStyle:member(1)
     package: ExcelScript!
     fullName: setMarkerStyle(markerStyle)
-    summary: Represents marker style of a chart data point. See `ExcelScript.ChartMarkerStyle` for details.
+    summary: >-
+      Represents marker style of a chart data point. See
+      `ExcelScript.ChartMarkerStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -198,7 +230,7 @@ methods:
       parameters:
         - id: markerStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartpointformat.yml
@@ -1,37 +1,44 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartPointFormat
-uid: 'ExcelScript!ExcelScript.ChartPointFormat:interface'
+uid: ExcelScript!ExcelScript.ChartPointFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPointFormat
 summary: Represents the formatting object for chart points.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartPointFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPointFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format of a chart data point, which includes color, style, and weight information.'
+    summary: >-
+      Represents the border format of a chart data point, which includes color,
+      style, and weight information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartPointFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartPointFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of a chart, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of a chart, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseries.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseries.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartSeries
-uid: 'ExcelScript!ExcelScript.ChartSeries:interface'
+uid: ExcelScript!ExcelScript.ChartSeries:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartSeries
 summary: Represents a series in a chart.
@@ -38,33 +38,38 @@ remarks: |-
     secondSeries.setValues(secondSeriesRange);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: addChartTrendline(type)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#addChartTrendline:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#addChartTrendline:member(1)
     package: ExcelScript!
     fullName: addChartTrendline(type)
     summary: Adds a new trendline to trendline collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'addChartTrendline(type?: ChartTrendlineType): ChartTrendline;'
       parameters:
         - id: type
-          description: Specifies the trendline type. The default value is "Linear". See `ExcelScript.ChartTrendline` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />'
+          description: >-
+            Specifies the trendline type. The default value is "Linear". See
+            `ExcelScript.ChartTrendline` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#delete:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -73,52 +78,59 @@ methods:
         type: void
         description: ''
   - name: getAxisGroup()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getAxisGroup:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getAxisGroup:member(1)
     package: ExcelScript!
     fullName: getAxisGroup()
     summary: Specifies the group for the specified series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAxisGroup(): ChartAxisGroup;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />
         description: ''
   - name: getBinOptions()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getBinOptions:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getBinOptions:member(1)
     package: ExcelScript!
     fullName: getBinOptions()
     summary: Encapsulates the bin options for histogram charts and pareto charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBinOptions(): ChartBinOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBinOptions:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBinOptions:interface" />
         description: ''
   - name: getBoxwhiskerOptions()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getBoxwhiskerOptions:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getBoxwhiskerOptions:member(1)
     package: ExcelScript!
     fullName: getBoxwhiskerOptions()
     summary: Encapsulates the options for the box and whisker charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBoxwhiskerOptions(): ChartBoxwhiskerOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface"
+          />
         description: ''
   - name: getBubbleScale()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getBubbleScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getBubbleScale:member(1)
     package: ExcelScript!
     fullName: getBubbleScale()
     summary: >-
-      This can be an integer value from 0 (zero) to 300, representing the percentage of the default size. This property
-      only applies to bubble charts.
+      This can be an integer value from 0 (zero) to 300, representing the
+      percentage of the default size. This property only applies to bubble
+      charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,11 +139,14 @@ methods:
         type: number
         description: ''
   - name: getChartTrendline(index)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getChartTrendline:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getChartTrendline:member(1)
     package: ExcelScript!
     fullName: getChartTrendline(index)
-    summary: 'Gets a trendline object by index, which is the insertion order in the items array.'
+    summary: >-
+      Gets a trendline object by index, which is the insertion order in the
+      items array.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -141,42 +156,47 @@ methods:
           description: Represents the insertion order in the items array.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />
         description: ''
   - name: getChartType()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getChartType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getChartType:member(1)
     package: ExcelScript!
     fullName: getChartType()
-    summary: Represents the chart type of a series. See `ExcelScript.ChartType` for details.
+    summary: >-
+      Represents the chart type of a series. See `ExcelScript.ChartType` for
+      details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getChartType(): ChartType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartType:enum" />
         description: ''
   - name: getDataLabels()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getDataLabels:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getDataLabels:member(1)
     package: ExcelScript!
     fullName: getDataLabels()
     summary: Represents a collection of all data labels in the series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataLabels(): ChartDataLabels;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataLabels:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataLabels:interface" />
         description: ''
   - name: getDimensionDataSourceString(dimension)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getDimensionDataSourceString:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getDimensionDataSourceString:member(1)
     package: ExcelScript!
     fullName: getDimensionDataSourceString(dimension)
     summary: >-
-      Gets the string representation of the data source of the chart series. The string representation could be
-      information such as a cell address.
+      Gets the string representation of the data source of the chart series. The
+      string representation could be information such as a cell address.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -184,16 +204,17 @@ methods:
       parameters:
         - id: dimension
           description: The dimension of the axis where the data is from.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />
       return:
         type: string
         description: ''
   - name: getDimensionDataSourceType(dimension)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getDimensionDataSourceType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getDimensionDataSourceType:member(1)
     package: ExcelScript!
     fullName: getDimensionDataSourceType(dimension)
     summary: Gets the data source type of the chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -204,18 +225,20 @@ methods:
       parameters:
         - id: dimension
           description: The dimension of the axis where the data is from.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartDataSourceType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartDataSourceType:enum" />
         description: ''
   - name: getDimensionValues(dimension)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getDimensionValues:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getDimensionValues:member(1)
     package: ExcelScript!
     fullName: getDimensionValues(dimension)
     summary: >-
-      Gets the values from a single dimension of the chart series. These could be either category values or data values,
-      depending on the dimension specified and how the data is mapped for the chart series.
+      Gets the values from a single dimension of the chart series. These could
+      be either category values or data values, depending on the dimension
+      specified and how the data is mapped for the chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -223,18 +246,20 @@ methods:
       parameters:
         - id: dimension
           description: The dimension of the axis where the data is from.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartSeriesDimension:enum" />
       return:
-        type: 'string[]'
+        type: string[]
         description: ''
   - name: getDoughnutHoleSize()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getDoughnutHoleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getDoughnutHoleSize:member(1)
     package: ExcelScript!
     fullName: getDoughnutHoleSize()
     summary: >-
-      Represents the doughnut hole size of a chart series. Only valid on doughnut and doughnut exploded charts. Throws
-      an `InvalidArgument` error on invalid charts.
+      Represents the doughnut hole size of a chart series. Only valid on
+      doughnut and doughnut exploded charts. Throws an `InvalidArgument` error
+      on invalid charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -243,13 +268,15 @@ methods:
         type: number
         description: ''
   - name: getExplosion()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getExplosion:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getExplosion:member(1)
     package: ExcelScript!
     fullName: getExplosion()
     summary: >-
-      Specifies the explosion value for a pie-chart or doughnut-chart slice. Returns 0 (zero) if there's no explosion
-      (the tip of the slice is in the center of the pie).
+      Specifies the explosion value for a pie-chart or doughnut-chart slice.
+      Returns 0 (zero) if there's no explosion (the tip of the slice is in the
+      center of the pie).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -258,11 +285,12 @@ methods:
         type: number
         description: ''
   - name: getFiltered()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getFiltered:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getFiltered:member(1)
     package: ExcelScript!
     fullName: getFiltered()
     summary: Specifies if the series is filtered. Not applicable for surface charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -271,13 +299,15 @@ methods:
         type: boolean
         description: ''
   - name: getFirstSliceAngle()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getFirstSliceAngle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getFirstSliceAngle:member(1)
     package: ExcelScript!
     fullName: getFirstSliceAngle()
     summary: >-
-      Specifies the angle of the first pie-chart or doughnut-chart slice, in degrees (clockwise from vertical). Applies
-      only to pie, 3-D pie, and doughnut charts. Can be a value from 0 through 360.
+      Specifies the angle of the first pie-chart or doughnut-chart slice, in
+      degrees (clockwise from vertical). Applies only to pie, 3-D pie, and
+      doughnut charts. Can be a value from 0 through 360.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -286,26 +316,31 @@ methods:
         type: number
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Represents the formatting of a chart series, which includes fill and line formatting.'
+    summary: >-
+      Represents the formatting of a chart series, which includes fill and line
+      formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartSeriesFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartSeriesFormat:interface" />
         description: ''
   - name: getGapWidth()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGapWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGapWidth:member(1)
     package: ExcelScript!
     fullName: getGapWidth()
     summary: >-
-      Represents the gap width of a chart series. Only valid on bar and column charts, as well as specific classes of
-      line and pie charts. Throws an invalid argument exception on invalid charts.
+      Represents the gap width of a chart series. Only valid on bar and column
+      charts, as well as specific classes of line and pie charts. Throws an
+      invalid argument exception on invalid charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -314,11 +349,12 @@ methods:
         type: number
         description: ''
   - name: getGradientMaximumColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMaximumColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMaximumColor:member(1)
     package: ExcelScript!
     fullName: getGradientMaximumColor()
     summary: Specifies the color for maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -327,24 +363,26 @@ methods:
         type: string
         description: ''
   - name: getGradientMaximumType()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMaximumType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMaximumType:member(1)
     package: ExcelScript!
     fullName: getGradientMaximumType()
     summary: Specifies the type for maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGradientMaximumType(): ChartGradientStyleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
         description: ''
   - name: getGradientMaximumValue()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMaximumValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMaximumValue:member(1)
     package: ExcelScript!
     fullName: getGradientMaximumValue()
     summary: Specifies the maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -353,11 +391,12 @@ methods:
         type: number
         description: ''
   - name: getGradientMidpointColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMidpointColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMidpointColor:member(1)
     package: ExcelScript!
     fullName: getGradientMidpointColor()
     summary: Specifies the color for the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -366,24 +405,26 @@ methods:
         type: string
         description: ''
   - name: getGradientMidpointType()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMidpointType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMidpointType:member(1)
     package: ExcelScript!
     fullName: getGradientMidpointType()
     summary: Specifies the type for the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGradientMidpointType(): ChartGradientStyleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
         description: ''
   - name: getGradientMidpointValue()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMidpointValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMidpointValue:member(1)
     package: ExcelScript!
     fullName: getGradientMidpointValue()
     summary: Specifies the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -392,11 +433,12 @@ methods:
         type: number
         description: ''
   - name: getGradientMinimumColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMinimumColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMinimumColor:member(1)
     package: ExcelScript!
     fullName: getGradientMinimumColor()
     summary: Specifies the color for the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -405,24 +447,26 @@ methods:
         type: string
         description: ''
   - name: getGradientMinimumType()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMinimumType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMinimumType:member(1)
     package: ExcelScript!
     fullName: getGradientMinimumType()
     summary: Specifies the type for the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGradientMinimumType(): ChartGradientStyleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
         description: ''
   - name: getGradientMinimumValue()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientMinimumValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientMinimumValue:member(1)
     package: ExcelScript!
     fullName: getGradientMinimumValue()
     summary: Specifies the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -431,24 +475,26 @@ methods:
         type: number
         description: ''
   - name: getGradientStyle()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getGradientStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getGradientStyle:member(1)
     package: ExcelScript!
     fullName: getGradientStyle()
     summary: Specifies the series gradient style of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGradientStyle(): ChartGradientStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyle:enum" />
         description: ''
   - name: getHasDataLabels()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getHasDataLabels:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getHasDataLabels:member(1)
     package: ExcelScript!
     fullName: getHasDataLabels()
     summary: Specifies if the series has data labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -457,11 +503,12 @@ methods:
         type: boolean
         description: ''
   - name: getInvertColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getInvertColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getInvertColor:member(1)
     package: ExcelScript!
     fullName: getInvertColor()
     summary: Specifies the fill color for negative data points in a series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -470,11 +517,14 @@ methods:
         type: string
         description: ''
   - name: getInvertIfNegative()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getInvertIfNegative:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getInvertIfNegative:member(1)
     package: ExcelScript!
     fullName: getInvertIfNegative()
-    summary: True if Excel inverts the pattern in the item when it corresponds to a negative number.
+    summary: >-
+      True if Excel inverts the pattern in the item when it corresponds to a
+      negative number.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -483,24 +533,26 @@ methods:
         type: boolean
         description: ''
   - name: getMapOptions()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getMapOptions:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getMapOptions:member(1)
     package: ExcelScript!
     fullName: getMapOptions()
     summary: Encapsulates the options for a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMapOptions(): ChartMapOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMapOptions:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMapOptions:interface" />
         description: ''
   - name: getMarkerBackgroundColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getMarkerBackgroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getMarkerBackgroundColor:member(1)
     package: ExcelScript!
     fullName: getMarkerBackgroundColor()
     summary: Specifies the marker background color of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -509,11 +561,12 @@ methods:
         type: string
         description: ''
   - name: getMarkerForegroundColor()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getMarkerForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getMarkerForegroundColor:member(1)
     package: ExcelScript!
     fullName: getMarkerForegroundColor()
     summary: Specifies the marker foreground color of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -522,13 +575,15 @@ methods:
         type: string
         description: ''
   - name: getMarkerSize()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getMarkerSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getMarkerSize:member(1)
     package: ExcelScript!
     fullName: getMarkerSize()
     summary: >-
-      Specifies the marker size of a chart series. The supported size range is 2 to 72. This method returns an
-      InvalidArgument error if it's set with a size outside of the supported range.
+      Specifies the marker size of a chart series. The supported size range is 2
+      to 72. This method returns an InvalidArgument error if it's set with a
+      size outside of the supported range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -537,24 +592,30 @@ methods:
         type: number
         description: ''
   - name: getMarkerStyle()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getMarkerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getMarkerStyle:member(1)
     package: ExcelScript!
     fullName: getMarkerStyle()
-    summary: Specifies the marker style of a chart series. See `ExcelScript.ChartMarkerStyle` for details.
+    summary: >-
+      Specifies the marker style of a chart series. See
+      `ExcelScript.ChartMarkerStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMarkerStyle(): ChartMarkerStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getName:member(1)
     package: ExcelScript!
     fullName: getName()
-    summary: Specifies the name of a series in a chart. The name's length should not be greater than 255 characters.
+    summary: >-
+      Specifies the name of a series in a chart. The name's length should not be
+      greater than 255 characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -585,13 +646,14 @@ methods:
           }
           ```
   - name: getOverlap()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getOverlap:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getOverlap:member(1)
     package: ExcelScript!
     fullName: getOverlap()
     summary: >-
-      Specifies how bars and columns are positioned. Can be a value between -100 and 100. Applies only to 2-D bar and
-      2-D column charts.
+      Specifies how bars and columns are positioned. Can be a value between -100
+      and 100. Applies only to 2-D bar and 2-D column charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -600,24 +662,26 @@ methods:
         type: number
         description: ''
   - name: getParentLabelStrategy()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getParentLabelStrategy:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getParentLabelStrategy:member(1)
     package: ExcelScript!
     fullName: getParentLabelStrategy()
     summary: Specifies the series parent label strategy area for a treemap chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getParentLabelStrategy(): ChartParentLabelStrategy;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartParentLabelStrategy:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartParentLabelStrategy:enum" />
         description: ''
   - name: getPlotOrder()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getPlotOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getPlotOrder:member(1)
     package: ExcelScript!
     fullName: getPlotOrder()
     summary: Specifies the plot order of a chart series within the chart group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -626,26 +690,29 @@ methods:
         type: number
         description: ''
   - name: getPoints()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getPoints:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getPoints:member(1)
     package: ExcelScript!
     fullName: getPoints()
     summary: Returns a collection of all points in the series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPoints(): ChartPoint[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartPoint:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ChartPoint:interface" />[]
         description: ''
   - name: getSecondPlotSize()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getSecondPlotSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getSecondPlotSize:member(1)
     package: ExcelScript!
     fullName: getSecondPlotSize()
     summary: >-
-      Specifies the size of the secondary section of either a pie-of-pie chart or a bar-of-pie chart, as a percentage of
-      the size of the primary pie. Can be a value from 5 to 200.
+      Specifies the size of the secondary section of either a pie-of-pie chart
+      or a bar-of-pie chart, as a percentage of the size of the primary pie. Can
+      be a value from 5 to 200.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -654,11 +721,12 @@ methods:
         type: number
         description: ''
   - name: getShowConnectorLines()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getShowConnectorLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getShowConnectorLines:member(1)
     package: ExcelScript!
     fullName: getShowConnectorLines()
     summary: Specifies whether connector lines are shown in waterfall charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -667,11 +735,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowLeaderLines()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getShowLeaderLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getShowLeaderLines:member(1)
     package: ExcelScript!
     fullName: getShowLeaderLines()
-    summary: Specifies whether leader lines are displayed for each data label in the series.
+    summary: >-
+      Specifies whether leader lines are displayed for each data label in the
+      series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -680,11 +751,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowShadow()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getShowShadow:member(1)
     package: ExcelScript!
     fullName: getShowShadow()
     summary: Specifies if the series has a shadow.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -693,11 +765,14 @@ methods:
         type: boolean
         description: ''
   - name: getSmooth()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getSmooth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getSmooth:member(1)
     package: ExcelScript!
     fullName: getSmooth()
-    summary: Specifies if the series is smooth. Only applicable to line and scatter charts.
+    summary: >-
+      Specifies if the series is smooth. Only applicable to line and scatter
+      charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -706,24 +781,30 @@ methods:
         type: boolean
         description: ''
   - name: getSplitType()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getSplitType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getSplitType:member(1)
     package: ExcelScript!
     fullName: getSplitType()
-    summary: Specifies the way the two sections of either a pie-of-pie chart or a bar-of-pie chart are split.
+    summary: >-
+      Specifies the way the two sections of either a pie-of-pie chart or a
+      bar-of-pie chart are split.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSplitType(): ChartSplitType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartSplitType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartSplitType:enum" />
         description: ''
   - name: getSplitValue()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getSplitValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getSplitValue:member(1)
     package: ExcelScript!
     fullName: getSplitValue()
-    summary: Specifies the threshold value that separates two sections of either a pie-of-pie chart or a bar-of-pie chart.
+    summary: >-
+      Specifies the threshold value that separates two sections of either a
+      pie-of-pie chart or a bar-of-pie chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -732,24 +813,28 @@ methods:
         type: number
         description: ''
   - name: getTrendlines()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getTrendlines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getTrendlines:member(1)
     package: ExcelScript!
     fullName: getTrendlines()
     summary: The collection of trendlines in the series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTrendlines(): ChartTrendline[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendline:interface" />[]
         description: ''
   - name: getVaryByCategories()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getVaryByCategories:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getVaryByCategories:member(1)
     package: ExcelScript!
     fullName: getVaryByCategories()
-    summary: True if Excel assigns a different color or pattern to each data marker. The chart must contain only one series.
+    summary: >-
+      True if Excel assigns a different color or pattern to each data marker.
+      The chart must contain only one series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -758,30 +843,32 @@ methods:
         type: boolean
         description: ''
   - name: getXErrorBars()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getXErrorBars:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getXErrorBars:member(1)
     package: ExcelScript!
     fullName: getXErrorBars()
     summary: Represents the error bar object of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getXErrorBars(): ChartErrorBars;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBars:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartErrorBars:interface" />
         description: ''
   - name: getYErrorBars()
-    uid: 'ExcelScript!ExcelScript.ChartSeries#getYErrorBars:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#getYErrorBars:member(1)
     package: ExcelScript!
     fullName: getYErrorBars()
     summary: Represents the error bar object of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getYErrorBars(): ChartErrorBars;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartErrorBars:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartErrorBars:interface" />
         description: |-
 
 
@@ -808,11 +895,12 @@ methods:
           }
           ```
   - name: setAxisGroup(axisGroup)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setAxisGroup:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setAxisGroup:member(1)
     package: ExcelScript!
     fullName: setAxisGroup(axisGroup)
     summary: Specifies the group for the specified series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -820,18 +908,20 @@ methods:
       parameters:
         - id: axisGroup
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartAxisGroup:enum" />
       return:
         type: void
         description: ''
   - name: setBubbleScale(bubbleScale)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setBubbleScale:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setBubbleScale:member(1)
     package: ExcelScript!
     fullName: setBubbleScale(bubbleScale)
     summary: >-
-      This can be an integer value from 0 (zero) to 300, representing the percentage of the default size. This property
-      only applies to bubble charts.
+      This can be an integer value from 0 (zero) to 300, representing the
+      percentage of the default size. This property only applies to bubble
+      charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -844,11 +934,12 @@ methods:
         type: void
         description: ''
   - name: setBubbleSizes(sourceData)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setBubbleSizes:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setBubbleSizes:member(1)
     package: ExcelScript!
     fullName: setBubbleSizes(sourceData)
     summary: Sets the bubble sizes for a chart series. Only works for bubble charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -856,16 +947,19 @@ methods:
       parameters:
         - id: sourceData
           description: The `Range` object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
       return:
         type: void
         description: ''
   - name: setChartType(chartType)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setChartType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setChartType:member(1)
     package: ExcelScript!
     fullName: setChartType(chartType)
-    summary: Represents the chart type of a series. See `ExcelScript.ChartType` for details.
+    summary: >-
+      Represents the chart type of a series. See `ExcelScript.ChartType` for
+      details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -873,18 +967,20 @@ methods:
       parameters:
         - id: chartType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartType:enum" />
       return:
         type: void
         description: ''
   - name: setDoughnutHoleSize(doughnutHoleSize)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setDoughnutHoleSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setDoughnutHoleSize:member(1)
     package: ExcelScript!
     fullName: setDoughnutHoleSize(doughnutHoleSize)
     summary: >-
-      Represents the doughnut hole size of a chart series. Only valid on doughnut and doughnut exploded charts. Throws
-      an `InvalidArgument` error on invalid charts.
+      Represents the doughnut hole size of a chart series. Only valid on
+      doughnut and doughnut exploded charts. Throws an `InvalidArgument` error
+      on invalid charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -897,13 +993,15 @@ methods:
         type: void
         description: ''
   - name: setExplosion(explosion)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setExplosion:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setExplosion:member(1)
     package: ExcelScript!
     fullName: setExplosion(explosion)
     summary: >-
-      Specifies the explosion value for a pie-chart or doughnut-chart slice. Returns 0 (zero) if there's no explosion
-      (the tip of the slice is in the center of the pie).
+      Specifies the explosion value for a pie-chart or doughnut-chart slice.
+      Returns 0 (zero) if there's no explosion (the tip of the slice is in the
+      center of the pie).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -916,11 +1014,12 @@ methods:
         type: void
         description: ''
   - name: setFiltered(filtered)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setFiltered:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setFiltered:member(1)
     package: ExcelScript!
     fullName: setFiltered(filtered)
     summary: Specifies if the series is filtered. Not applicable for surface charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -933,13 +1032,15 @@ methods:
         type: void
         description: ''
   - name: setFirstSliceAngle(firstSliceAngle)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setFirstSliceAngle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setFirstSliceAngle:member(1)
     package: ExcelScript!
     fullName: setFirstSliceAngle(firstSliceAngle)
     summary: >-
-      Specifies the angle of the first pie-chart or doughnut-chart slice, in degrees (clockwise from vertical). Applies
-      only to pie, 3-D pie, and doughnut charts. Can be a value from 0 through 360.
+      Specifies the angle of the first pie-chart or doughnut-chart slice, in
+      degrees (clockwise from vertical). Applies only to pie, 3-D pie, and
+      doughnut charts. Can be a value from 0 through 360.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -952,13 +1053,15 @@ methods:
         type: void
         description: ''
   - name: setGapWidth(gapWidth)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGapWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGapWidth:member(1)
     package: ExcelScript!
     fullName: setGapWidth(gapWidth)
     summary: >-
-      Represents the gap width of a chart series. Only valid on bar and column charts, as well as specific classes of
-      line and pie charts. Throws an invalid argument exception on invalid charts.
+      Represents the gap width of a chart series. Only valid on bar and column
+      charts, as well as specific classes of line and pie charts. Throws an
+      invalid argument exception on invalid charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -971,11 +1074,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMaximumColor(gradientMaximumColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMaximumColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMaximumColor:member(1)
     package: ExcelScript!
     fullName: setGradientMaximumColor(gradientMaximumColor)
     summary: Specifies the color for maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -988,11 +1092,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMaximumType(gradientMaximumType)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMaximumType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMaximumType:member(1)
     package: ExcelScript!
     fullName: setGradientMaximumType(gradientMaximumType)
     summary: Specifies the type for maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1003,16 +1108,17 @@ methods:
       parameters:
         - id: gradientMaximumType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
       return:
         type: void
         description: ''
   - name: setGradientMaximumValue(gradientMaximumValue)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMaximumValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMaximumValue:member(1)
     package: ExcelScript!
     fullName: setGradientMaximumValue(gradientMaximumValue)
     summary: Specifies the maximum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1025,11 +1131,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMidpointColor(gradientMidpointColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMidpointColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMidpointColor:member(1)
     package: ExcelScript!
     fullName: setGradientMidpointColor(gradientMidpointColor)
     summary: Specifies the color for the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1042,11 +1149,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMidpointType(gradientMidpointType)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMidpointType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMidpointType:member(1)
     package: ExcelScript!
     fullName: setGradientMidpointType(gradientMidpointType)
     summary: Specifies the type for the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1057,16 +1165,17 @@ methods:
       parameters:
         - id: gradientMidpointType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
       return:
         type: void
         description: ''
   - name: setGradientMidpointValue(gradientMidpointValue)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMidpointValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMidpointValue:member(1)
     package: ExcelScript!
     fullName: setGradientMidpointValue(gradientMidpointValue)
     summary: Specifies the midpoint value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1079,11 +1188,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMinimumColor(gradientMinimumColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMinimumColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMinimumColor:member(1)
     package: ExcelScript!
     fullName: setGradientMinimumColor(gradientMinimumColor)
     summary: Specifies the color for the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1096,11 +1206,12 @@ methods:
         type: void
         description: ''
   - name: setGradientMinimumType(gradientMinimumType)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMinimumType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMinimumType:member(1)
     package: ExcelScript!
     fullName: setGradientMinimumType(gradientMinimumType)
     summary: Specifies the type for the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1111,16 +1222,17 @@ methods:
       parameters:
         - id: gradientMinimumType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyleType:enum" />
       return:
         type: void
         description: ''
   - name: setGradientMinimumValue(gradientMinimumValue)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientMinimumValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientMinimumValue:member(1)
     package: ExcelScript!
     fullName: setGradientMinimumValue(gradientMinimumValue)
     summary: Specifies the minimum value of a region map chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1133,11 +1245,12 @@ methods:
         type: void
         description: ''
   - name: setGradientStyle(gradientStyle)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setGradientStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setGradientStyle:member(1)
     package: ExcelScript!
     fullName: setGradientStyle(gradientStyle)
     summary: Specifies the series gradient style of a region map chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1145,16 +1258,17 @@ methods:
       parameters:
         - id: gradientStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartGradientStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartGradientStyle:enum" />
       return:
         type: void
         description: ''
   - name: setHasDataLabels(hasDataLabels)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setHasDataLabels:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setHasDataLabels:member(1)
     package: ExcelScript!
     fullName: setHasDataLabels(hasDataLabels)
     summary: Specifies if the series has data labels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1167,11 +1281,12 @@ methods:
         type: void
         description: ''
   - name: setInvertColor(invertColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setInvertColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setInvertColor:member(1)
     package: ExcelScript!
     fullName: setInvertColor(invertColor)
     summary: Specifies the fill color for negative data points in a series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1184,11 +1299,14 @@ methods:
         type: void
         description: ''
   - name: setInvertIfNegative(invertIfNegative)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setInvertIfNegative:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setInvertIfNegative:member(1)
     package: ExcelScript!
     fullName: setInvertIfNegative(invertIfNegative)
-    summary: True if Excel inverts the pattern in the item when it corresponds to a negative number.
+    summary: >-
+      True if Excel inverts the pattern in the item when it corresponds to a
+      negative number.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1201,11 +1319,12 @@ methods:
         type: void
         description: ''
   - name: setMarkerBackgroundColor(markerBackgroundColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setMarkerBackgroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setMarkerBackgroundColor:member(1)
     package: ExcelScript!
     fullName: setMarkerBackgroundColor(markerBackgroundColor)
     summary: Specifies the marker background color of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1218,11 +1337,12 @@ methods:
         type: void
         description: ''
   - name: setMarkerForegroundColor(markerForegroundColor)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setMarkerForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setMarkerForegroundColor:member(1)
     package: ExcelScript!
     fullName: setMarkerForegroundColor(markerForegroundColor)
     summary: Specifies the marker foreground color of a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1235,13 +1355,15 @@ methods:
         type: void
         description: ''
   - name: setMarkerSize(markerSize)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setMarkerSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setMarkerSize:member(1)
     package: ExcelScript!
     fullName: setMarkerSize(markerSize)
     summary: >-
-      Specifies the marker size of a chart series. The supported size range is 2 to 72. This method returns an
-      InvalidArgument error if it's set with a size outside of the supported range.
+      Specifies the marker size of a chart series. The supported size range is 2
+      to 72. This method returns an InvalidArgument error if it's set with a
+      size outside of the supported range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1254,11 +1376,14 @@ methods:
         type: void
         description: ''
   - name: setMarkerStyle(markerStyle)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setMarkerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setMarkerStyle:member(1)
     package: ExcelScript!
     fullName: setMarkerStyle(markerStyle)
-    summary: Specifies the marker style of a chart series. See `ExcelScript.ChartMarkerStyle` for details.
+    summary: >-
+      Specifies the marker style of a chart series. See
+      `ExcelScript.ChartMarkerStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1266,16 +1391,19 @@ methods:
       parameters:
         - id: markerStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartMarkerStyle:enum" />
       return:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
-    summary: Specifies the name of a series in a chart. The name's length should not be greater than 255 characters.
+    summary: >-
+      Specifies the name of a series in a chart. The name's length should not be
+      greater than 255 characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1288,13 +1416,14 @@ methods:
         type: void
         description: ''
   - name: setOverlap(overlap)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setOverlap:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setOverlap:member(1)
     package: ExcelScript!
     fullName: setOverlap(overlap)
     summary: >-
-      Specifies how bars and columns are positioned. Can be a value between -100 and 100. Applies only to 2-D bar and
-      2-D column charts.
+      Specifies how bars and columns are positioned. Can be a value between -100
+      and 100. Applies only to 2-D bar and 2-D column charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1330,11 +1459,12 @@ methods:
           }
           ```
   - name: setParentLabelStrategy(parentLabelStrategy)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setParentLabelStrategy:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setParentLabelStrategy:member(1)
     package: ExcelScript!
     fullName: setParentLabelStrategy(parentLabelStrategy)
     summary: Specifies the series parent label strategy area for a treemap chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1345,16 +1475,17 @@ methods:
       parameters:
         - id: parentLabelStrategy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartParentLabelStrategy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartParentLabelStrategy:enum" />
       return:
         type: void
         description: ''
   - name: setPlotOrder(plotOrder)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setPlotOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setPlotOrder:member(1)
     package: ExcelScript!
     fullName: setPlotOrder(plotOrder)
     summary: Specifies the plot order of a chart series within the chart group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1367,13 +1498,15 @@ methods:
         type: void
         description: ''
   - name: setSecondPlotSize(secondPlotSize)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setSecondPlotSize:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setSecondPlotSize:member(1)
     package: ExcelScript!
     fullName: setSecondPlotSize(secondPlotSize)
     summary: >-
-      Specifies the size of the secondary section of either a pie-of-pie chart or a bar-of-pie chart, as a percentage of
-      the size of the primary pie. Can be a value from 5 to 200.
+      Specifies the size of the secondary section of either a pie-of-pie chart
+      or a bar-of-pie chart, as a percentage of the size of the primary pie. Can
+      be a value from 5 to 200.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1386,11 +1519,12 @@ methods:
         type: void
         description: ''
   - name: setShowConnectorLines(showConnectorLines)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setShowConnectorLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setShowConnectorLines:member(1)
     package: ExcelScript!
     fullName: setShowConnectorLines(showConnectorLines)
     summary: Specifies whether connector lines are shown in waterfall charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1403,11 +1537,14 @@ methods:
         type: void
         description: ''
   - name: setShowLeaderLines(showLeaderLines)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setShowLeaderLines:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setShowLeaderLines:member(1)
     package: ExcelScript!
     fullName: setShowLeaderLines(showLeaderLines)
-    summary: Specifies whether leader lines are displayed for each data label in the series.
+    summary: >-
+      Specifies whether leader lines are displayed for each data label in the
+      series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1420,11 +1557,12 @@ methods:
         type: void
         description: ''
   - name: setShowShadow(showShadow)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setShowShadow:member(1)
     package: ExcelScript!
     fullName: setShowShadow(showShadow)
     summary: Specifies if the series has a shadow.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1437,11 +1575,14 @@ methods:
         type: void
         description: ''
   - name: setSmooth(smooth)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setSmooth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setSmooth:member(1)
     package: ExcelScript!
     fullName: setSmooth(smooth)
-    summary: Specifies if the series is smooth. Only applicable to line and scatter charts.
+    summary: >-
+      Specifies if the series is smooth. Only applicable to line and scatter
+      charts.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1454,11 +1595,14 @@ methods:
         type: void
         description: ''
   - name: setSplitType(splitType)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setSplitType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setSplitType:member(1)
     package: ExcelScript!
     fullName: setSplitType(splitType)
-    summary: Specifies the way the two sections of either a pie-of-pie chart or a bar-of-pie chart are split.
+    summary: >-
+      Specifies the way the two sections of either a pie-of-pie chart or a
+      bar-of-pie chart are split.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1466,16 +1610,19 @@ methods:
       parameters:
         - id: splitType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSplitType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartSplitType:enum" />
       return:
         type: void
         description: ''
   - name: setSplitValue(splitValue)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setSplitValue:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setSplitValue:member(1)
     package: ExcelScript!
     fullName: setSplitValue(splitValue)
-    summary: Specifies the threshold value that separates two sections of either a pie-of-pie chart or a bar-of-pie chart.
+    summary: >-
+      Specifies the threshold value that separates two sections of either a
+      pie-of-pie chart or a bar-of-pie chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1488,11 +1635,14 @@ methods:
         type: void
         description: ''
   - name: setValues(sourceData)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setValues:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setValues:member(1)
     package: ExcelScript!
     fullName: setValues(sourceData)
-    summary: 'Sets the values for a chart series. For scatter charts, it refers to y-axis values.'
+    summary: >-
+      Sets the values for a chart series. For scatter charts, it refers to
+      y-axis values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1500,16 +1650,19 @@ methods:
       parameters:
         - id: sourceData
           description: The `Range` object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
       return:
         type: void
         description: ''
   - name: setVaryByCategories(varyByCategories)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setVaryByCategories:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setVaryByCategories:member(1)
     package: ExcelScript!
     fullName: setVaryByCategories(varyByCategories)
-    summary: True if Excel assigns a different color or pattern to each data marker. The chart must contain only one series.
+    summary: >-
+      True if Excel assigns a different color or pattern to each data marker.
+      The chart must contain only one series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1522,11 +1675,12 @@ methods:
         type: void
         description: ''
   - name: setXAxisValues(sourceData)
-    uid: 'ExcelScript!ExcelScript.ChartSeries#setXAxisValues:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeries#setXAxisValues:member(1)
     package: ExcelScript!
     fullName: setXAxisValues(sourceData)
     summary: Sets the values of the x-axis for a chart series.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1534,7 +1688,7 @@ methods:
       parameters:
         - id: sourceData
           description: The `Range` object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesby.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesby.yml
@@ -1,12 +1,13 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartSeriesBy
-uid: 'ExcelScript!ExcelScript.ChartSeriesBy:enum'
+uid: ExcelScript!ExcelScript.ChartSeriesBy:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartSeriesBy
 summary: >-
-  Specifies whether the series are by rows or by columns. In Excel on desktop, the "auto" option will inspect the source
-  data shape to automatically guess whether the data is by rows or columns. In Excel on the web, "auto" will simply
-  default to "columns".
+  Specifies whether the series are by rows or by columns. In Excel on desktop,
+  the "auto" option will inspect the source data shape to automatically guess
+  whether the data is by rows or columns. In Excel on the web, "auto" will
+  simply default to "columns".
 remarks: |-
 
 
@@ -29,20 +30,22 @@ remarks: |-
       );   
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: auto
-    uid: 'ExcelScript!ExcelScript.ChartSeriesBy.auto:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesBy.auto:member
     package: ExcelScript!
     summary: >-
-      In Excel on desktop, the "auto" option will inspect the source data shape to automatically guess whether the data
-      is by rows or columns. In Excel on the web, "auto" will simply default to "columns".
+      In Excel on desktop, the "auto" option will inspect the source data shape
+      to automatically guess whether the data is by rows or columns. In Excel on
+      the web, "auto" will simply default to "columns".
   - name: columns
-    uid: 'ExcelScript!ExcelScript.ChartSeriesBy.columns:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesBy.columns:member
     package: ExcelScript!
     summary: ''
   - name: rows
-    uid: 'ExcelScript!ExcelScript.ChartSeriesBy.rows:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesBy.rows:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesdimension.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesdimension.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartSeriesDimension
-uid: 'ExcelScript!ExcelScript.ChartSeriesDimension:enum'
+uid: ExcelScript!ExcelScript.ChartSeriesDimension:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartSeriesDimension
 summary: Represents the dimensions when getting values from chart series.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bubbleSizes
-    uid: 'ExcelScript!ExcelScript.ChartSeriesDimension.bubbleSizes:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesDimension.bubbleSizes:member
     package: ExcelScript!
     summary: The chart series axis for the bubble sizes in bubble charts.
   - name: categories
-    uid: 'ExcelScript!ExcelScript.ChartSeriesDimension.categories:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesDimension.categories:member
     package: ExcelScript!
     summary: The chart series axis for the categories.
   - name: values
-    uid: 'ExcelScript!ExcelScript.ChartSeriesDimension.values:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesDimension.values:member
     package: ExcelScript!
     summary: The chart series axis for the values.
   - name: xvalues
-    uid: 'ExcelScript!ExcelScript.ChartSeriesDimension.xvalues:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesDimension.xvalues:member
     package: ExcelScript!
     summary: The chart series axis for the x-axis values in scatter and bubble charts.
   - name: yvalues
-    uid: 'ExcelScript!ExcelScript.ChartSeriesDimension.yvalues:member'
+    uid: ExcelScript!ExcelScript.ChartSeriesDimension.yvalues:member
     package: ExcelScript!
     summary: The chart series axis for the y-axis values in scatter and bubble charts.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartseriesformat.yml
@@ -1,37 +1,42 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartSeriesFormat
-uid: 'ExcelScript!ExcelScript.ChartSeriesFormat:interface'
+uid: ExcelScript!ExcelScript.ChartSeriesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartSeriesFormat
 summary: Encapsulates the format properties for the chart series
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartSeriesFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeriesFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of a chart series, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of a chart series, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartSeriesFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartSeriesFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Represents line formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartsplittype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartsplittype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartSplitType
-uid: 'ExcelScript!ExcelScript.ChartSplitType:enum'
+uid: ExcelScript!ExcelScript.ChartSplitType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartSplitType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: splitByCustomSplit
-    uid: 'ExcelScript!ExcelScript.ChartSplitType.splitByCustomSplit:member'
+    uid: ExcelScript!ExcelScript.ChartSplitType.splitByCustomSplit:member
     package: ExcelScript!
     summary: ''
   - name: splitByPercentValue
-    uid: 'ExcelScript!ExcelScript.ChartSplitType.splitByPercentValue:member'
+    uid: ExcelScript!ExcelScript.ChartSplitType.splitByPercentValue:member
     package: ExcelScript!
     summary: ''
   - name: splitByPosition
-    uid: 'ExcelScript!ExcelScript.ChartSplitType.splitByPosition:member'
+    uid: ExcelScript!ExcelScript.ChartSplitType.splitByPosition:member
     package: ExcelScript!
     summary: ''
   - name: splitByValue
-    uid: 'ExcelScript!ExcelScript.ChartSplitType.splitByValue:member'
+    uid: ExcelScript!ExcelScript.ChartSplitType.splitByValue:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttexthorizontalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttexthorizontalalignment.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartTextHorizontalAlignment
-uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum'
+uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTextHorizontalAlignment
 summary: Represents the horizontal alignment for the specified object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: center
-    uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment.center:member'
+    uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: justify
-    uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment.justify:member'
+    uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment.justify:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment.left:member'
+    uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ChartTextHorizontalAlignment.right:member'
+    uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment.right:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttextverticalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttextverticalalignment.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartTextVerticalAlignment
-uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum'
+uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTextVerticalAlignment
 summary: Represents the vertical alignment for the specified object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment.bottom:member'
+    uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment.bottom:member
     package: ExcelScript!
     summary: ''
   - name: center
-    uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment.center:member'
+    uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: justify
-    uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment.justify:member'
+    uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment.justify:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ChartTextVerticalAlignment.top:member'
+    uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartticklabelalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartticklabelalignment.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartTickLabelAlignment
-uid: 'ExcelScript!ExcelScript.ChartTickLabelAlignment:enum'
+uid: ExcelScript!ExcelScript.ChartTickLabelAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTickLabelAlignment
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: center
-    uid: 'ExcelScript!ExcelScript.ChartTickLabelAlignment.center:member'
+    uid: ExcelScript!ExcelScript.ChartTickLabelAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ChartTickLabelAlignment.left:member'
+    uid: ExcelScript!ExcelScript.ChartTickLabelAlignment.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ChartTickLabelAlignment.right:member'
+    uid: ExcelScript!ExcelScript.ChartTickLabelAlignment.right:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitle.yml
@@ -1,33 +1,40 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTitle
-uid: 'ExcelScript!ExcelScript.ChartTitle:interface'
+uid: ExcelScript!ExcelScript.ChartTitle:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTitle
 summary: Represents a chart title object of a chart.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Represents the formatting of a chart title, which includes fill and font formatting.'
+    summary: >-
+      Represents the formatting of a chart title, which includes fill and font
+      formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartTitleFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTitleFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTitleFormat:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Returns the height, in points, of the chart title. Value is `null` if the chart title is not visible.'
+    summary: >-
+      Returns the height, in points, of the chart title. Value is `null` if the
+      chart title is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,26 +43,31 @@ methods:
         type: number
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
     summary: Specifies the horizontal alignment for chart title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): ChartTextHorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum"
+          />
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Specifies the distance, in points, from the left edge of chart title to the left edge of chart area. Value is
-      `null` if the chart title is not visible.
+      Specifies the distance, in points, from the left edge of chart title to
+      the left edge of chart area. Value is `null` if the chart title is not
+      visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,11 +76,12 @@ methods:
         type: number
         description: ''
   - name: getOverlay()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getOverlay:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getOverlay:member(1)
     package: ExcelScript!
     fullName: getOverlay()
     summary: Specifies if the chart title will overlay the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,24 +90,30 @@ methods:
         type: boolean
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
-    summary: Represents the position of chart title. See `ExcelScript.ChartTitlePosition` for details.
+    summary: >-
+      Represents the position of chart title. See
+      `ExcelScript.ChartTitlePosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPosition(): ChartTitlePosition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTitlePosition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTitlePosition:enum" />
         description: ''
   - name: getShowShadow()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getShowShadow:member(1)
     package: ExcelScript!
     fullName: getShowShadow()
-    summary: Represents a boolean value that determines if the chart title has a shadow.
+    summary: >-
+      Represents a boolean value that determines if the chart title has a
+      shadow.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -102,12 +121,15 @@ methods:
       return:
         type: boolean
         description: ''
-  - name: 'getSubstring(start, length)'
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getSubstring:member(1)'
+  - name: getSubstring(start, length)
+    uid: ExcelScript!ExcelScript.ChartTitle#getSubstring:member(1)
     package: ExcelScript!
-    fullName: 'getSubstring(start, length)'
-    summary: Get the substring of a chart title. Line break '<!-- -->\\<!-- -->n' counts one character.
+    fullName: getSubstring(start, length)
+    summary: >-
+      Get the substring of a chart title. Line break '<!-- -->\\<!-- -->n'
+      counts one character.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -120,14 +142,15 @@ methods:
           description: Length of the substring to be retrieved.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFormatString:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFormatString:interface" />
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: Specifies the chart's title text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -136,13 +159,15 @@ methods:
         type: string
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Specifies the angle to which the text is oriented for the chart title. The value should either be an integer from
-      -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart title. The
+      value should either be an integer from -90 to 90 or the integer 180 for
+      vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -151,13 +176,14 @@ methods:
         type: number
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Specifies the distance, in points, from the top edge of chart title to the top of chart area. Value is `null` if
-      the chart title is not visible.
+      Specifies the distance, in points, from the top edge of chart title to the
+      top of chart area. Value is `null` if the chart title is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -166,24 +192,28 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
-    summary: Specifies the vertical alignment of chart title. See `ExcelScript.ChartTextVerticalAlignment` for details.
+    summary: >-
+      Specifies the vertical alignment of chart title. See
+      `ExcelScript.ChartTextVerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): ChartTextVerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the chart title is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -192,11 +222,14 @@ methods:
         type: boolean
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartTitle#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Specifies the width, in points, of the chart title. Value is `null` if the chart title is not visible.'
+    summary: >-
+      Specifies the width, in points, of the chart title. Value is `null` if the
+      chart title is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -205,11 +238,14 @@ methods:
         type: number
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: Sets a string value that represents the formula of chart title using A1-style notation.
+    summary: >-
+      Sets a string value that represents the formula of chart title using
+      A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -222,11 +258,12 @@ methods:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
     summary: Specifies the horizontal alignment for chart title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -237,18 +274,22 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      Specifies the distance, in points, from the left edge of chart title to the left edge of chart area. Value is
-      `null` if the chart title is not visible.
+      Specifies the distance, in points, from the left edge of chart title to
+      the left edge of chart area. Value is `null` if the chart title is not
+      visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -261,11 +302,12 @@ methods:
         type: void
         description: ''
   - name: setOverlay(overlay)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setOverlay:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setOverlay:member(1)
     package: ExcelScript!
     fullName: setOverlay(overlay)
     summary: Specifies if the chart title will overlay the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -278,11 +320,14 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
-    summary: Represents the position of chart title. See `ExcelScript.ChartTitlePosition` for details.
+    summary: >-
+      Represents the position of chart title. See
+      `ExcelScript.ChartTitlePosition` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -290,16 +335,19 @@ methods:
       parameters:
         - id: position
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTitlePosition:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartTitlePosition:enum" />
       return:
         type: void
         description: ''
   - name: setShowShadow(showShadow)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setShowShadow:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setShowShadow:member(1)
     package: ExcelScript!
     fullName: setShowShadow(showShadow)
-    summary: Represents a boolean value that determines if the chart title has a shadow.
+    summary: >-
+      Represents a boolean value that determines if the chart title has a
+      shadow.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -312,11 +360,12 @@ methods:
         type: void
         description: ''
   - name: setText(text)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setText:member(1)
     package: ExcelScript!
     fullName: setText(text)
     summary: Specifies the chart's title text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -329,13 +378,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Specifies the angle to which the text is oriented for the chart title. The value should either be an integer from
-      -90 to 90 or the integer 180 for vertically-oriented text.
+      Specifies the angle to which the text is oriented for the chart title. The
+      value should either be an integer from -90 to 90 or the integer 180 for
+      vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -348,13 +399,14 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Specifies the distance, in points, from the top edge of chart title to the top of chart area. Value is `null` if
-      the chart title is not visible.
+      Specifies the distance, in points, from the top edge of chart title to the
+      top of chart area. Value is `null` if the chart title is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -367,11 +419,14 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
-    summary: Specifies the vertical alignment of chart title. See `ExcelScript.ChartTextVerticalAlignment` for details.
+    summary: >-
+      Specifies the vertical alignment of chart title. See
+      `ExcelScript.ChartTextVerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -382,16 +437,19 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum"
+            />
       return:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ChartTitle#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitle#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the chart title is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitleformat.yml
@@ -1,50 +1,60 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTitleFormat
-uid: 'ExcelScript!ExcelScript.ChartTitleFormat:interface'
+uid: ExcelScript!ExcelScript.ChartTitleFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTitleFormat
 summary: Provides access to the formatting options for a chart title.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartTitleFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitleFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Represents the border format of chart title, which includes color, linestyle, and weight.'
+    summary: >-
+      Represents the border format of chart title, which includes color,
+      linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartTitleFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitleFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
-    summary: 'Represents the fill format of an object, which includes background formatting information.'
+    summary: >-
+      Represents the fill format of an object, which includes background
+      formatting information.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartTitleFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTitleFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Represents the font attributes (such as font name, font size, and color) for an object.'
+    summary: >-
+      Represents the font attributes (such as font name, font size, and color)
+      for an object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitleposition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttitleposition.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartTitlePosition
-uid: 'ExcelScript!ExcelScript.ChartTitlePosition:enum'
+uid: ExcelScript!ExcelScript.ChartTitlePosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTitlePosition
 summary: Represents the position of the chart title.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ChartTitlePosition.automatic:member'
+    uid: ExcelScript!ExcelScript.ChartTitlePosition.automatic:member
     package: ExcelScript!
     summary: ''
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ChartTitlePosition.bottom:member'
+    uid: ExcelScript!ExcelScript.ChartTitlePosition.bottom:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ChartTitlePosition.left:member'
+    uid: ExcelScript!ExcelScript.ChartTitlePosition.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ChartTitlePosition.right:member'
+    uid: ExcelScript!ExcelScript.ChartTitlePosition.right:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ChartTitlePosition.top:member'
+    uid: ExcelScript!ExcelScript.ChartTitlePosition.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendline.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendline.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTrendline
-uid: 'ExcelScript!ExcelScript.ChartTrendline:interface'
+uid: ExcelScript!ExcelScript.ChartTrendline:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendline
 summary: This object represents the attributes for a chart trendline object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#delete:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Delete the trendline object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getBackwardPeriod()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getBackwardPeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getBackwardPeriod:member(1)
     package: ExcelScript!
     fullName: getBackwardPeriod()
     summary: Represents the number of periods that the trendline extends backward.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,24 +39,26 @@ methods:
         type: number
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Represents the formatting of a chart trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartTrendlineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendlineFormat:interface" />
         description: ''
   - name: getForwardPeriod()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getForwardPeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getForwardPeriod:member(1)
     package: ExcelScript!
     fullName: getForwardPeriod()
     summary: Represents the number of periods that the trendline extends forward.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +67,12 @@ methods:
         type: number
         description: ''
   - name: getIntercept()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getIntercept:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getIntercept:member(1)
     package: ExcelScript!
     fullName: getIntercept()
     summary: Specifies the intercept value of the trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,24 +81,28 @@ methods:
         type: number
         description: ''
   - name: getLabel()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getLabel:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getLabel:member(1)
     package: ExcelScript!
     fullName: getLabel()
     summary: Represents the label of a chart trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLabel(): ChartTrendlineLabel;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineLabel:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendlineLabel:interface" />
         description: ''
   - name: getMovingAveragePeriod()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getMovingAveragePeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getMovingAveragePeriod:member(1)
     package: ExcelScript!
     fullName: getMovingAveragePeriod()
-    summary: Represents the period of a chart trendline. Only applicable to trendlines with the type `MovingAverage`<!-- -->.
+    summary: >-
+      Represents the period of a chart trendline. Only applicable to trendlines
+      with the type `MovingAverage`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,13 +111,15 @@ methods:
         type: number
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: >-
-      Represents the name of the trendline. Can be set to a string value, a `null` value represents automatic values.
-      The returned value is always a string
+      Represents the name of the trendline. Can be set to a string value, a
+      `null` value represents automatic values. The returned value is always a
+      string
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,11 +128,14 @@ methods:
         type: string
         description: ''
   - name: getPolynomialOrder()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getPolynomialOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getPolynomialOrder:member(1)
     package: ExcelScript!
     fullName: getPolynomialOrder()
-    summary: Represents the order of a chart trendline. Only applicable to trendlines with the type `Polynomial`<!-- -->.
+    summary: >-
+      Represents the order of a chart trendline. Only applicable to trendlines
+      with the type `Polynomial`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -129,11 +144,12 @@ methods:
         type: number
         description: ''
   - name: getShowEquation()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getShowEquation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getShowEquation:member(1)
     package: ExcelScript!
     fullName: getShowEquation()
     summary: True if the equation for the trendline is displayed on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -142,11 +158,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowRSquared()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getShowRSquared:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getShowRSquared:member(1)
     package: ExcelScript!
     fullName: getShowRSquared()
     summary: True if the r-squared value for the trendline is displayed on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -155,24 +172,26 @@ methods:
         type: boolean
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: Represents the type of a chart trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ChartTrendlineType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />
         description: ''
   - name: setBackwardPeriod(backwardPeriod)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setBackwardPeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setBackwardPeriod:member(1)
     package: ExcelScript!
     fullName: setBackwardPeriod(backwardPeriod)
     summary: Represents the number of periods that the trendline extends backward.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -185,11 +204,12 @@ methods:
         type: void
         description: ''
   - name: setForwardPeriod(forwardPeriod)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setForwardPeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setForwardPeriod:member(1)
     package: ExcelScript!
     fullName: setForwardPeriod(forwardPeriod)
     summary: Represents the number of periods that the trendline extends forward.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -202,11 +222,12 @@ methods:
         type: void
         description: ''
   - name: setIntercept(intercept)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setIntercept:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setIntercept:member(1)
     package: ExcelScript!
     fullName: setIntercept(intercept)
     summary: Specifies the intercept value of the trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -219,11 +240,14 @@ methods:
         type: void
         description: ''
   - name: setMovingAveragePeriod(movingAveragePeriod)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setMovingAveragePeriod:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setMovingAveragePeriod:member(1)
     package: ExcelScript!
     fullName: setMovingAveragePeriod(movingAveragePeriod)
-    summary: Represents the period of a chart trendline. Only applicable to trendlines with the type `MovingAverage`<!-- -->.
+    summary: >-
+      Represents the period of a chart trendline. Only applicable to trendlines
+      with the type `MovingAverage`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -236,13 +260,15 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setName:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: >-
-      Represents the name of the trendline. Can be set to a string value, a `null` value represents automatic values.
-      The returned value is always a string
+      Represents the name of the trendline. Can be set to a string value, a
+      `null` value represents automatic values. The returned value is always a
+      string
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -255,11 +281,14 @@ methods:
         type: void
         description: ''
   - name: setPolynomialOrder(polynomialOrder)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setPolynomialOrder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setPolynomialOrder:member(1)
     package: ExcelScript!
     fullName: setPolynomialOrder(polynomialOrder)
-    summary: Represents the order of a chart trendline. Only applicable to trendlines with the type `Polynomial`<!-- -->.
+    summary: >-
+      Represents the order of a chart trendline. Only applicable to trendlines
+      with the type `Polynomial`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -272,11 +301,12 @@ methods:
         type: void
         description: ''
   - name: setShowEquation(showEquation)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setShowEquation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setShowEquation:member(1)
     package: ExcelScript!
     fullName: setShowEquation(showEquation)
     summary: True if the equation for the trendline is displayed on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -289,11 +319,12 @@ methods:
         type: void
         description: ''
   - name: setShowRSquared(showRSquared)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setShowRSquared:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setShowRSquared:member(1)
     package: ExcelScript!
     fullName: setShowRSquared(showRSquared)
     summary: True if the r-squared value for the trendline is displayed on the chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -306,11 +337,12 @@ methods:
         type: void
         description: ''
   - name: setType(type)
-    uid: 'ExcelScript!ExcelScript.ChartTrendline#setType:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendline#setType:member(1)
     package: ExcelScript!
     fullName: setType(type)
     summary: Represents the type of a chart trendline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -318,7 +350,7 @@ methods:
       parameters:
         - id: type
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ChartTrendlineType:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlineformat.yml
@@ -1,24 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTrendlineFormat
-uid: 'ExcelScript!ExcelScript.ChartTrendlineFormat:interface'
+uid: ExcelScript!ExcelScript.ChartTrendlineFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineFormat
 summary: Represents the format properties for the chart trendline.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineFormat#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineFormat#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
     summary: Represents chart line formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): ChartLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartLineFormat:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinelabel.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTrendlineLabel
-uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel:interface'
+uid: ExcelScript!ExcelScript.ChartTrendlineLabel:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineLabel
 summary: This object represents the attributes for a chart trendline label object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAutoText()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getAutoText:member(1)
     package: ExcelScript!
     fullName: getAutoText()
-    summary: Specifies if the trendline label automatically generates appropriate text based on context.
+    summary: >-
+      Specifies if the trendline label automatically generates appropriate text
+      based on context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,30 @@ methods:
         type: boolean
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: The format of the chart trendline label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ChartTrendlineLabelFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface" />
         description: ''
   - name: getFormula()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getFormula:member(1)
     package: ExcelScript!
     fullName: getFormula()
-    summary: String value that represents the formula of the chart trendline label using A1-style notation.
+    summary: >-
+      String value that represents the formula of the chart trendline label
+      using A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,13 +59,14 @@ methods:
         type: string
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
     summary: >-
-      Returns the height, in points, of the chart trendline label. Value is `null` if the chart trendline label is not
-      visible.
+      Returns the height, in points, of the chart trendline label. Value is
+      `null` if the chart trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,28 +75,35 @@ methods:
         type: number
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getHorizontalAlignment:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartTrendlineLabel#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
     summary: >-
-      Represents the horizontal alignment of the chart trendline label. See `ExcelScript.ChartTextHorizontalAlignment`
-      for details. This property is valid only when `TextOrientation` of a trendline label is -90, 90, or 180.
+      Represents the horizontal alignment of the chart trendline label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when `TextOrientation` of a trendline label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): ChartTextHorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum"
+          />
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Represents the distance, in points, from the left edge of the chart trendline label to the left edge of the chart
-      area. Value is `null` if the chart trendline label is not visible.
+      Represents the distance, in points, from the left edge of the chart
+      trendline label to the left edge of the chart area. Value is `null` if the
+      chart trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -94,13 +112,14 @@ methods:
         type: number
         description: ''
   - name: getLinkNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: getLinkNumberFormat()
     summary: >-
-      Specifies if the number format is linked to the cells (so that the number format changes in the labels when it
-      changes in the cells).
+      Specifies if the number format is linked to the cells (so that the number
+      format changes in the labels when it changes in the cells).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -109,11 +128,12 @@ methods:
         type: boolean
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: String value that represents the format code for the trendline label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -122,11 +142,12 @@ methods:
         type: string
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: String representing the text of the trendline label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,13 +156,15 @@ methods:
         type: string
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      Represents the angle to which the text is oriented for the chart trendline label. The value should either be an
-      integer from -90 to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for the chart trendline
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -150,13 +173,15 @@ methods:
         type: number
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Represents the distance, in points, from the top edge of the chart trendline label to the top of the chart area.
-      Value is `null` if the chart trendline label is not visible.
+      Represents the distance, in points, from the top edge of the chart
+      trendline label to the top of the chart area. Value is `null` if the chart
+      trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -165,28 +190,31 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
     summary: >-
-      Represents the vertical alignment of the chart trendline label. See `ExcelScript.ChartTextVerticalAlignment` for
-      details. This property is valid only when `TextOrientation` of a trendline label is 0.
+      Represents the vertical alignment of the chart trendline label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of a trendline label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): ChartTextVerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: >-
-      Returns the width, in points, of the chart trendline label. Value is `null` if the chart trendline label is not
-      visible.
+      Returns the width, in points, of the chart trendline label. Value is
+      `null` if the chart trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -195,11 +223,14 @@ methods:
         type: number
         description: ''
   - name: setAutoText(autoText)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setAutoText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setAutoText:member(1)
     package: ExcelScript!
     fullName: setAutoText(autoText)
-    summary: Specifies if the trendline label automatically generates appropriate text based on context.
+    summary: >-
+      Specifies if the trendline label automatically generates appropriate text
+      based on context.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -212,11 +243,14 @@ methods:
         type: void
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: String value that represents the formula of the chart trendline label using A1-style notation.
+    summary: >-
+      String value that represents the formula of the chart trendline label
+      using A1-style notation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -229,13 +263,16 @@ methods:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setHorizontalAlignment:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ChartTrendlineLabel#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
     summary: >-
-      Represents the horizontal alignment of the chart trendline label. See `ExcelScript.ChartTextHorizontalAlignment`
-      for details. This property is valid only when `TextOrientation` of a trendline label is -90, 90, or 180.
+      Represents the horizontal alignment of the chart trendline label. See
+      `ExcelScript.ChartTextHorizontalAlignment` for details. This property is
+      valid only when `TextOrientation` of a trendline label is -90, 90, or 180.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -246,18 +283,22 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      Represents the distance, in points, from the left edge of the chart trendline label to the left edge of the chart
-      area. Value is `null` if the chart trendline label is not visible.
+      Represents the distance, in points, from the left edge of the chart
+      trendline label to the left edge of the chart area. Value is `null` if the
+      chart trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -270,13 +311,14 @@ methods:
         type: void
         description: ''
   - name: setLinkNumberFormat(linkNumberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setLinkNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setLinkNumberFormat:member(1)
     package: ExcelScript!
     fullName: setLinkNumberFormat(linkNumberFormat)
     summary: >-
-      Specifies if the number format is linked to the cells (so that the number format changes in the labels when it
-      changes in the cells).
+      Specifies if the number format is linked to the cells (so that the number
+      format changes in the labels when it changes in the cells).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -289,11 +331,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: String value that represents the format code for the trendline label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -306,11 +349,12 @@ methods:
         type: void
         description: ''
   - name: setText(text)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setText:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setText:member(1)
     package: ExcelScript!
     fullName: setText(text)
     summary: String representing the text of the trendline label on a chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -323,13 +367,15 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      Represents the angle to which the text is oriented for the chart trendline label. The value should either be an
-      integer from -90 to 90 or the integer 180 for vertically-oriented text.
+      Represents the angle to which the text is oriented for the chart trendline
+      label. The value should either be an integer from -90 to 90 or the integer
+      180 for vertically-oriented text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -342,13 +388,15 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Represents the distance, in points, from the top edge of the chart trendline label to the top of the chart area.
-      Value is `null` if the chart trendline label is not visible.
+      Represents the distance, in points, from the top edge of the chart
+      trendline label to the top of the chart area. Value is `null` if the chart
+      trendline label is not visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -361,13 +409,15 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabel#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabel#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
     summary: >-
-      Represents the vertical alignment of the chart trendline label. See `ExcelScript.ChartTextVerticalAlignment` for
-      details. This property is valid only when `TextOrientation` of a trendline label is 0.
+      Represents the vertical alignment of the chart trendline label. See
+      `ExcelScript.ChartTextVerticalAlignment` for details. This property is
+      valid only when `TextOrientation` of a trendline label is 0.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -378,7 +428,9 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinelabelformat.yml
@@ -1,50 +1,56 @@
 ### YamlMime:TSType
 name: ExcelScript.ChartTrendlineLabelFormat
-uid: 'ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface'
+uid: ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineLabelFormat
 summary: Encapsulates the format properties for the chart trendline label.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorder()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getBorder:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getBorder:member(1)
     package: ExcelScript!
     fullName: getBorder()
-    summary: 'Specifies the border format, which includes color, linestyle, and weight.'
+    summary: Specifies the border format, which includes color, linestyle, and weight.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorder(): ChartBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartBorder:interface" />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Specifies the fill format of the current chart trendline label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ChartFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ChartTrendlineLabelFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: 'Specifies the font attributes (such as font name, font size, and color) for a chart trendline label.'
+    summary: >-
+      Specifies the font attributes (such as font name, font size, and color)
+      for a chart trendline label.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ChartFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ChartFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ChartFont:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttrendlinetype.yml
@@ -1,34 +1,35 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartTrendlineType
-uid: 'ExcelScript!ExcelScript.ChartTrendlineType:enum'
+uid: ExcelScript!ExcelScript.ChartTrendlineType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: exponential
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.exponential:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.exponential:member
     package: ExcelScript!
     summary: ''
   - name: linear
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.linear:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.linear:member
     package: ExcelScript!
     summary: ''
   - name: logarithmic
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.logarithmic:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.logarithmic:member
     package: ExcelScript!
     summary: ''
   - name: movingAverage
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.movingAverage:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.movingAverage:member
     package: ExcelScript!
     summary: ''
   - name: polynomial
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.polynomial:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.polynomial:member
     package: ExcelScript!
     summary: ''
   - name: power
-    uid: 'ExcelScript!ExcelScript.ChartTrendlineType.power:member'
+    uid: ExcelScript!ExcelScript.ChartTrendlineType.power:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.charttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.charttype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartType
-uid: 'ExcelScript!ExcelScript.ChartType:enum'
+uid: ExcelScript!ExcelScript.ChartType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartType
 summary: ''
@@ -27,282 +27,283 @@ remarks: |-
     chart.setName("ColumnChart");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: area
-    uid: 'ExcelScript!ExcelScript.ChartType.area:member'
+    uid: ExcelScript!ExcelScript.ChartType.area:member
     package: ExcelScript!
     summary: ''
   - name: areaStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.areaStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.areaStacked:member
     package: ExcelScript!
     summary: ''
   - name: areaStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.areaStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.areaStacked100:member
     package: ExcelScript!
     summary: ''
   - name: barClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.barClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.barClustered:member
     package: ExcelScript!
     summary: ''
   - name: barOfPie
-    uid: 'ExcelScript!ExcelScript.ChartType.barOfPie:member'
+    uid: ExcelScript!ExcelScript.ChartType.barOfPie:member
     package: ExcelScript!
     summary: ''
   - name: barStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.barStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.barStacked:member
     package: ExcelScript!
     summary: ''
   - name: barStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.barStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.barStacked100:member
     package: ExcelScript!
     summary: ''
   - name: boxwhisker
-    uid: 'ExcelScript!ExcelScript.ChartType.boxwhisker:member'
+    uid: ExcelScript!ExcelScript.ChartType.boxwhisker:member
     package: ExcelScript!
     summary: ''
   - name: bubble
-    uid: 'ExcelScript!ExcelScript.ChartType.bubble:member'
+    uid: ExcelScript!ExcelScript.ChartType.bubble:member
     package: ExcelScript!
     summary: ''
   - name: bubble3DEffect
-    uid: 'ExcelScript!ExcelScript.ChartType.bubble3DEffect:member'
+    uid: ExcelScript!ExcelScript.ChartType.bubble3DEffect:member
     package: ExcelScript!
     summary: ''
   - name: columnClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.columnClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.columnClustered:member
     package: ExcelScript!
     summary: ''
   - name: columnStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.columnStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.columnStacked:member
     package: ExcelScript!
     summary: ''
   - name: columnStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.columnStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.columnStacked100:member
     package: ExcelScript!
     summary: ''
   - name: coneBarClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.coneBarClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneBarClustered:member
     package: ExcelScript!
     summary: ''
   - name: coneBarStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.coneBarStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneBarStacked:member
     package: ExcelScript!
     summary: ''
   - name: coneBarStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.coneBarStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneBarStacked100:member
     package: ExcelScript!
     summary: ''
   - name: coneCol
-    uid: 'ExcelScript!ExcelScript.ChartType.coneCol:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneCol:member
     package: ExcelScript!
     summary: ''
   - name: coneColClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.coneColClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneColClustered:member
     package: ExcelScript!
     summary: ''
   - name: coneColStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.coneColStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneColStacked:member
     package: ExcelScript!
     summary: ''
   - name: coneColStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.coneColStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.coneColStacked100:member
     package: ExcelScript!
     summary: ''
   - name: cylinderBarClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderBarClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderBarClustered:member
     package: ExcelScript!
     summary: ''
   - name: cylinderBarStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderBarStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderBarStacked:member
     package: ExcelScript!
     summary: ''
   - name: cylinderBarStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderBarStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderBarStacked100:member
     package: ExcelScript!
     summary: ''
   - name: cylinderCol
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderCol:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderCol:member
     package: ExcelScript!
     summary: ''
   - name: cylinderColClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderColClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderColClustered:member
     package: ExcelScript!
     summary: ''
   - name: cylinderColStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderColStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderColStacked:member
     package: ExcelScript!
     summary: ''
   - name: cylinderColStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.cylinderColStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.cylinderColStacked100:member
     package: ExcelScript!
     summary: ''
   - name: doughnut
-    uid: 'ExcelScript!ExcelScript.ChartType.doughnut:member'
+    uid: ExcelScript!ExcelScript.ChartType.doughnut:member
     package: ExcelScript!
     summary: ''
   - name: doughnutExploded
-    uid: 'ExcelScript!ExcelScript.ChartType.doughnutExploded:member'
+    uid: ExcelScript!ExcelScript.ChartType.doughnutExploded:member
     package: ExcelScript!
     summary: ''
   - name: funnel
-    uid: 'ExcelScript!ExcelScript.ChartType.funnel:member'
+    uid: ExcelScript!ExcelScript.ChartType.funnel:member
     package: ExcelScript!
     summary: ''
   - name: histogram
-    uid: 'ExcelScript!ExcelScript.ChartType.histogram:member'
+    uid: ExcelScript!ExcelScript.ChartType.histogram:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ChartType.invalid:member'
+    uid: ExcelScript!ExcelScript.ChartType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: line
-    uid: 'ExcelScript!ExcelScript.ChartType.line:member'
+    uid: ExcelScript!ExcelScript.ChartType.line:member
     package: ExcelScript!
     summary: ''
   - name: lineMarkers
-    uid: 'ExcelScript!ExcelScript.ChartType.lineMarkers:member'
+    uid: ExcelScript!ExcelScript.ChartType.lineMarkers:member
     package: ExcelScript!
     summary: ''
   - name: lineMarkersStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.lineMarkersStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.lineMarkersStacked:member
     package: ExcelScript!
     summary: ''
   - name: lineMarkersStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.lineMarkersStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.lineMarkersStacked100:member
     package: ExcelScript!
     summary: ''
   - name: lineStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.lineStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.lineStacked:member
     package: ExcelScript!
     summary: ''
   - name: lineStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.lineStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.lineStacked100:member
     package: ExcelScript!
     summary: ''
   - name: pareto
-    uid: 'ExcelScript!ExcelScript.ChartType.pareto:member'
+    uid: ExcelScript!ExcelScript.ChartType.pareto:member
     package: ExcelScript!
     summary: ''
   - name: pie
-    uid: 'ExcelScript!ExcelScript.ChartType.pie:member'
+    uid: ExcelScript!ExcelScript.ChartType.pie:member
     package: ExcelScript!
     summary: ''
   - name: pieExploded
-    uid: 'ExcelScript!ExcelScript.ChartType.pieExploded:member'
+    uid: ExcelScript!ExcelScript.ChartType.pieExploded:member
     package: ExcelScript!
     summary: ''
   - name: pieOfPie
-    uid: 'ExcelScript!ExcelScript.ChartType.pieOfPie:member'
+    uid: ExcelScript!ExcelScript.ChartType.pieOfPie:member
     package: ExcelScript!
     summary: ''
   - name: pyramidBarClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidBarClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidBarClustered:member
     package: ExcelScript!
     summary: ''
   - name: pyramidBarStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidBarStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidBarStacked:member
     package: ExcelScript!
     summary: ''
   - name: pyramidBarStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidBarStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidBarStacked100:member
     package: ExcelScript!
     summary: ''
   - name: pyramidCol
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidCol:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidCol:member
     package: ExcelScript!
     summary: ''
   - name: pyramidColClustered
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidColClustered:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidColClustered:member
     package: ExcelScript!
     summary: ''
   - name: pyramidColStacked
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidColStacked:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidColStacked:member
     package: ExcelScript!
     summary: ''
   - name: pyramidColStacked100
-    uid: 'ExcelScript!ExcelScript.ChartType.pyramidColStacked100:member'
+    uid: ExcelScript!ExcelScript.ChartType.pyramidColStacked100:member
     package: ExcelScript!
     summary: ''
   - name: radar
-    uid: 'ExcelScript!ExcelScript.ChartType.radar:member'
+    uid: ExcelScript!ExcelScript.ChartType.radar:member
     package: ExcelScript!
     summary: ''
   - name: radarFilled
-    uid: 'ExcelScript!ExcelScript.ChartType.radarFilled:member'
+    uid: ExcelScript!ExcelScript.ChartType.radarFilled:member
     package: ExcelScript!
     summary: ''
   - name: radarMarkers
-    uid: 'ExcelScript!ExcelScript.ChartType.radarMarkers:member'
+    uid: ExcelScript!ExcelScript.ChartType.radarMarkers:member
     package: ExcelScript!
     summary: ''
   - name: regionMap
-    uid: 'ExcelScript!ExcelScript.ChartType.regionMap:member'
+    uid: ExcelScript!ExcelScript.ChartType.regionMap:member
     package: ExcelScript!
     summary: ''
   - name: stockHLC
-    uid: 'ExcelScript!ExcelScript.ChartType.stockHLC:member'
+    uid: ExcelScript!ExcelScript.ChartType.stockHLC:member
     package: ExcelScript!
     summary: ''
   - name: stockOHLC
-    uid: 'ExcelScript!ExcelScript.ChartType.stockOHLC:member'
+    uid: ExcelScript!ExcelScript.ChartType.stockOHLC:member
     package: ExcelScript!
     summary: ''
   - name: stockVHLC
-    uid: 'ExcelScript!ExcelScript.ChartType.stockVHLC:member'
+    uid: ExcelScript!ExcelScript.ChartType.stockVHLC:member
     package: ExcelScript!
     summary: ''
   - name: stockVOHLC
-    uid: 'ExcelScript!ExcelScript.ChartType.stockVOHLC:member'
+    uid: ExcelScript!ExcelScript.ChartType.stockVOHLC:member
     package: ExcelScript!
     summary: ''
   - name: sunburst
-    uid: 'ExcelScript!ExcelScript.ChartType.sunburst:member'
+    uid: ExcelScript!ExcelScript.ChartType.sunburst:member
     package: ExcelScript!
     summary: ''
   - name: surface
-    uid: 'ExcelScript!ExcelScript.ChartType.surface:member'
+    uid: ExcelScript!ExcelScript.ChartType.surface:member
     package: ExcelScript!
     summary: ''
   - name: surfaceTopView
-    uid: 'ExcelScript!ExcelScript.ChartType.surfaceTopView:member'
+    uid: ExcelScript!ExcelScript.ChartType.surfaceTopView:member
     package: ExcelScript!
     summary: ''
   - name: surfaceTopViewWireframe
-    uid: 'ExcelScript!ExcelScript.ChartType.surfaceTopViewWireframe:member'
+    uid: ExcelScript!ExcelScript.ChartType.surfaceTopViewWireframe:member
     package: ExcelScript!
     summary: ''
   - name: surfaceWireframe
-    uid: 'ExcelScript!ExcelScript.ChartType.surfaceWireframe:member'
+    uid: ExcelScript!ExcelScript.ChartType.surfaceWireframe:member
     package: ExcelScript!
     summary: ''
   - name: treemap
-    uid: 'ExcelScript!ExcelScript.ChartType.treemap:member'
+    uid: ExcelScript!ExcelScript.ChartType.treemap:member
     package: ExcelScript!
     summary: ''
   - name: waterfall
-    uid: 'ExcelScript!ExcelScript.ChartType.waterfall:member'
+    uid: ExcelScript!ExcelScript.ChartType.waterfall:member
     package: ExcelScript!
     summary: ''
   - name: xyscatter
-    uid: 'ExcelScript!ExcelScript.ChartType.xyscatter:member'
+    uid: ExcelScript!ExcelScript.ChartType.xyscatter:member
     package: ExcelScript!
     summary: ''
   - name: xyscatterLines
-    uid: 'ExcelScript!ExcelScript.ChartType.xyscatterLines:member'
+    uid: ExcelScript!ExcelScript.ChartType.xyscatterLines:member
     package: ExcelScript!
     summary: ''
   - name: xyscatterLinesNoMarkers
-    uid: 'ExcelScript!ExcelScript.ChartType.xyscatterLinesNoMarkers:member'
+    uid: ExcelScript!ExcelScript.ChartType.xyscatterLinesNoMarkers:member
     package: ExcelScript!
     summary: ''
   - name: xyscatterSmooth
-    uid: 'ExcelScript!ExcelScript.ChartType.xyscatterSmooth:member'
+    uid: ExcelScript!ExcelScript.ChartType.xyscatterSmooth:member
     package: ExcelScript!
     summary: ''
   - name: xyscatterSmoothNoMarkers
-    uid: 'ExcelScript!ExcelScript.ChartType.xyscatterSmoothNoMarkers:member'
+    uid: ExcelScript!ExcelScript.ChartType.xyscatterSmoothNoMarkers:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.chartunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.chartunderlinestyle.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ChartUnderlineStyle
-uid: 'ExcelScript!ExcelScript.ChartUnderlineStyle:enum'
+uid: ExcelScript!ExcelScript.ChartUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartUnderlineStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: none
-    uid: 'ExcelScript!ExcelScript.ChartUnderlineStyle.none:member'
+    uid: ExcelScript!ExcelScript.ChartUnderlineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: single
-    uid: 'ExcelScript!ExcelScript.ChartUnderlineStyle.single:member'
+    uid: ExcelScript!ExcelScript.ChartUnderlineStyle.single:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.checkboxcellcontrol.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.checkboxcellcontrol.yml
@@ -1,23 +1,27 @@
 ### YamlMime:TSType
 name: ExcelScript.CheckboxCellControl
-uid: 'ExcelScript!ExcelScript.CheckboxCellControl:interface'
+uid: ExcelScript!ExcelScript.CheckboxCellControl:interface
 package: ExcelScript!
 fullName: ExcelScript.CheckboxCellControl
-summary: Represents a checkbox. This is a cell control that allows a user to toggle the boolean value in a cell.
+summary: >-
+  Represents a checkbox. This is a cell control that allows a user to toggle the
+  boolean value in a cell.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: type
-    uid: 'ExcelScript!ExcelScript.CheckboxCellControl#type:member'
+    uid: ExcelScript!ExcelScript.CheckboxCellControl#type:member
     package: ExcelScript!
     fullName: type
     summary: ''
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: CellControlType.checkbox;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellControlType.checkbox:member" />'
+        type: <xref uid="ExcelScript!ExcelScript.CellControlType.checkbox:member" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.clearapplyto.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.clearapplyto.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ClearApplyTo
-uid: 'ExcelScript!ExcelScript.ClearApplyTo:enum'
+uid: ExcelScript!ExcelScript.ClearApplyTo:enum
 package: ExcelScript!
 fullName: ExcelScript.ClearApplyTo
 summary: ''
@@ -27,34 +27,36 @@ remarks: |-
     range.clear(ExcelScript.ClearApplyTo.formats);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: all
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.all:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.all:member
     package: ExcelScript!
     summary: Clears everything in the range.
   - name: contents
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.contents:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.contents:member
     package: ExcelScript!
-    summary: 'Clears the contents of the range, leaving formatting intact.'
+    summary: Clears the contents of the range, leaving formatting intact.
   - name: formats
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.formats:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.formats:member
     package: ExcelScript!
-    summary: 'Clears all formatting for the range, leaving values intact.'
+    summary: Clears all formatting for the range, leaving values intact.
   - name: hyperlinks
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.hyperlinks:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.hyperlinks:member
     package: ExcelScript!
-    summary: 'Clears all hyperlinks, but leaves all content and formatting intact.'
+    summary: Clears all hyperlinks, but leaves all content and formatting intact.
   - name: removeHyperlinks
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.removeHyperlinks:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.removeHyperlinks:member
     package: ExcelScript!
     summary: >-
-      Removes hyperlinks and formatting for the cell but leaves content, conditional formats, and data validation
-      intact.
+      Removes hyperlinks and formatting for the cell but leaves content,
+      conditional formats, and data validation intact.
   - name: resetContents
-    uid: 'ExcelScript!ExcelScript.ClearApplyTo.resetContents:member'
+    uid: ExcelScript!ExcelScript.ClearApplyTo.resetContents:member
     package: ExcelScript!
     summary: >-
-      Sets all cells in the range to their default state. Cells with cell controls are set to the default value defined
-      by each control. Cells without cell controls are set to blank.
+      Sets all cells in the range to their default state. Cells with cell
+      controls are set to the default value defined by each control. Cells
+      without cell controls are set to blank.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.colorscaleconditionalformat.yml
@@ -1,35 +1,44 @@
 ### YamlMime:TSType
 name: ExcelScript.ColorScaleConditionalFormat
-uid: 'ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ColorScaleConditionalFormat
 summary: Represents the color scale criteria for conditional formatting.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCriteria()
-    uid: 'ExcelScript!ExcelScript.ColorScaleConditionalFormat#getCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.ColorScaleConditionalFormat#getCriteria:member(1)
     package: ExcelScript!
     fullName: getCriteria()
-    summary: The criteria of the color scale. Midpoint is optional when using a two point color scale.
+    summary: >-
+      The criteria of the color scale. Midpoint is optional when using a two
+      point color scale.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCriteria(): ConditionalColorScaleCriteria;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface"
+          />
         description: ''
   - name: getThreeColorScale()
-    uid: 'ExcelScript!ExcelScript.ColorScaleConditionalFormat#getThreeColorScale:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ColorScaleConditionalFormat#getThreeColorScale:member(1)
     package: ExcelScript!
     fullName: getThreeColorScale()
     summary: >-
-      If `true`<!-- -->, the color scale will have three points (minimum, midpoint, maximum), otherwise it will have two
-      (minimum, maximum).
+      If `true`<!-- -->, the color scale will have three points (minimum,
+      midpoint, maximum), otherwise it will have two (minimum, maximum).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -38,11 +47,14 @@ methods:
         type: boolean
         description: ''
   - name: setCriteria(criteria)
-    uid: 'ExcelScript!ExcelScript.ColorScaleConditionalFormat#setCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.ColorScaleConditionalFormat#setCriteria:member(1)
     package: ExcelScript!
     fullName: setCriteria(criteria)
-    summary: The criteria of the color scale. Midpoint is optional when using a two point color scale.
+    summary: >-
+      The criteria of the color scale. Midpoint is optional when using a two
+      point color scale.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,7 +62,10 @@ methods:
       parameters:
         - id: criteria
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.comment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.comment.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.Comment
-uid: 'ExcelScript!ExcelScript.Comment:interface'
+uid: ExcelScript!ExcelScript.Comment:interface
 package: ExcelScript!
 fullName: ExcelScript.Comment
 summary: Represents a comment in the workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'addCommentReply(content, contentType)'
-    uid: 'ExcelScript!ExcelScript.Comment#addCommentReply:member(1)'
+  - name: addCommentReply(content, contentType)
+    uid: ExcelScript!ExcelScript.Comment#addCommentReply:member(1)
     package: ExcelScript!
-    fullName: 'addCommentReply(content, contentType)'
+    fullName: addCommentReply(content, contentType)
     summary: Creates a comment reply for a comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -26,23 +28,26 @@ methods:
       parameters:
         - id: content
           description: >-
-            The comment's content. This can be either a string or a `CommentRichContent` object (e.g., for comments with
-            mentions).
-          type: '<xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" /> | string'
+            The comment's content. This can be either a string or a
+            `CommentRichContent` object (e.g., for comments with mentions).
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />
+            | string
         - id: contentType
           description: >-
-            Optional. The type of content contained within the comment. The default value is enum
-            `ContentType.Plain`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.ContentType:enum" />'
+            Optional. The type of content contained within the comment. The
+            default value is enum `ContentType.Plain`<!-- -->.
+          type: <xref uid="ExcelScript!ExcelScript.ContentType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentReply:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.CommentReply:interface" />
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Comment#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the comment and all the connected replies.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -51,11 +56,12 @@ methods:
         type: void
         description: ''
   - name: getAuthorEmail()
-    uid: 'ExcelScript!ExcelScript.Comment#getAuthorEmail:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getAuthorEmail:member(1)
     package: ExcelScript!
     fullName: getAuthorEmail()
     summary: Gets the email of the comment's author.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,11 +70,12 @@ methods:
         type: string
         description: ''
   - name: getAuthorName()
-    uid: 'ExcelScript!ExcelScript.Comment#getAuthorName:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getAuthorName:member(1)
     package: ExcelScript!
     fullName: getAuthorName()
     summary: Gets the name of the comment's author.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,13 +84,14 @@ methods:
         type: string
         description: ''
   - name: getCommentReply(commentReplyId)
-    uid: 'ExcelScript!ExcelScript.Comment#getCommentReply:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getCommentReply:member(1)
     package: ExcelScript!
     fullName: getCommentReply(commentReplyId)
     summary: >-
-      Returns a comment reply identified by its ID. If the comment reply object does not exist, then this method returns
-      `undefined`<!-- -->.
+      Returns a comment reply identified by its ID. If the comment reply object
+      does not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,14 +101,17 @@ methods:
           description: The identifier for the comment reply.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentReply:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.CommentReply:interface" /> |
+          undefined
         description: ''
   - name: getContent()
-    uid: 'ExcelScript!ExcelScript.Comment#getContent:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getContent:member(1)
     package: ExcelScript!
     fullName: getContent()
     summary: The comment's content. The string is plain text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -109,26 +120,28 @@ methods:
         type: string
         description: ''
   - name: getContentType()
-    uid: 'ExcelScript!ExcelScript.Comment#getContentType:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getContentType:member(1)
     package: ExcelScript!
     fullName: getContentType()
     summary: Gets the content type of the comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getContentType(): ContentType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ContentType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ContentType:enum" />
         description: ''
   - name: getCreationDate()
-    uid: 'ExcelScript!ExcelScript.Comment#getCreationDate:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getCreationDate:member(1)
     package: ExcelScript!
     fullName: getCreationDate()
     summary: >-
-      Gets the creation time of the comment. Returns `null` if the comment was converted from a note, since the comment
-      does not have a creation date.
+      Gets the creation time of the comment. Returns `null` if the comment was
+      converted from a note, since the comment does not have a creation date.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -137,11 +150,12 @@ methods:
         type: Date
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Comment#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the comment identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -150,50 +164,56 @@ methods:
         type: string
         description: ''
   - name: getLocation()
-    uid: 'ExcelScript!ExcelScript.Comment#getLocation:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getLocation:member(1)
     package: ExcelScript!
     fullName: getLocation()
     summary: Gets the cell where this comment is located.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLocation(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getMentions()
-    uid: 'ExcelScript!ExcelScript.Comment#getMentions:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getMentions:member(1)
     package: ExcelScript!
     fullName: getMentions()
-    summary: 'Gets the entities (e.g., people) that are mentioned in comments.'
+    summary: Gets the entities (e.g., people) that are mentioned in comments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMentions(): CommentMention[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]
         description: ''
   - name: getReplies()
-    uid: 'ExcelScript!ExcelScript.Comment#getReplies:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getReplies:member(1)
     package: ExcelScript!
     fullName: getReplies()
     summary: Represents a collection of reply objects associated with the comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getReplies(): CommentReply[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentReply:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CommentReply:interface" />[]
         description: ''
   - name: getResolved()
-    uid: 'ExcelScript!ExcelScript.Comment#getResolved:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getResolved:member(1)
     package: ExcelScript!
     fullName: getResolved()
-    summary: The comment thread status. A value of `true` means that the comment thread is resolved.
+    summary: >-
+      The comment thread status. A value of `true` means that the comment thread
+      is resolved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -202,13 +222,15 @@ methods:
         type: boolean
         description: ''
   - name: getRichContent()
-    uid: 'ExcelScript!ExcelScript.Comment#getRichContent:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#getRichContent:member(1)
     package: ExcelScript!
     fullName: getRichContent()
     summary: >-
-      Gets the rich comment content (e.g., mentions in comments). This string is not meant to be displayed to end-users.
-      Your add-in should only use this to parse rich comment content.
+      Gets the rich comment content (e.g., mentions in comments). This string is
+      not meant to be displayed to end-users. Your add-in should only use this
+      to parse rich comment content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -217,11 +239,12 @@ methods:
         type: string
         description: ''
   - name: setContent(content)
-    uid: 'ExcelScript!ExcelScript.Comment#setContent:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#setContent:member(1)
     package: ExcelScript!
     fullName: setContent(content)
     summary: The comment's content. The string is plain text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -234,11 +257,14 @@ methods:
         type: void
         description: ''
   - name: setResolved(resolved)
-    uid: 'ExcelScript!ExcelScript.Comment#setResolved:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#setResolved:member(1)
     package: ExcelScript!
     fullName: setResolved(resolved)
-    summary: The comment thread status. A value of `true` means that the comment thread is resolved.
+    summary: >-
+      The comment thread status. A value of `true` means that the comment thread
+      is resolved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -251,11 +277,14 @@ methods:
         type: void
         description: ''
   - name: updateMentions(contentWithMentions)
-    uid: 'ExcelScript!ExcelScript.Comment#updateMentions:member(1)'
+    uid: ExcelScript!ExcelScript.Comment#updateMentions:member(1)
     package: ExcelScript!
     fullName: updateMentions(contentWithMentions)
-    summary: Updates the comment content with a specially formatted string and a list of mentions.
+    summary: >-
+      Updates the comment content with a specially formatted string and a list
+      of mentions.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -263,9 +292,10 @@ methods:
       parameters:
         - id: contentWithMentions
           description: >-
-            The content for the comment. This contains a specially formatted string and a list of mentions that will be
-            parsed into the string when displayed by Excel.
-          type: '<xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />'
+            The content for the comment. This contains a specially formatted
+            string and a list of mentions that will be parsed into the string
+            when displayed by Excel.
+          type: <xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.commentmention.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.commentmention.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.CommentMention
-uid: 'ExcelScript!ExcelScript.CommentMention:interface'
+uid: ExcelScript!ExcelScript.CommentMention:interface
 package: ExcelScript!
 fullName: ExcelScript.CommentMention
 summary: Represents the entity that is mentioned in comments.
@@ -46,16 +46,18 @@ remarks: |-
     currentSheet.addComment(cell, content, ExcelScript.ContentType.mention);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: email
-    uid: 'ExcelScript!ExcelScript.CommentMention#email:member'
+    uid: ExcelScript!ExcelScript.CommentMention#email:member
     package: ExcelScript!
     fullName: email
     summary: The email address of the entity that is mentioned in a comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -63,11 +65,14 @@ properties:
       return:
         type: string
   - name: id
-    uid: 'ExcelScript!ExcelScript.CommentMention#id:member'
+    uid: ExcelScript!ExcelScript.CommentMention#id:member
     package: ExcelScript!
     fullName: id
-    summary: The ID of the entity. The ID matches one of the IDs in `CommentRichContent.richContent`<!-- -->.
+    summary: >-
+      The ID of the entity. The ID matches one of the IDs in
+      `CommentRichContent.richContent`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +80,12 @@ properties:
       return:
         type: number
   - name: name
-    uid: 'ExcelScript!ExcelScript.CommentMention#name:member'
+    uid: ExcelScript!ExcelScript.CommentMention#name:member
     package: ExcelScript!
     fullName: name
     summary: The name of the entity that is mentioned in a comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.commentreply.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.commentreply.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.CommentReply
-uid: 'ExcelScript!ExcelScript.CommentReply:interface'
+uid: ExcelScript!ExcelScript.CommentReply:interface
 package: ExcelScript!
 fullName: ExcelScript.CommentReply
 summary: Represents a comment reply in the workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.CommentReply#delete:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the comment reply.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getAuthorEmail()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getAuthorEmail:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getAuthorEmail:member(1)
     package: ExcelScript!
     fullName: getAuthorEmail()
     summary: Gets the email of the comment reply's author.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: string
         description: ''
   - name: getAuthorName()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getAuthorName:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getAuthorName:member(1)
     package: ExcelScript!
     fullName: getAuthorName()
     summary: Gets the name of the comment reply's author.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +53,12 @@ methods:
         type: string
         description: ''
   - name: getContent()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getContent:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getContent:member(1)
     package: ExcelScript!
     fullName: getContent()
     summary: The comment reply's content. The string is plain text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,24 +67,26 @@ methods:
         type: string
         description: ''
   - name: getContentType()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getContentType:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getContentType:member(1)
     package: ExcelScript!
     fullName: getContentType()
     summary: The content type of the reply.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getContentType(): ContentType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ContentType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ContentType:enum" />
         description: ''
   - name: getCreationDate()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getCreationDate:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getCreationDate:member(1)
     package: ExcelScript!
     fullName: getCreationDate()
     summary: Gets the creation time of the comment reply.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +95,12 @@ methods:
         type: Date
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getId:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the comment reply identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,50 +109,56 @@ methods:
         type: string
         description: ''
   - name: getLocation()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getLocation:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getLocation:member(1)
     package: ExcelScript!
     fullName: getLocation()
     summary: Gets the cell where this comment reply is located.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLocation(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getMentions()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getMentions:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getMentions:member(1)
     package: ExcelScript!
     fullName: getMentions()
-    summary: 'The entities (e.g., people) that are mentioned in comments.'
+    summary: The entities (e.g., people) that are mentioned in comments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMentions(): CommentMention[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]
         description: ''
   - name: getParentComment()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getParentComment:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getParentComment:member(1)
     package: ExcelScript!
     fullName: getParentComment()
     summary: Gets the parent comment of this reply.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getParentComment(): Comment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: getResolved()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getResolved:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getResolved:member(1)
     package: ExcelScript!
     fullName: getResolved()
-    summary: The comment reply status. A value of `true` means the reply is in the resolved state.
+    summary: >-
+      The comment reply status. A value of `true` means the reply is in the
+      resolved state.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -153,13 +167,15 @@ methods:
         type: boolean
         description: ''
   - name: getRichContent()
-    uid: 'ExcelScript!ExcelScript.CommentReply#getRichContent:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#getRichContent:member(1)
     package: ExcelScript!
     fullName: getRichContent()
     summary: >-
-      The rich comment content (e.g., mentions in comments). This string is not meant to be displayed to end-users. Your
-      add-in should only use this to parse rich comment content.
+      The rich comment content (e.g., mentions in comments). This string is not
+      meant to be displayed to end-users. Your add-in should only use this to
+      parse rich comment content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -168,11 +184,12 @@ methods:
         type: string
         description: ''
   - name: setContent(content)
-    uid: 'ExcelScript!ExcelScript.CommentReply#setContent:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#setContent:member(1)
     package: ExcelScript!
     fullName: setContent(content)
     summary: The comment reply's content. The string is plain text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -185,11 +202,14 @@ methods:
         type: void
         description: ''
   - name: updateMentions(contentWithMentions)
-    uid: 'ExcelScript!ExcelScript.CommentReply#updateMentions:member(1)'
+    uid: ExcelScript!ExcelScript.CommentReply#updateMentions:member(1)
     package: ExcelScript!
     fullName: updateMentions(contentWithMentions)
-    summary: Updates the comment content with a specially formatted string and a list of mentions.
+    summary: >-
+      Updates the comment content with a specially formatted string and a list
+      of mentions.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,9 +217,10 @@ methods:
       parameters:
         - id: contentWithMentions
           description: >-
-            The content for the comment. This contains a specially formatted string and a list of mentions that will be
-            parsed into the string when displayed by Excel.
-          type: '<xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />'
+            The content for the comment. This contains a specially formatted
+            string and a list of mentions that will be parsed into the string
+            when displayed by Excel.
+          type: <xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.commentrichcontent.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.commentrichcontent.yml
@@ -1,36 +1,43 @@
 ### YamlMime:TSType
 name: ExcelScript.CommentRichContent
-uid: 'ExcelScript!ExcelScript.CommentRichContent:interface'
+uid: ExcelScript!ExcelScript.CommentRichContent:interface
 package: ExcelScript!
 fullName: ExcelScript.CommentRichContent
 summary: >-
-  Represents the content contained within a comment or comment reply. Rich content incudes the text string and any other
-  objects contained within the comment body, such as mentions.
+  Represents the content contained within a comment or comment reply. Rich
+  content incudes the text string and any other objects contained within the
+  comment body, such as mentions.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: mentions
-    uid: 'ExcelScript!ExcelScript.CommentRichContent#mentions:member'
+    uid: ExcelScript!ExcelScript.CommentRichContent#mentions:member
     package: ExcelScript!
     fullName: mentions
-    summary: 'An array containing all the entities (e.g., people) mentioned within the comment.'
+    summary: >-
+      An array containing all the entities (e.g., people) mentioned within the
+      comment.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'mentions?: CommentMention[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CommentMention:interface" />[]
   - name: richContent
-    uid: 'ExcelScript!ExcelScript.CommentRichContent#richContent:member'
+    uid: ExcelScript!ExcelScript.CommentRichContent#richContent:member
     package: ExcelScript!
     fullName: richContent
     summary: >-
-      Specifies the rich content of the comment (e.g., comment content with mentions, the first mentioned entity has an
-      ID attribute of 0, and the second mentioned entity has an ID attribute of 1).
+      Specifies the rich content of the comment (e.g., comment content with
+      mentions, the first mentioned entity has an ID attribute of 0, and the
+      second mentioned entity has an ID attribute of 1).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcellvalueoperator.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcellvalueoperator.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalCellValueOperator
-uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator:enum'
+uid: ExcelScript!ExcelScript.ConditionalCellValueOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalCellValueOperator
 summary: Represents the operator of the text conditional format type.
@@ -38,42 +38,45 @@ remarks: |-
     cellValueConditionalFormatting.setRule(rule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: between
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.between:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.between:member
     package: ExcelScript!
     summary: ''
   - name: equalTo
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.equalTo:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.equalTo:member
     package: ExcelScript!
     summary: ''
   - name: greaterThan
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.greaterThan:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.greaterThan:member
     package: ExcelScript!
     summary: ''
   - name: greaterThanOrEqual
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.greaterThanOrEqual:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalCellValueOperator.greaterThanOrEqual:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.invalid:member
     package: ExcelScript!
     summary: ''
   - name: lessThan
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.lessThan:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.lessThan:member
     package: ExcelScript!
     summary: ''
   - name: lessThanOrEqual
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.lessThanOrEqual:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalCellValueOperator.lessThanOrEqual:member
     package: ExcelScript!
     summary: ''
   - name: notBetween
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.notBetween:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.notBetween:member
     package: ExcelScript!
     summary: ''
   - name: notEqualTo
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueOperator.notEqualTo:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueOperator.notEqualTo:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcellvaluerule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcellvaluerule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalCellValueRule
-uid: 'ExcelScript!ExcelScript.ConditionalCellValueRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalCellValueRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalCellValueRule
 summary: Represents a cell value conditional format rule.
@@ -38,16 +38,20 @@ remarks: |-
     format.getFont().setItalic(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: formula1
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueRule#formula1:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueRule#formula1:member
     package: ExcelScript!
     fullName: formula1
-    summary: 'The formula, if required, on which to evaluate the conditional format rule.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format
+      rule.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,11 +59,14 @@ properties:
       return:
         type: string
   - name: formula2
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueRule#formula2:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueRule#formula2:member
     package: ExcelScript!
     fullName: formula2
-    summary: 'The formula, if required, on which to evaluate the conditional format rule.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format
+      rule.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -67,14 +74,17 @@ properties:
       return:
         type: string
   - name: operator
-    uid: 'ExcelScript!ExcelScript.ConditionalCellValueRule#operator:member'
+    uid: ExcelScript!ExcelScript.ConditionalCellValueRule#operator:member
     package: ExcelScript!
     fullName: operator
     summary: The operator of the cell value conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator: ConditionalCellValueOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalCellValueOperator:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalCellValueOperator:enum"
+          />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcolorscalecriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcolorscalecriteria.yml
@@ -1,47 +1,62 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalColorScaleCriteria
-uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface'
+uid: ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalColorScaleCriteria
 summary: Represents the criteria of the color scale.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: maximum
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriteria#maximum:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriteria#maximum:member
     package: ExcelScript!
     fullName: maximum
     summary: The maximum point of the color scale criterion.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'maximum: ConditionalColorScaleCriterion;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface"
+          />
   - name: midpoint
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriteria#midpoint:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriteria#midpoint:member
     package: ExcelScript!
     fullName: midpoint
-    summary: 'The midpoint of the color scale criterion, if the color scale is a 3-color scale.'
+    summary: >-
+      The midpoint of the color scale criterion, if the color scale is a 3-color
+      scale.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'midpoint?: ConditionalColorScaleCriterion;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface"
+          />
   - name: minimum
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriteria#minimum:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriteria#minimum:member
     package: ExcelScript!
     fullName: minimum
     summary: The minimum point of the color scale criterion.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'minimum: ConditionalColorScaleCriterion;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface"
+          />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcolorscalecriterion.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalcolorscalecriterion.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalColorScaleCriterion
-uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface'
+uid: ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalColorScaleCriterion
-summary: 'Represents a color scale criterion which contains a type, value, and a color.'
+summary: Represents a color scale criterion which contains a type, value, and a color.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: color
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriterion#color:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriterion#color:member
     package: ExcelScript!
     fullName: color
-    summary: 'HTML color code representation of the color scale color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the color scale color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,11 +26,12 @@ properties:
       return:
         type: string
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriterion#formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriterion#formula:member
     package: ExcelScript!
     fullName: formula
-    summary: 'A number, a formula, or `null` (if `type` is `lowestValue`<!-- -->).'
+    summary: A number, a formula, or `null` (if `type` is `lowestValue`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -34,14 +39,18 @@ properties:
       return:
         type: string
   - name: type
-    uid: 'ExcelScript!ExcelScript.ConditionalColorScaleCriterion#type:member'
+    uid: ExcelScript!ExcelScript.ConditionalColorScaleCriterion#type:member
     package: ExcelScript!
     fullName: type
     summary: What the criterion conditional formula should be based on.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: ConditionalFormatColorCriterionType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum"
+          />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabaraxisformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabaraxisformat.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalDataBarAxisFormat
-uid: 'ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum'
+uid: ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarAxisFormat
 summary: Represents the format options for a data bar axis.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.automatic:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.automatic:member
     package: ExcelScript!
     summary: ''
   - name: cellMidPoint
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.cellMidPoint:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.cellMidPoint:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.none:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarAxisFormat.none:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabardirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabardirection.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalDataBarDirection
-uid: 'ExcelScript!ExcelScript.ConditionalDataBarDirection:enum'
+uid: ExcelScript!ExcelScript.ConditionalDataBarDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarDirection
 summary: Represents the data bar direction within a cell.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: context
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarDirection.context:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarDirection.context:member
     package: ExcelScript!
     summary: ''
   - name: leftToRight
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarDirection.leftToRight:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarDirection.leftToRight:member
     package: ExcelScript!
     summary: ''
   - name: rightToLeft
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarDirection.rightToLeft:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarDirection.rightToLeft:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarnegativeformat.yml
@@ -1,22 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalDataBarNegativeFormat
-uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface'
+uid: ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarNegativeFormat
 summary: Represents a conditional format for the negative side of the data bar.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorderColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getBorderColor:member(1)
     package: ExcelScript!
     fullName: getBorderColor()
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange"). Value is "" (an empty string) if no border is present or set.
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no border is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,13 +29,15 @@ methods:
         type: string
         description: ''
   - name: getFillColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getFillColor:member(1)
     package: ExcelScript!
     fullName: getFillColor()
     summary: >-
-      HTML color code representing the fill color, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
-      "orange").
+      HTML color code representing the fill color, in the form \#RRGGBB (e.g.,
+      "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,11 +46,15 @@ methods:
         type: string
         description: ''
   - name: getMatchPositiveBorderColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getMatchPositiveBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getMatchPositiveBorderColor:member(1)
     package: ExcelScript!
     fullName: getMatchPositiveBorderColor()
-    summary: Specifies if the negative data bar has the same border color as the positive data bar.
+    summary: >-
+      Specifies if the negative data bar has the same border color as the
+      positive data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -53,11 +63,15 @@ methods:
         type: boolean
         description: ''
   - name: getMatchPositiveFillColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getMatchPositiveFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#getMatchPositiveFillColor:member(1)
     package: ExcelScript!
     fullName: getMatchPositiveFillColor()
-    summary: Specifies if the negative data bar has the same fill color as the positive data bar.
+    summary: >-
+      Specifies if the negative data bar has the same fill color as the positive
+      data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -66,13 +80,16 @@ methods:
         type: boolean
         description: ''
   - name: setBorderColor(borderColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setBorderColor:member(1)
     package: ExcelScript!
     fullName: setBorderColor(borderColor)
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange"). Value is "" (an empty string) if no border is present or set.
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no border is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -85,13 +102,15 @@ methods:
         type: void
         description: ''
   - name: setFillColor(fillColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setFillColor:member(1)
     package: ExcelScript!
     fullName: setFillColor(fillColor)
     summary: >-
-      HTML color code representing the fill color, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
-      "orange").
+      HTML color code representing the fill color, in the form \#RRGGBB (e.g.,
+      "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -104,11 +123,15 @@ methods:
         type: void
         description: ''
   - name: setMatchPositiveBorderColor(matchPositiveBorderColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setMatchPositiveBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setMatchPositiveBorderColor:member(1)
     package: ExcelScript!
     fullName: setMatchPositiveBorderColor(matchPositiveBorderColor)
-    summary: Specifies if the negative data bar has the same border color as the positive data bar.
+    summary: >-
+      Specifies if the negative data bar has the same border color as the
+      positive data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -121,11 +144,15 @@ methods:
         type: void
         description: ''
   - name: setMatchPositiveFillColor(matchPositiveFillColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setMatchPositiveFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat#setMatchPositiveFillColor:member(1)
     package: ExcelScript!
     fullName: setMatchPositiveFillColor(matchPositiveFillColor)
-    summary: Specifies if the negative data bar has the same fill color as the positive data bar.
+    summary: >-
+      Specifies if the negative data bar has the same fill color as the positive
+      data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarpositiveformat.yml
@@ -1,22 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalDataBarPositiveFormat
-uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface'
+uid: ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarPositiveFormat
 summary: Represents a conditional format for the positive side of the data bar.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBorderColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getBorderColor:member(1)
     package: ExcelScript!
     fullName: getBorderColor()
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange"). Value is "" (an empty string) if no border is present or set.
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no border is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,13 +29,15 @@ methods:
         type: string
         description: ''
   - name: getFillColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getFillColor:member(1)
     package: ExcelScript!
     fullName: getFillColor()
     summary: >-
-      HTML color code representing the fill color, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
-      "orange").
+      HTML color code representing the fill color, in the form \#RRGGBB (e.g.,
+      "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,11 +46,13 @@ methods:
         type: string
         description: ''
   - name: getGradientFill()
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getGradientFill:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#getGradientFill:member(1)
     package: ExcelScript!
     fullName: getGradientFill()
     summary: Specifies if the data bar has a gradient.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -53,13 +61,16 @@ methods:
         type: boolean
         description: ''
   - name: setBorderColor(borderColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setBorderColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setBorderColor:member(1)
     package: ExcelScript!
     fullName: setBorderColor(borderColor)
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange"). Value is "" (an empty string) if no border is present or set.
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no border is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,13 +83,15 @@ methods:
         type: void
         description: ''
   - name: setFillColor(fillColor)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setFillColor:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setFillColor:member(1)
     package: ExcelScript!
     fullName: setFillColor(fillColor)
     summary: >-
-      HTML color code representing the fill color, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
-      "orange").
+      HTML color code representing the fill color, in the form \#RRGGBB (e.g.,
+      "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,11 +104,13 @@ methods:
         type: void
         description: ''
   - name: setGradientFill(gradientFill)
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setGradientFill:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat#setGradientFill:member(1)
     package: ExcelScript!
     fullName: setGradientFill(gradientFill)
     summary: Specifies if the data bar has a gradient.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaldatabarrule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalDataBarRule
-uid: 'ExcelScript!ExcelScript.ConditionalDataBarRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalDataBarRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarRule
 summary: Represents a rule-type for a data bar.
@@ -37,16 +37,18 @@ remarks: |-
     dataBarFormat.setUpperBoundRule(upperBound);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarRule#formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarRule#formula:member
     package: ExcelScript!
     fullName: formula
-    summary: 'The formula, if required, on which to evaluate the data bar rule.'
+    summary: The formula, if required, on which to evaluate the data bar rule.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -54,14 +56,15 @@ properties:
       return:
         type: string
   - name: type
-    uid: 'ExcelScript!ExcelScript.ConditionalDataBarRule#type:member'
+    uid: ExcelScript!ExcelScript.ConditionalDataBarRule#type:member
     package: ExcelScript!
     fullName: type
     summary: The type of rule for the data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: ConditionalFormatRuleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatRuleType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormatRuleType:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformat.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalFormat
-uid: 'ExcelScript!ExcelScript.ConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.ConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormat
-summary: 'An object encapsulating a conditional format''s range, format, rule, and other properties.'
+summary: >-
+  An object encapsulating a conditional format's range, format, rule, and other
+  properties.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: changeRuleToCellValue(properties)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToCellValue:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToCellValue:member(1)
     package: ExcelScript!
     fullName: changeRuleToCellValue(properties)
     summary: Change the conditional format rule type to cell value.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,16 +26,19 @@ methods:
       parameters:
         - id: properties
           description: The properties to set for the cell value conditional format rule.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalCellValueRule:interface" />
       return:
         type: void
         description: ''
   - name: changeRuleToColorScale()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToColorScale:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToColorScale:member(1)
     package: ExcelScript!
     fullName: changeRuleToColorScale()
     summary: Change the conditional format rule type to color scale.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,11 +47,13 @@ methods:
         type: void
         description: ''
   - name: changeRuleToContainsText(properties)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToContainsText:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormat#changeRuleToContainsText:member(1)
     package: ExcelScript!
     fullName: changeRuleToContainsText(properties)
     summary: Change the conditional format rule type to text comparison.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -54,17 +63,23 @@ methods:
                 ): void;
       parameters:
         - id: properties
-          description: The properties to set for the text comparison conditional format rule.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface" />'
+          description: >-
+            The properties to set for the text comparison conditional format
+            rule.
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface"
+            />
       return:
         type: void
         description: ''
   - name: changeRuleToCustom(formula)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToCustom:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToCustom:member(1)
     package: ExcelScript!
     fullName: changeRuleToCustom(formula)
     summary: Change the conditional format rule type to custom.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,11 +92,12 @@ methods:
         type: void
         description: ''
   - name: changeRuleToDataBar()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToDataBar:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToDataBar:member(1)
     package: ExcelScript!
     fullName: changeRuleToDataBar()
     summary: Change the conditional format rule type to data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,11 +106,12 @@ methods:
         type: void
         description: ''
   - name: changeRuleToIconSet()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToIconSet:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToIconSet:member(1)
     package: ExcelScript!
     fullName: changeRuleToIconSet()
     summary: Change the conditional format rule type to icon set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -103,11 +120,13 @@ methods:
         type: void
         description: ''
   - name: changeRuleToPresetCriteria(properties)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToPresetCriteria:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormat#changeRuleToPresetCriteria:member(1)
     package: ExcelScript!
     fullName: changeRuleToPresetCriteria(properties)
     summary: Change the conditional format rule type to preset criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -117,17 +136,23 @@ methods:
                 ): void;
       parameters:
         - id: properties
-          description: The properties to set for the preset criteria conditional format rule.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface" />'
+          description: >-
+            The properties to set for the preset criteria conditional format
+            rule.
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface"
+            />
       return:
         type: void
         description: ''
   - name: changeRuleToTopBottom(properties)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#changeRuleToTopBottom:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#changeRuleToTopBottom:member(1)
     package: ExcelScript!
     fullName: changeRuleToTopBottom(properties)
     summary: Change the conditional format rule type to top/bottom.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,16 +160,19 @@ methods:
       parameters:
         - id: properties
           description: The properties to set for the top/bottom conditional format rule.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface" />
       return:
         type: void
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#delete:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes this conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -153,17 +181,23 @@ methods:
         type: void
         description: ''
   - name: getCellValue()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getCellValue:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getCellValue:member(1)
     package: ExcelScript!
     fullName: getCellValue()
-    summary: Returns the cell value conditional format properties if the current conditional format is a `CellValue` type.
+    summary: >-
+      Returns the cell value conditional format properties if the current
+      conditional format is a `CellValue` type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCellValue(): CellValueConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellValueConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.CellValueConditionalFormat:interface" />
+          | undefined
         description: |-
 
 
@@ -200,17 +234,23 @@ methods:
           }
           ```
   - name: getColorScale()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getColorScale:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getColorScale:member(1)
     package: ExcelScript!
     fullName: getColorScale()
-    summary: Returns the color scale conditional format properties if the current conditional format is a `ColorScale` type.
+    summary: >-
+      Returns the color scale conditional format properties if the current
+      conditional format is a `ColorScale` type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getColorScale(): ColorScaleConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface" />
+          | undefined
         description: |-
 
 
@@ -245,17 +285,22 @@ methods:
           }
           ```
   - name: getCustom()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getCustom:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getCustom:member(1)
     package: ExcelScript!
     fullName: getCustom()
-    summary: Returns the custom conditional format properties if the current conditional format is a custom type.
+    summary: >-
+      Returns the custom conditional format properties if the current
+      conditional format is a custom type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCustom(): CustomConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.CustomConditionalFormat:interface"
+          /> | undefined
         description: |-
 
 
@@ -277,17 +322,22 @@ methods:
           }
           ```
   - name: getDataBar()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getDataBar:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getDataBar:member(1)
     package: ExcelScript!
     fullName: getDataBar()
-    summary: Returns the data bar properties if the current conditional format is a data bar.
+    summary: >-
+      Returns the data bar properties if the current conditional format is a
+      data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataBar(): DataBarConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataBarConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.DataBarConditionalFormat:interface"
+          /> | undefined
         description: |-
 
 
@@ -322,17 +372,22 @@ methods:
           }
           ```
   - name: getIconSet()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getIconSet:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getIconSet:member(1)
     package: ExcelScript!
     fullName: getIconSet()
-    summary: Returns the icon set conditional format properties if the current conditional format is an `IconSet` type.
+    summary: >-
+      Returns the icon set conditional format properties if the current
+      conditional format is an `IconSet` type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getIconSet(): IconSetConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.IconSetConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.IconSetConditionalFormat:interface"
+          /> | undefined
         description: |-
 
 
@@ -369,11 +424,14 @@ methods:
           }
           ```
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getId:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getId:member(1)
     package: ExcelScript!
     fullName: getId()
-    summary: The priority of the conditional format in the current `ConditionalFormatCollection`<!-- -->.
+    summary: >-
+      The priority of the conditional format in the current
+      `ConditionalFormatCollection`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -382,19 +440,23 @@ methods:
         type: string
         description: ''
   - name: getPreset()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getPreset:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getPreset:member(1)
     package: ExcelScript!
     fullName: getPreset()
     summary: >-
-      Returns the preset criteria conditional format. See `ExcelScript.PresetCriteriaConditionalFormat` for more
-      details.
+      Returns the preset criteria conditional format. See
+      `ExcelScript.PresetCriteriaConditionalFormat` for more details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPreset(): PresetCriteriaConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface"
+          /> | undefined
         description: |-
 
 
@@ -427,16 +489,20 @@ methods:
           }
           ```
   - name: getPriority()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getPriority:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getPriority:member(1)
     package: ExcelScript!
     fullName: getPriority()
     summary: >-
-      The priority (or index) within the conditional format collection that this conditional format currently exists in.
-      Changing this also changes other conditional formats' priorities, to allow for a contiguous priority order. Use a
-      negative priority to begin from the back. Priorities greater than the bounds will get and set to the maximum (or
-      minimum if negative) priority. Also note that if you change the priority, you have to re-fetch a new copy of the
-      object at that new priority location if you want to make further changes to it.
+      The priority (or index) within the conditional format collection that this
+      conditional format currently exists in. Changing this also changes other
+      conditional formats' priorities, to allow for a contiguous priority order.
+      Use a negative priority to begin from the back. Priorities greater than
+      the bounds will get and set to the maximum (or minimum if negative)
+      priority. Also note that if you change the priority, you have to re-fetch
+      a new copy of the object at that new priority location if you want to make
+      further changes to it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -445,43 +511,48 @@ methods:
         type: number
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: >-
-      Returns the range to which the conditional format is applied. If the conditional format is applied to multiple
-      ranges, then this method returns `undefined`<!-- -->.
+      Returns the range to which the conditional format is applied. If the
+      conditional format is applied to multiple ranges, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRanges()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getRanges:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getRanges:member(1)
     package: ExcelScript!
     fullName: getRanges()
     summary: >-
-      Returns the `RangeAreas`<!-- -->, comprising one or more rectangular ranges, to which the conditional format is
-      applied.
+      Returns the `RangeAreas`<!-- -->, comprising one or more rectangular
+      ranges, to which the conditional format is applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRanges(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getStopIfTrue()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getStopIfTrue:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getStopIfTrue:member(1)
     package: ExcelScript!
     fullName: getStopIfTrue()
     summary: >-
-      If the conditions of this conditional format are met, no lower-priority formats shall take effect on that cell.
-      Value is `null` on data bars, icon sets, and color scales as there's no concept of `StopIfTrue` for these.
+      If the conditions of this conditional format are met, no lower-priority
+      formats shall take effect on that cell. Value is `null` on data bars, icon
+      sets, and color scales as there's no concept of `StopIfTrue` for these.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -490,19 +561,23 @@ methods:
         type: boolean
         description: ''
   - name: getTextComparison()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getTextComparison:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getTextComparison:member(1)
     package: ExcelScript!
     fullName: getTextComparison()
     summary: >-
-      Returns the specific text conditional format properties if the current conditional format is a text type. For
-      example, to format cells matching the word "Text".
+      Returns the specific text conditional format properties if the current
+      conditional format is a text type. For example, to format cells matching
+      the word "Text".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTextComparison(): TextConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TextConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TextConditionalFormat:interface" />
+          | undefined
         description: |-
 
 
@@ -534,19 +609,24 @@ methods:
           }
           ```
   - name: getTopBottom()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getTopBottom:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getTopBottom:member(1)
     package: ExcelScript!
     fullName: getTopBottom()
     summary: >-
-      Returns the top/bottom conditional format properties if the current conditional format is a `TopBottom` type. For
-      example, to format the top 10% or bottom 10 items.
+      Returns the top/bottom conditional format properties if the current
+      conditional format is a `TopBottom` type. For example, to format the top
+      10% or bottom 10 items.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTopBottom(): TopBottomConditionalFormat | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TopBottomConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.TopBottomConditionalFormat:interface" />
+          | undefined
         description: |-
 
 
@@ -573,29 +653,34 @@ methods:
           }
           ```
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: A type of conditional format. Only one can be set at a time.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ConditionalFormatType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />
         description: ''
   - name: setPriority(priority)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#setPriority:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#setPriority:member(1)
     package: ExcelScript!
     fullName: setPriority(priority)
     summary: >-
-      The priority (or index) within the conditional format collection that this conditional format currently exists in.
-      Changing this also changes other conditional formats' priorities, to allow for a contiguous priority order. Use a
-      negative priority to begin from the back. Priorities greater than the bounds will get and set to the maximum (or
-      minimum if negative) priority. Also note that if you change the priority, you have to re-fetch a new copy of the
-      object at that new priority location if you want to make further changes to it.
+      The priority (or index) within the conditional format collection that this
+      conditional format currently exists in. Changing this also changes other
+      conditional formats' priorities, to allow for a contiguous priority order.
+      Use a negative priority to begin from the back. Priorities greater than
+      the bounds will get and set to the maximum (or minimum if negative)
+      priority. Also note that if you change the priority, you have to re-fetch
+      a new copy of the object at that new priority location if you want to make
+      further changes to it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -608,11 +693,12 @@ methods:
         type: void
         description: ''
   - name: setRanges(ranges)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#setRanges:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#setRanges:member(1)
     package: ExcelScript!
     fullName: setRanges(ranges)
     summary: Set the ranges that the conditional format rule is applied to.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -627,13 +713,15 @@ methods:
         type: void
         description: ''
   - name: setStopIfTrue(stopIfTrue)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormat#setStopIfTrue:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormat#setStopIfTrue:member(1)
     package: ExcelScript!
     fullName: setStopIfTrue(stopIfTrue)
     summary: >-
-      If the conditions of this conditional format are met, no lower-priority formats shall take effect on that cell.
-      Value is `null` on data bars, icon sets, and color scales as there's no concept of `StopIfTrue` for these.
+      If the conditions of this conditional format are met, no lower-priority
+      formats shall take effect on that cell. Value is `null` on data bars, icon
+      sets, and color scales as there's no concept of `StopIfTrue` for these.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatcolorcriteriontype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatcolorcriteriontype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatColorCriterionType
-uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatColorCriterionType
 summary: Represents the types of color criterion for conditional formatting.
@@ -37,34 +37,38 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.formula:member
     package: ExcelScript!
     summary: ''
   - name: highestValue
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.highestValue:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.highestValue:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: lowestValue
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.lowestValue:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.lowestValue:member
     package: ExcelScript!
     summary: ''
   - name: number
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.number:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.number:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.percent:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.percent:member
     package: ExcelScript!
     summary: ''
   - name: percentile
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.percentile:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatColorCriterionType.percentile:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatdirection.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatDirection
-uid: 'ExcelScript!ExcelScript.ConditionalFormatDirection:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatDirection
 summary: Represents the direction for a selection.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatDirection.bottom:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatDirection.bottom:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatDirection.top:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatDirection.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformaticonruletype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformaticonruletype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatIconRuleType
-uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatIconRuleType
 summary: Represents the types of icon conditional format.
@@ -41,26 +41,27 @@ remarks: |-
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType.formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType.formula:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: number
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType.number:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType.number:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType.percent:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType.percent:member
     package: ExcelScript!
     summary: ''
   - name: percentile
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatIconRuleType.percentile:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType.percentile:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatpresetcriterion.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatpresetcriterion.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatPresetCriterion
-uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatPresetCriterion
 summary: Represents the criteria of the preset criteria conditional format type.
@@ -35,114 +35,128 @@ remarks: |-
     presetFormat.setRule(duplicateRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: aboveAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.aboveAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.aboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: belowAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.belowAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.belowAverage:member
     package: ExcelScript!
     summary: ''
   - name: blanks
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.blanks:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.blanks:member
     package: ExcelScript!
     summary: ''
   - name: duplicateValues
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.duplicateValues:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.duplicateValues:member
     package: ExcelScript!
     summary: ''
   - name: equalOrAboveAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.equalOrAboveAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.equalOrAboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: equalOrBelowAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.equalOrBelowAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.equalOrBelowAverage:member
     package: ExcelScript!
     summary: ''
   - name: errors
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.errors:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.errors:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.invalid:member
     package: ExcelScript!
     summary: ''
   - name: lastMonth
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastMonth:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastMonth:member
     package: ExcelScript!
     summary: ''
   - name: lastSevenDays
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastSevenDays:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastSevenDays:member
     package: ExcelScript!
     summary: ''
   - name: lastWeek
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastWeek:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.lastWeek:member
     package: ExcelScript!
     summary: ''
   - name: nextMonth
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nextMonth:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nextMonth:member
     package: ExcelScript!
     summary: ''
   - name: nextWeek
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nextWeek:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nextWeek:member
     package: ExcelScript!
     summary: ''
   - name: nonBlanks
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nonBlanks:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nonBlanks:member
     package: ExcelScript!
     summary: ''
   - name: nonErrors
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nonErrors:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.nonErrors:member
     package: ExcelScript!
     summary: ''
   - name: oneStdDevAboveAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.oneStdDevAboveAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.oneStdDevAboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: oneStdDevBelowAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.oneStdDevBelowAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.oneStdDevBelowAverage:member
     package: ExcelScript!
     summary: ''
   - name: thisMonth
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.thisMonth:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.thisMonth:member
     package: ExcelScript!
     summary: ''
   - name: thisWeek
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.thisWeek:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.thisWeek:member
     package: ExcelScript!
     summary: ''
   - name: threeStdDevAboveAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.threeStdDevAboveAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.threeStdDevAboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: threeStdDevBelowAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.threeStdDevBelowAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.threeStdDevBelowAverage:member
     package: ExcelScript!
     summary: ''
   - name: today
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.today:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.today:member
     package: ExcelScript!
     summary: ''
   - name: tomorrow
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.tomorrow:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.tomorrow:member
     package: ExcelScript!
     summary: ''
   - name: twoStdDevAboveAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.twoStdDevAboveAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.twoStdDevAboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: twoStdDevBelowAverage
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.twoStdDevBelowAverage:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.twoStdDevBelowAverage:member
     package: ExcelScript!
     summary: ''
   - name: uniqueValues
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.uniqueValues:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.uniqueValues:member
     package: ExcelScript!
     summary: ''
   - name: yesterday
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.yesterday:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion.yesterday:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatrule.yml
@@ -1,9 +1,9 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalFormatRule
-uid: 'ExcelScript!ExcelScript.ConditionalFormatRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalFormatRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatRule
-summary: 'Represents a rule, for all traditional rule/format pairings.'
+summary: Represents a rule, for all traditional rule/format pairings.
 remarks: |-
 
 
@@ -30,16 +30,20 @@ remarks: |-
     positiveRule.setFormula(`=${selectedRange.getCell(0, 0).getAddress()}>${selectedRange.getOffsetRange(0, -1).getCell(0, 0).getAddress()}`);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormula()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRule#getFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRule#getFormula:member(1)
     package: ExcelScript!
     fullName: getFormula()
-    summary: 'The formula, if required, on which to evaluate the conditional format rule.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format
+      rule.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -48,11 +52,14 @@ methods:
         type: string
         description: ''
   - name: getFormulaLocal()
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRule#getFormulaLocal:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRule#getFormulaLocal:member(1)
     package: ExcelScript!
     fullName: getFormulaLocal()
-    summary: 'The formula, if required, on which to evaluate the conditional format rule in the user''s language.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format rule
+      in the user's language.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,11 +68,14 @@ methods:
         type: string
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRule#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRule#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: 'The formula, if required, on which to evaluate the conditional format rule.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format
+      rule.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -78,11 +88,14 @@ methods:
         type: void
         description: ''
   - name: setFormulaLocal(formulaLocal)
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRule#setFormulaLocal:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRule#setFormulaLocal:member(1)
     package: ExcelScript!
     fullName: setFormulaLocal(formulaLocal)
-    summary: 'The formula, if required, on which to evaluate the conditional format rule in the user''s language.'
+    summary: >-
+      The formula, if required, on which to evaluate the conditional format rule
+      in the user's language.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatruletype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformatruletype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatRuleType
-uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatRuleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatRuleType
 summary: Represents the types of conditional format values.
@@ -37,38 +37,39 @@ remarks: |-
     dataBarFormat.setUpperBoundRule(upperBound);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.automatic:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.automatic:member
     package: ExcelScript!
     summary: ''
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.formula:member
     package: ExcelScript!
     summary: ''
   - name: highestValue
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.highestValue:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.highestValue:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: lowestValue
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.lowestValue:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.lowestValue:member
     package: ExcelScript!
     summary: ''
   - name: number
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.number:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.number:member
     package: ExcelScript!
     summary: ''
   - name: percent
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.percent:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.percent:member
     package: ExcelScript!
     summary: ''
   - name: percentile
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatRuleType.percentile:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatRuleType.percentile:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformattype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalformattype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalFormatType
-uid: 'ExcelScript!ExcelScript.ConditionalFormatType:enum'
+uid: ExcelScript!ExcelScript.ConditionalFormatType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatType
 summary: ''
@@ -37,38 +37,39 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: cellValue
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.cellValue:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.cellValue:member
     package: ExcelScript!
     summary: ''
   - name: colorScale
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.colorScale:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.colorScale:member
     package: ExcelScript!
     summary: ''
   - name: containsText
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.containsText:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.containsText:member
     package: ExcelScript!
     summary: ''
   - name: custom
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.custom:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.custom:member
     package: ExcelScript!
     summary: ''
   - name: dataBar
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.dataBar:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.dataBar:member
     package: ExcelScript!
     summary: ''
   - name: iconSet
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.iconSet:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.iconSet:member
     package: ExcelScript!
     summary: ''
   - name: presetCriteria
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.presetCriteria:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.presetCriteria:member
     package: ExcelScript!
     summary: ''
   - name: topBottom
-    uid: 'ExcelScript!ExcelScript.ConditionalFormatType.topBottom:member'
+    uid: ExcelScript!ExcelScript.ConditionalFormatType.topBottom:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaliconcriterion.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaliconcriterion.yml
@@ -1,11 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalIconCriterion
-uid: 'ExcelScript!ExcelScript.ConditionalIconCriterion:interface'
+uid: ExcelScript!ExcelScript.ConditionalIconCriterion:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalIconCriterion
 summary: >-
-  Represents an icon criterion which contains a type, value, an operator, and an optional custom icon, if not using an
-  icon set.
+  Represents an icon criterion which contains a type, value, an operator, and an
+  optional custom icon, if not using an icon set.
 remarks: |-
 
 
@@ -43,28 +43,33 @@ remarks: |-
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: customIcon
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterion#customIcon:member'
+    uid: ExcelScript!ExcelScript.ConditionalIconCriterion#customIcon:member
     package: ExcelScript!
     fullName: customIcon
-    summary: 'The custom icon for the current criterion, if different from the default icon set, else `null` will be returned.'
+    summary: >-
+      The custom icon for the current criterion, if different from the default
+      icon set, else `null` will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'customIcon?: Icon;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Icon:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Icon:interface" />
   - name: formula
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterion#formula:member'
+    uid: ExcelScript!ExcelScript.ConditionalIconCriterion#formula:member
     package: ExcelScript!
     fullName: formula
     summary: A number or a formula depending on the type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,26 +77,34 @@ properties:
       return:
         type: string
   - name: operator
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterion#operator:member'
+    uid: ExcelScript!ExcelScript.ConditionalIconCriterion#operator:member
     package: ExcelScript!
     fullName: operator
-    summary: '`greaterThan` or `greaterThanOrEqual` for each of the rule types for the icon conditional format.'
+    summary: >-
+      `greaterThan` or `greaterThanOrEqual` for each of the rule types for the
+      icon conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator: ConditionalIconCriterionOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum" />
   - name: type
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterion#type:member'
+    uid: ExcelScript!ExcelScript.ConditionalIconCriterion#type:member
     package: ExcelScript!
     fullName: type
     summary: What the icon conditional formula should be based on.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: ConditionalFormatIconRuleType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum"
+          />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaliconcriterionoperator.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaliconcriterionoperator.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalIconCriterionOperator
-uid: 'ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum'
+uid: ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalIconCriterionOperator
 summary: Represents the operator for each icon criteria.
@@ -41,18 +41,21 @@ remarks: |-
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: greaterThan
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterionOperator.greaterThan:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalIconCriterionOperator.greaterThan:member
     package: ExcelScript!
     summary: ''
   - name: greaterThanOrEqual
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterionOperator.greaterThanOrEqual:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalIconCriterionOperator.greaterThanOrEqual:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalIconCriterionOperator.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalIconCriterionOperator.invalid:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalpresetcriteriarule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalpresetcriteriarule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalPresetCriteriaRule
-uid: 'ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalPresetCriteriaRule
 summary: Represents the preset criteria conditional format rule.
@@ -35,19 +35,23 @@ remarks: |-
     presetFormat.setRule(duplicateRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: criterion
-    uid: 'ExcelScript!ExcelScript.ConditionalPresetCriteriaRule#criterion:member'
+    uid: ExcelScript!ExcelScript.ConditionalPresetCriteriaRule#criterion:member
     package: ExcelScript!
     fullName: criterion
     summary: The criterion of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'criterion: ConditionalFormatPresetCriterion;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborder.yml
@@ -1,22 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalRangeBorder
-uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder:interface'
+uid: ExcelScript!ExcelScript.ConditionalRangeBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorder
 summary: Represents the border of an object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorder#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange").
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,43 +27,50 @@ methods:
         type: string
         description: ''
   - name: getSideIndex()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder#getSideIndex:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorder#getSideIndex:member(1)
     package: ExcelScript!
     fullName: getSideIndex()
     summary: >-
-      Constant value that indicates the specific side of the border. See `ExcelScript.ConditionalRangeBorderIndex` for
-      details.
+      Constant value that indicates the specific side of the border. See
+      `ExcelScript.ConditionalRangeBorderIndex` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSideIndex(): ConditionalRangeBorderIndex;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum"
+          />
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorder#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
     summary: >-
-      One of the constants of line style specifying the line style for the border. See `ExcelScript.BorderLineStyle` for
-      details.
+      One of the constants of line style specifying the line style for the
+      border. See `ExcelScript.BorderLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getStyle(): ConditionalRangeBorderLineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum" />
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorder#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500") or as a named
-      HTML color (e.g., "orange").
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -74,13 +83,14 @@ methods:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorder#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorder#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
     summary: >-
-      One of the constants of line style specifying the line style for the border. See `ExcelScript.BorderLineStyle` for
-      details.
+      One of the constants of line style specifying the line style for the
+      border. See `ExcelScript.BorderLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,7 +98,10 @@ methods:
       parameters:
         - id: style
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborderindex.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborderindex.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalRangeBorderIndex
-uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum'
+uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorderIndex
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: edgeBottom
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeBottom:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeBottom:member
     package: ExcelScript!
     summary: ''
   - name: edgeLeft
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeLeft:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeLeft:member
     package: ExcelScript!
     summary: ''
   - name: edgeRight
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeRight:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeRight:member
     package: ExcelScript!
     summary: ''
   - name: edgeTop
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeTop:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex.edgeTop:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeborderlinestyle.yml
@@ -1,34 +1,35 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalRangeBorderLineStyle
-uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum'
+uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorderLineStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: continuous
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.continuous:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.continuous:member
     package: ExcelScript!
     summary: ''
   - name: dash
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dash:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: dashDot
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dashDot:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dashDot:member
     package: ExcelScript!
     summary: ''
   - name: dashDotDot
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dashDotDot:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dashDotDot:member
     package: ExcelScript!
     summary: ''
   - name: dot
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dot:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.dot:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.none:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle.none:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefill.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalRangeFill
-uid: 'ExcelScript!ExcelScript.ConditionalRangeFill:interface'
+uid: ExcelScript!ExcelScript.ConditionalRangeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFill
 summary: Represents the background of a conditional range object.
@@ -37,16 +37,18 @@ remarks: |-
     font.setItalic(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFill#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFill#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Resets the fill.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,13 +57,14 @@ methods:
         type: void
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFill#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFill#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      HTML color code representing the color of the fill, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color
-      (e.g., "orange").
+      HTML color code representing the color of the fill, in the form \#RRGGBB
+      (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -70,13 +73,14 @@ methods:
         type: string
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFill#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFill#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      HTML color code representing the color of the fill, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color
-      (e.g., "orange").
+      HTML color code representing the color of the fill, in the form \#RRGGBB
+      (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefont.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalRangeFont
-uid: 'ExcelScript!ExcelScript.ConditionalRangeFont:interface'
+uid: ExcelScript!ExcelScript.ConditionalRangeFont:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFont
-summary: 'This object represents the font attributes (font style, color, etc.) for an object.'
+summary: >-
+  This object represents the font attributes (font style, color, etc.) for an
+  object.
 remarks: |-
 
 
@@ -37,16 +39,18 @@ remarks: |-
     font.setItalic(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Resets the font formats.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,11 +59,12 @@ methods:
         type: void
         description: ''
   - name: getBold()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#getBold:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#getBold:member(1)
     package: ExcelScript!
     fullName: getBold()
     summary: Specifies if the font is bold.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -68,11 +73,14 @@ methods:
         type: boolean
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -81,11 +89,12 @@ methods:
         type: string
         description: ''
   - name: getItalic()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#getItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#getItalic:member(1)
     package: ExcelScript!
     fullName: getItalic()
     summary: Specifies if the font is italic.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -94,11 +103,12 @@ methods:
         type: boolean
         description: ''
   - name: getStrikethrough()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#getStrikethrough:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#getStrikethrough:member(1)
     package: ExcelScript!
     fullName: getStrikethrough()
     summary: Specifies the strikethrough status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -107,24 +117,31 @@ methods:
         type: boolean
         description: ''
   - name: getUnderline()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#getUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#getUnderline:member(1)
     package: ExcelScript!
     fullName: getUnderline()
-    summary: The type of underline applied to the font. See `ExcelScript.ConditionalRangeFontUnderlineStyle` for details.
+    summary: >-
+      The type of underline applied to the font. See
+      `ExcelScript.ConditionalRangeFontUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getUnderline(): ConditionalRangeFontUnderlineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum"
+          />
         description: ''
   - name: setBold(bold)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#setBold:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#setBold:member(1)
     package: ExcelScript!
     fullName: setBold(bold)
     summary: Specifies if the font is bold.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -137,11 +154,14 @@ methods:
         type: void
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -154,11 +174,12 @@ methods:
         type: void
         description: ''
   - name: setItalic(italic)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#setItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#setItalic:member(1)
     package: ExcelScript!
     fullName: setItalic(italic)
     summary: Specifies if the font is italic.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -171,11 +192,12 @@ methods:
         type: void
         description: ''
   - name: setStrikethrough(strikethrough)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#setStrikethrough:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#setStrikethrough:member(1)
     package: ExcelScript!
     fullName: setStrikethrough(strikethrough)
     summary: Specifies the strikethrough status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -188,11 +210,14 @@ methods:
         type: void
         description: ''
   - name: setUnderline(underline)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFont#setUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFont#setUnderline:member(1)
     package: ExcelScript!
     fullName: setUnderline(underline)
-    summary: The type of underline applied to the font. See `ExcelScript.ConditionalRangeFontUnderlineStyle` for details.
+    summary: >-
+      The type of underline applied to the font. See
+      `ExcelScript.ConditionalRangeFontUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -200,7 +225,10 @@ methods:
       parameters:
         - id: underline
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefontunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangefontunderlinestyle.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalRangeFontUnderlineStyle
-uid: 'ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum'
+uid: ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFontUnderlineStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: double
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.double:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.double:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.none:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: single
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.single:member'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle.single:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionalrangeformat.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalRangeFormat
-uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat:interface'
+uid: ExcelScript!ExcelScript.ConditionalRangeFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFormat
-summary: 'A format object encapsulating the conditional formats range''s font, fill, borders, and other properties.'
+summary: >-
+  A format object encapsulating the conditional formats range's font, fill,
+  borders, and other properties.
 remarks: |-
 
 
@@ -35,16 +37,20 @@ remarks: |-
     format.getFont().setItalic(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clearFormat()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#clearFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#clearFormat:member(1)
     package: ExcelScript!
     fullName: clearFormat()
-    summary: Remove the format properties from a conditional format rule. This creates a rule with no format settings.
+    summary: >-
+      Remove the format properties from a conditional format rule. This creates
+      a rule with no format settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -53,24 +59,31 @@ methods:
         type: void
         description: ''
   - name: getBorders()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getBorders:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#getBorders:member(1)
     package: ExcelScript!
     fullName: getBorders()
-    summary: Collection of border objects that apply to the overall conditional format range.
+    summary: >-
+      Collection of border objects that apply to the overall conditional format
+      range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorders(): ConditionalRangeBorder[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />[]
         description: ''
   - name: getConditionalRangeBorder(index)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorder:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorder:member(1)
     package: ExcelScript!
     fullName: getConditionalRangeBorder(index)
     summary: Gets a border object using its name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,95 +93,122 @@ methods:
                 ): ConditionalRangeBorder;
       parameters:
         - id: index
-          description: Index value of the border object to be retrieved. See `ExcelScript.ConditionalRangeBorderIndex` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum" />'
+          description: >-
+            Index value of the border object to be retrieved. See
+            `ExcelScript.ConditionalRangeBorderIndex` for details.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum"
+            />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />
         description: ''
   - name: getConditionalRangeBorderBottom()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderBottom:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderBottom:member(1)
     package: ExcelScript!
     fullName: getConditionalRangeBorderBottom()
     summary: Gets the bottom border.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalRangeBorderBottom(): ConditionalRangeBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />
         description: ''
   - name: getConditionalRangeBorderLeft()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderLeft:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderLeft:member(1)
     package: ExcelScript!
     fullName: getConditionalRangeBorderLeft()
     summary: Gets the left border.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalRangeBorderLeft(): ConditionalRangeBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />
         description: ''
   - name: getConditionalRangeBorderRight()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderRight:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderRight:member(1)
     package: ExcelScript!
     fullName: getConditionalRangeBorderRight()
     summary: Gets the right border.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalRangeBorderRight(): ConditionalRangeBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />
         description: ''
   - name: getConditionalRangeBorderTop()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderTop:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalRangeFormat#getConditionalRangeBorderTop:member(1)
     package: ExcelScript!
     fullName: getConditionalRangeBorderTop()
     summary: Gets the top border.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalRangeBorderTop(): ConditionalRangeBorder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeBorder:interface"
+          />
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Returns the fill object defined on the overall conditional format range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ConditionalRangeFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalRangeFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
     summary: Returns the font object defined on the overall conditional format range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ConditionalRangeFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalRangeFont:interface" />
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
-    summary: Represents Excel's number format code for the given range. Cleared if `null` is passed in.
+    summary: >-
+      Represents Excel's number format code for the given range. Cleared if
+      `null` is passed in.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -177,11 +217,14 @@ methods:
         type: string
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.ConditionalRangeFormat#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.ConditionalRangeFormat#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
-    summary: Represents Excel's number format code for the given range. Cleared if `null` is passed in.
+    summary: >-
+      Represents Excel's number format code for the given range. Cleared if
+      `null` is passed in.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltextcomparisonrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltextcomparisonrule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalTextComparisonRule
-uid: 'ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTextComparisonRule
 summary: Represents a cell value conditional format rule.
@@ -34,28 +34,31 @@ remarks: |-
     textConditionFormat.setRule(textRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: operator
-    uid: 'ExcelScript!ExcelScript.ConditionalTextComparisonRule#operator:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextComparisonRule#operator:member
     package: ExcelScript!
     fullName: operator
     summary: The operator of the text conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator: ConditionalTextOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalTextOperator:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalTextOperator:enum" />
   - name: text
-    uid: 'ExcelScript!ExcelScript.ConditionalTextComparisonRule#text:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextComparisonRule#text:member
     package: ExcelScript!
     fullName: text
     summary: The text value of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltextoperator.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltextoperator.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalTextOperator
-uid: 'ExcelScript!ExcelScript.ConditionalTextOperator:enum'
+uid: ExcelScript!ExcelScript.ConditionalTextOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTextOperator
 summary: Represents the operator of the text conditional format type.
@@ -34,26 +34,27 @@ remarks: |-
     textConditionFormat.setRule(textRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: beginsWith
-    uid: 'ExcelScript!ExcelScript.ConditionalTextOperator.beginsWith:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextOperator.beginsWith:member
     package: ExcelScript!
     summary: ''
   - name: contains
-    uid: 'ExcelScript!ExcelScript.ConditionalTextOperator.contains:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextOperator.contains:member
     package: ExcelScript!
     summary: ''
   - name: endsWith
-    uid: 'ExcelScript!ExcelScript.ConditionalTextOperator.endsWith:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextOperator.endsWith:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalTextOperator.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextOperator.invalid:member
     package: ExcelScript!
     summary: ''
   - name: notContains
-    uid: 'ExcelScript!ExcelScript.ConditionalTextOperator.notContains:member'
+    uid: ExcelScript!ExcelScript.ConditionalTextOperator.notContains:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltopbottomcriteriontype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltopbottomcriteriontype.yml
@@ -1,30 +1,34 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConditionalTopBottomCriterionType
-uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum'
+uid: ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTopBottomCriterionType
 summary: Represents the criteria for the above/below average conditional format type.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottomItems
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.bottomItems:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.bottomItems:member
     package: ExcelScript!
     summary: ''
   - name: bottomPercent
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.bottomPercent:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.bottomPercent:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.invalid:member'
+    uid: ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.invalid:member
     package: ExcelScript!
     summary: ''
   - name: topItems
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.topItems:member'
+    uid: ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.topItems:member
     package: ExcelScript!
     summary: ''
   - name: topPercent
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.topPercent:member'
+    uid: >-
+      ExcelScript!ExcelScript.ConditionalTopBottomCriterionType.topPercent:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltopbottomrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.conditionaltopbottomrule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ConditionalTopBottomRule
-uid: 'ExcelScript!ExcelScript.ConditionalTopBottomRule:interface'
+uid: ExcelScript!ExcelScript.ConditionalTopBottomRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTopBottomRule
 summary: Represents the rule of the top/bottom conditional format.
@@ -30,16 +30,20 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: rank
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomRule#rank:member'
+    uid: ExcelScript!ExcelScript.ConditionalTopBottomRule#rank:member
     package: ExcelScript!
     fullName: rank
-    summary: The rank between 1 and 1000 for numeric ranks or 1 and 100 for percent ranks.
+    summary: >-
+      The rank between 1 and 1000 for numeric ranks or 1 and 100 for percent
+      ranks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -47,14 +51,18 @@ properties:
       return:
         type: number
   - name: type
-    uid: 'ExcelScript!ExcelScript.ConditionalTopBottomRule#type:member'
+    uid: ExcelScript!ExcelScript.ConditionalTopBottomRule#type:member
     package: ExcelScript!
     fullName: type
     summary: Format values based on the top or bottom rank.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: ConditionalTopBottomCriterionType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum"
+          />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.connectortype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.connectortype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ConnectorType
-uid: 'ExcelScript!ExcelScript.ConnectorType:enum'
+uid: ExcelScript!ExcelScript.ConnectorType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConnectorType
 summary: ''
@@ -30,18 +30,19 @@ remarks: |-
       ExcelScript.ConnectorType.straight);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: curve
-    uid: 'ExcelScript!ExcelScript.ConnectorType.curve:member'
+    uid: ExcelScript!ExcelScript.ConnectorType.curve:member
     package: ExcelScript!
     summary: ''
   - name: elbow
-    uid: 'ExcelScript!ExcelScript.ConnectorType.elbow:member'
+    uid: ExcelScript!ExcelScript.ConnectorType.elbow:member
     package: ExcelScript!
     summary: ''
   - name: straight
-    uid: 'ExcelScript!ExcelScript.ConnectorType.straight:member'
+    uid: ExcelScript!ExcelScript.ConnectorType.straight:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.contenttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.contenttype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ContentType
-uid: 'ExcelScript!ExcelScript.ContentType:enum'
+uid: ExcelScript!ExcelScript.ContentType:enum
 package: ExcelScript!
 fullName: ExcelScript.ContentType
 summary: ''
@@ -46,14 +46,15 @@ remarks: |-
     currentSheet.addComment(cell, content, ExcelScript.ContentType.mention);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: mention
-    uid: 'ExcelScript!ExcelScript.ContentType.mention:member'
+    uid: ExcelScript!ExcelScript.ContentType.mention:member
     package: ExcelScript!
     summary: Comment content containing mentions.
   - name: plain
-    uid: 'ExcelScript!ExcelScript.ContentType.plain:member'
+    uid: ExcelScript!ExcelScript.ContentType.plain:member
     package: ExcelScript!
     summary: Indicates a plain format type for the comment content.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.cultureinfo.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.cultureinfo.yml
@@ -1,11 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.CultureInfo
-uid: 'ExcelScript!ExcelScript.CultureInfo:interface'
+uid: ExcelScript!ExcelScript.CultureInfo:interface
 package: ExcelScript!
 fullName: ExcelScript.CultureInfo
 summary: >-
-  Provides information based on current system culture settings. This includes the culture names, number formatting, and
-  other culturally dependent settings.
+  Provides information based on current system culture settings. This includes
+  the culture names, number formatting, and other culturally dependent settings.
 remarks: |-
 
 
@@ -33,33 +33,36 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getDatetimeFormat()
-    uid: 'ExcelScript!ExcelScript.CultureInfo#getDatetimeFormat:member(1)'
+    uid: ExcelScript!ExcelScript.CultureInfo#getDatetimeFormat:member(1)
     package: ExcelScript!
     fullName: getDatetimeFormat()
     summary: >-
-      Defines the culturally appropriate format of displaying date and time. This is based on current system culture
-      settings.
+      Defines the culturally appropriate format of displaying date and time.
+      This is based on current system culture settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDatetimeFormat(): DatetimeFormatInfo;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DatetimeFormatInfo:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DatetimeFormatInfo:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.CultureInfo#getName:member(1)'
+    uid: ExcelScript!ExcelScript.CultureInfo#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: >-
-      Gets the culture name in the format languagecode2-country/regioncode2 (e.g., "zh-cn" or "en-us"). This is based on
-      current system settings.
+      Gets the culture name in the format languagecode2-country/regioncode2
+      (e.g., "zh-cn" or "en-us"). This is based on current system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -68,15 +71,18 @@ methods:
         type: string
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.CultureInfo#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.CultureInfo#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
-    summary: Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+    summary: >-
+      Defines the culturally appropriate format of displaying numbers. This is
+      based on current system culture settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormat(): NumberFormatInfo;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NumberFormatInfo:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NumberFormatInfo:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.customconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.CustomConditionalFormat
-uid: 'ExcelScript!ExcelScript.CustomConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.CustomConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomConditionalFormat
 summary: Represents a custom conditional format type.
@@ -37,33 +37,40 @@ remarks: |-
     sameCustom.getRule().setFormula(`=${selectedRange.getCell(0, 0).getAddress()}=${selectedRange.getOffsetRange(0, -1).getCell(0, 0).getAddress()}`);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.CustomConditionalFormat#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.CustomConditionalFormat#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the conditional formats font, fill, borders, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the conditional formats font, fill,
+      borders, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ConditionalRangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface"
+          />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.CustomConditionalFormat#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.CustomConditionalFormat#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
     summary: Specifies the `Rule` object on this conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): ConditionalFormatRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatRule:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormatRule:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.customdatavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.customdatavalidation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.CustomDataValidation
-uid: 'ExcelScript!ExcelScript.CustomDataValidation:interface'
+uid: ExcelScript!ExcelScript.CustomDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomDataValidation
 summary: Represents the custom data validation criteria.
@@ -30,18 +30,20 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: formula
-    uid: 'ExcelScript!ExcelScript.CustomDataValidation#formula:member'
+    uid: ExcelScript!ExcelScript.CustomDataValidation#formula:member
     package: ExcelScript!
     fullName: formula
     summary: >-
-      A custom data validation formula. This creates special input rules, such as preventing duplicates, or limiting the
-      total in a range of cells.
+      A custom data validation formula. This creates special input rules, such
+      as preventing duplicates, or limiting the total in a range of cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.customproperty.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.customproperty.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.CustomProperty
-uid: 'ExcelScript!ExcelScript.CustomProperty:interface'
+uid: ExcelScript!ExcelScript.CustomProperty:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomProperty
 summary: Represents a custom property.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.CustomProperty#delete:member(1)'
+    uid: ExcelScript!ExcelScript.CustomProperty#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,13 +25,15 @@ methods:
         type: void
         description: ''
   - name: getKey()
-    uid: 'ExcelScript!ExcelScript.CustomProperty#getKey:member(1)'
+    uid: ExcelScript!ExcelScript.CustomProperty#getKey:member(1)
     package: ExcelScript!
     fullName: getKey()
     summary: >-
-      The key of the custom property. The key is limited to 255 characters outside of Excel on the web (larger keys are
-      automatically trimmed to 255 characters on other platforms).
+      The key of the custom property. The key is limited to 255 characters
+      outside of Excel on the web (larger keys are automatically trimmed to 255
+      characters on other platforms).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -38,26 +42,29 @@ methods:
         type: string
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.CustomProperty#getType:member(1)'
+    uid: ExcelScript!ExcelScript.CustomProperty#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: The type of the value used for the custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): DocumentPropertyType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DocumentPropertyType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DocumentPropertyType:enum" />
         description: ''
   - name: getValue()
-    uid: 'ExcelScript!ExcelScript.CustomProperty#getValue:member(1)'
+    uid: ExcelScript!ExcelScript.CustomProperty#getValue:member(1)
     package: ExcelScript!
     fullName: getValue()
     summary: >-
-      The value of the custom property. The value is limited to 255 characters outside of Excel on the web (larger
-      values are automatically trimmed to 255 characters on other platforms).
+      The value of the custom property. The value is limited to 255 characters
+      outside of Excel on the web (larger values are automatically trimmed to
+      255 characters on other platforms).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -66,13 +73,15 @@ methods:
         type: any
         description: ''
   - name: setValue(value)
-    uid: 'ExcelScript!ExcelScript.CustomProperty#setValue:member(1)'
+    uid: ExcelScript!ExcelScript.CustomProperty#setValue:member(1)
     package: ExcelScript!
     fullName: setValue(value)
     summary: >-
-      The value of the custom property. The value is limited to 255 characters outside of Excel on the web (larger
-      values are automatically trimmed to 255 characters on other platforms).
+      The value of the custom property. The value is limited to 255 characters
+      outside of Excel on the web (larger values are automatically trimmed to
+      255 characters on other platforms).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.customxmlpart.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.CustomXmlPart
-uid: 'ExcelScript!ExcelScript.CustomXmlPart:interface'
+uid: ExcelScript!ExcelScript.CustomXmlPart:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomXmlPart
 summary: Represents a custom XML part object in a workbook.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.CustomXmlPart#delete:member(1)'
+    uid: ExcelScript!ExcelScript.CustomXmlPart#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the custom XML part.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,12 @@ methods:
         type: void
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.CustomXmlPart#getId:member(1)'
+    uid: ExcelScript!ExcelScript.CustomXmlPart#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: The custom XML part's ID.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ methods:
         type: string
         description: ''
   - name: getNamespaceUri()
-    uid: 'ExcelScript!ExcelScript.CustomXmlPart#getNamespaceUri:member(1)'
+    uid: ExcelScript!ExcelScript.CustomXmlPart#getNamespaceUri:member(1)
     package: ExcelScript!
     fullName: getNamespaceUri()
     summary: The custom XML part's namespace URI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +53,12 @@ methods:
         type: string
         description: ''
   - name: getXml()
-    uid: 'ExcelScript!ExcelScript.CustomXmlPart#getXml:member(1)'
+    uid: ExcelScript!ExcelScript.CustomXmlPart#getXml:member(1)
     package: ExcelScript!
     fullName: getXml()
     summary: Gets the custom XML part's full XML content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +67,12 @@ methods:
         type: string
         description: ''
   - name: setXml(xml)
-    uid: 'ExcelScript!ExcelScript.CustomXmlPart#setXml:member(1)'
+    uid: ExcelScript!ExcelScript.CustomXmlPart#setXml:member(1)
     package: ExcelScript!
     fullName: setXml(xml)
     summary: Sets the custom XML part's full XML content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.databarconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DataBarConditionalFormat
-uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.DataBarConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.DataBarConditionalFormat
 summary: Represents an Excel conditional data bar type.
@@ -37,18 +37,21 @@ remarks: |-
     dataBarFormat.setUpperBoundRule(upperBound);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAxisColor()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getAxisColor:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#getAxisColor:member(1)
     package: ExcelScript!
     fullName: getAxisColor()
     summary: >-
-      HTML color code representing the color of the Axis line, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML
-      color (e.g., "orange"). Value is "" (an empty string) if no axis is present or set.
+      HTML color code representing the color of the Axis line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no axis is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -57,79 +60,106 @@ methods:
         type: string
         description: ''
   - name: getAxisFormat()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getAxisFormat:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#getAxisFormat:member(1)
     package: ExcelScript!
     fullName: getAxisFormat()
     summary: Representation of how the axis is determined for an Excel data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAxisFormat(): ConditionalDataBarAxisFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum"
+          />
         description: ''
   - name: getBarDirection()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getBarDirection:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#getBarDirection:member(1)
     package: ExcelScript!
     fullName: getBarDirection()
     summary: Specifies the direction that the data bar graphic should be based on.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBarDirection(): ConditionalDataBarDirection;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarDirection:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalDataBarDirection:enum"
+          />
         description: ''
   - name: getLowerBoundRule()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getLowerBoundRule:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#getLowerBoundRule:member(1)
     package: ExcelScript!
     fullName: getLowerBoundRule()
     summary: >-
-      The rule for what constitutes the lower bound (and how to calculate it, if applicable) for a data bar. The
-      `ConditionalDataBarRule` object must be set as a JSON object (use `x.lowerBoundRule = {...}` instead of
+      The rule for what constitutes the lower bound (and how to calculate it, if
+      applicable) for a data bar. The `ConditionalDataBarRule` object must be
+      set as a JSON object (use `x.lowerBoundRule = {...}` instead of
       `x.lowerBoundRule.formula = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLowerBoundRule(): ConditionalDataBarRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface"
+          />
         description: ''
   - name: getNegativeFormat()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getNegativeFormat:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#getNegativeFormat:member(1)
     package: ExcelScript!
     fullName: getNegativeFormat()
     summary: Representation of all values to the left of the axis in an Excel data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNegativeFormat(): ConditionalDataBarNegativeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface"
+          />
         description: ''
   - name: getPositiveFormat()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getPositiveFormat:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#getPositiveFormat:member(1)
     package: ExcelScript!
     fullName: getPositiveFormat()
-    summary: Representation of all values to the right of the axis in an Excel data bar.
+    summary: >-
+      Representation of all values to the right of the axis in an Excel data
+      bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPositiveFormat(): ConditionalDataBarPositiveFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface"
+          />
         description: ''
   - name: getShowDataBarOnly()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getShowDataBarOnly:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#getShowDataBarOnly:member(1)
     package: ExcelScript!
     fullName: getShowDataBarOnly()
-    summary: 'If `true`<!-- -->, hides the values from the cells where the data bar is applied.'
+    summary: >-
+      If `true`<!-- -->, hides the values from the cells where the data bar is
+      applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -138,29 +168,36 @@ methods:
         type: boolean
         description: ''
   - name: getUpperBoundRule()
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#getUpperBoundRule:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#getUpperBoundRule:member(1)
     package: ExcelScript!
     fullName: getUpperBoundRule()
     summary: >-
-      The rule for what constitutes the upper bound (and how to calculate it, if applicable) for a data bar. The
-      `ConditionalDataBarRule` object must be set as a JSON object (use `x.upperBoundRule = {...}` instead of
+      The rule for what constitutes the upper bound (and how to calculate it, if
+      applicable) for a data bar. The `ConditionalDataBarRule` object must be
+      set as a JSON object (use `x.upperBoundRule = {...}` instead of
       `x.upperBoundRule.formula = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getUpperBoundRule(): ConditionalDataBarRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface"
+          />
         description: ''
   - name: setAxisColor(axisColor)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setAxisColor:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#setAxisColor:member(1)
     package: ExcelScript!
     fullName: setAxisColor(axisColor)
     summary: >-
-      HTML color code representing the color of the Axis line, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML
-      color (e.g., "orange"). Value is "" (an empty string) if no axis is present or set.
+      HTML color code representing the color of the Axis line, in the form
+      \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange"). Value
+      is "" (an empty string) if no axis is present or set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -173,11 +210,12 @@ methods:
         type: void
         description: ''
   - name: setAxisFormat(axisFormat)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setAxisFormat:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#setAxisFormat:member(1)
     package: ExcelScript!
     fullName: setAxisFormat(axisFormat)
     summary: Representation of how the axis is determined for an Excel data bar.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -185,16 +223,19 @@ methods:
       parameters:
         - id: axisFormat
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum" />
       return:
         type: void
         description: ''
   - name: setBarDirection(barDirection)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setBarDirection:member(1)'
+    uid: ExcelScript!ExcelScript.DataBarConditionalFormat#setBarDirection:member(1)
     package: ExcelScript!
     fullName: setBarDirection(barDirection)
     summary: Specifies the direction that the data bar graphic should be based on.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -202,19 +243,24 @@ methods:
       parameters:
         - id: barDirection
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarDirection:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ConditionalDataBarDirection:enum"
+            />
       return:
         type: void
         description: ''
   - name: setLowerBoundRule(lowerBoundRule)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setLowerBoundRule:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#setLowerBoundRule:member(1)
     package: ExcelScript!
     fullName: setLowerBoundRule(lowerBoundRule)
     summary: >-
-      The rule for what constitutes the lower bound (and how to calculate it, if applicable) for a data bar. The
-      `ConditionalDataBarRule` object must be set as a JSON object (use `x.lowerBoundRule = {...}` instead of
+      The rule for what constitutes the lower bound (and how to calculate it, if
+      applicable) for a data bar. The `ConditionalDataBarRule` object must be
+      set as a JSON object (use `x.lowerBoundRule = {...}` instead of
       `x.lowerBoundRule.formula = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -222,16 +268,22 @@ methods:
       parameters:
         - id: lowerBoundRule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface"
+            />
       return:
         type: void
         description: ''
   - name: setShowDataBarOnly(showDataBarOnly)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setShowDataBarOnly:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#setShowDataBarOnly:member(1)
     package: ExcelScript!
     fullName: setShowDataBarOnly(showDataBarOnly)
-    summary: 'If `true`<!-- -->, hides the values from the cells where the data bar is applied.'
+    summary: >-
+      If `true`<!-- -->, hides the values from the cells where the data bar is
+      applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -244,14 +296,17 @@ methods:
         type: void
         description: ''
   - name: setUpperBoundRule(upperBoundRule)
-    uid: 'ExcelScript!ExcelScript.DataBarConditionalFormat#setUpperBoundRule:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DataBarConditionalFormat#setUpperBoundRule:member(1)
     package: ExcelScript!
     fullName: setUpperBoundRule(upperBoundRule)
     summary: >-
-      The rule for what constitutes the upper bound (and how to calculate it, if applicable) for a data bar. The
-      `ConditionalDataBarRule` object must be set as a JSON object (use `x.upperBoundRule = {...}` instead of
+      The rule for what constitutes the upper bound (and how to calculate it, if
+      applicable) for a data bar. The `ConditionalDataBarRule` object must be
+      set as a JSON object (use `x.upperBoundRule = {...}` instead of
       `x.upperBoundRule.formula = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -259,7 +314,9 @@ methods:
       parameters:
         - id: upperBoundRule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ConditionalDataBarRule:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datapivothierarchy.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DataPivotHierarchy
-uid: 'ExcelScript!ExcelScript.DataPivotHierarchy:interface'
+uid: ExcelScript!ExcelScript.DataPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.DataPivotHierarchy
 summary: Represents the Excel DataPivotHierarchy.
@@ -27,29 +27,32 @@ remarks: |-
     rowToSort.getFields()[0].sortByValues(ExcelScript.SortBy.descending, valueFieldToSortOn);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getField()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getField:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getField:member(1)
     package: ExcelScript!
     fullName: getField()
     summary: Returns the PivotFields associated with the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getField(): PivotField;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotField:interface" />
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getId:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -58,11 +61,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getName:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -71,11 +75,12 @@ methods:
         type: string
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: Number format of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -84,11 +89,12 @@ methods:
         type: string
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: Position of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -97,37 +103,40 @@ methods:
         type: number
         description: ''
   - name: getShowAs()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getShowAs:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getShowAs:member(1)
     package: ExcelScript!
     fullName: getShowAs()
     summary: Specifies if the data should be shown as a specific summary calculation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getShowAs(): ShowAsRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShowAsRule:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShowAsRule:interface" />
         description: ''
   - name: getSummarizeBy()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#getSummarizeBy:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#getSummarizeBy:member(1)
     package: ExcelScript!
     fullName: getSummarizeBy()
     summary: Specifies if all items of the DataPivotHierarchy are shown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSummarizeBy(): AggregationFunction;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.AggregationFunction:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.AggregationFunction:enum" />
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setName:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,11 +149,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: Number format of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,11 +167,12 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: Position of the DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,11 +185,12 @@ methods:
         type: void
         description: ''
   - name: setShowAs(showAs)
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setShowAs:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setShowAs:member(1)
     package: ExcelScript!
     fullName: setShowAs(showAs)
     summary: Specifies if the data should be shown as a specific summary calculation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -186,7 +198,7 @@ methods:
       parameters:
         - id: showAs
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShowAsRule:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShowAsRule:interface" />
       return:
         type: void
         description: |-
@@ -214,11 +226,12 @@ methods:
           }
           ```
   - name: setSummarizeBy(summarizeBy)
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setSummarizeBy:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setSummarizeBy:member(1)
     package: ExcelScript!
     fullName: setSummarizeBy(summarizeBy)
     summary: Specifies if all items of the DataPivotHierarchy are shown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -226,7 +239,7 @@ methods:
       parameters:
         - id: summarizeBy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.AggregationFunction:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.AggregationFunction:enum" />
       return:
         type: void
         description: |-
@@ -248,11 +261,12 @@ methods:
           }
           ```
   - name: setToDefault()
-    uid: 'ExcelScript!ExcelScript.DataPivotHierarchy#setToDefault:member(1)'
+    uid: ExcelScript!ExcelScript.DataPivotHierarchy#setToDefault:member(1)
     package: ExcelScript!
     fullName: setToDefault()
     summary: Reset the DataPivotHierarchy back to its default values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datasourcetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datasourcetype.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DataSourceType
-uid: 'ExcelScript!ExcelScript.DataSourceType:enum'
+uid: ExcelScript!ExcelScript.DataSourceType:enum
 package: ExcelScript!
 fullName: ExcelScript.DataSourceType
 summary: Represents a command type of `DataConnection`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: localRange
-    uid: 'ExcelScript!ExcelScript.DataSourceType.localRange:member'
+    uid: ExcelScript!ExcelScript.DataSourceType.localRange:member
     package: ExcelScript!
     summary: The data source type is a range in the current workbook.
   - name: localTable
-    uid: 'ExcelScript!ExcelScript.DataSourceType.localTable:member'
+    uid: ExcelScript!ExcelScript.DataSourceType.localTable:member
     package: ExcelScript!
     summary: The data source type is a table in the current workbook.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.DataSourceType.unknown:member'
+    uid: ExcelScript!ExcelScript.DataSourceType.unknown:member
     package: ExcelScript!
     summary: The data source type is unknown or unsupported.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidation.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.DataValidation
-uid: 'ExcelScript!ExcelScript.DataValidation:interface'
+uid: ExcelScript!ExcelScript.DataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidation
 summary: Represents the data validation applied to the current range.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.DataValidation#clear:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clears the data validation from the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +25,30 @@ methods:
         type: void
         description: ''
   - name: getErrorAlert()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getErrorAlert:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getErrorAlert:member(1)
     package: ExcelScript!
     fullName: getErrorAlert()
     summary: Error alert when user enters invalid data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getErrorAlert(): DataValidationErrorAlert;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationErrorAlert:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.DataValidationErrorAlert:interface"
+          />
         description: ''
   - name: getIgnoreBlanks()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getIgnoreBlanks:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getIgnoreBlanks:member(1)
     package: ExcelScript!
     fullName: getIgnoreBlanks()
-    summary: Specifies if data validation will be performed on blank cells. Default is `true`<!-- -->.
+    summary: >-
+      Specifies if data validation will be performed on blank cells. Default is
+      `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,58 +57,67 @@ methods:
         type: boolean
         description: ''
   - name: getInvalidCells()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getInvalidCells:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getInvalidCells:member(1)
     package: ExcelScript!
     fullName: getInvalidCells()
     summary: >-
-      Returns a `RangeAreas` object, comprising one or more rectangular ranges, with invalid cell values. If all cell
-      values are valid, this function will return `null`<!-- -->.
+      Returns a `RangeAreas` object, comprising one or more rectangular ranges,
+      with invalid cell values. If all cell values are valid, this function will
+      return `null`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getInvalidCells(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getPrompt()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getPrompt:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getPrompt:member(1)
     package: ExcelScript!
     fullName: getPrompt()
     summary: Prompt when users select a cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrompt(): DataValidationPrompt;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationPrompt:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationPrompt:interface" />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
-    summary: Data validation rule that contains different type of data validation criteria.
+    summary: >-
+      Data validation rule that contains different type of data validation
+      criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): DataValidationRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationRule:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationRule:interface" />
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getType:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getType:member(1)
     package: ExcelScript!
     fullName: getType()
-    summary: 'Type of the data validation, see `ExcelScript.DataValidationType` for details.'
+    summary: >-
+      Type of the data validation, see `ExcelScript.DataValidationType` for
+      details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): DataValidationType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationType:enum" />
         description: |-
 
 
@@ -127,14 +144,16 @@ methods:
           }
           ```
   - name: getValid()
-    uid: 'ExcelScript!ExcelScript.DataValidation#getValid:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#getValid:member(1)
     package: ExcelScript!
     fullName: getValid()
     summary: >-
-      Represents if all cell values are valid according to the data validation rules. Returns `true` if all cell values
-      are valid, or `false` if all cell values are invalid. Returns `null` if there are both valid and invalid cell
-      values within the range.
+      Represents if all cell values are valid according to the data validation
+      rules. Returns `true` if all cell values are valid, or `false` if all cell
+      values are invalid. Returns `null` if there are both valid and invalid
+      cell values within the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -143,11 +162,12 @@ methods:
         type: boolean
         description: ''
   - name: setErrorAlert(errorAlert)
-    uid: 'ExcelScript!ExcelScript.DataValidation#setErrorAlert:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#setErrorAlert:member(1)
     package: ExcelScript!
     fullName: setErrorAlert(errorAlert)
     summary: Error alert when user enters invalid data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -155,16 +175,21 @@ methods:
       parameters:
         - id: errorAlert
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.DataValidationErrorAlert:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.DataValidationErrorAlert:interface" />
       return:
         type: void
         description: ''
   - name: setIgnoreBlanks(ignoreBlanks)
-    uid: 'ExcelScript!ExcelScript.DataValidation#setIgnoreBlanks:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#setIgnoreBlanks:member(1)
     package: ExcelScript!
     fullName: setIgnoreBlanks(ignoreBlanks)
-    summary: Specifies if data validation will be performed on blank cells. Default is `true`<!-- -->.
+    summary: >-
+      Specifies if data validation will be performed on blank cells. Default is
+      `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -177,11 +202,12 @@ methods:
         type: void
         description: ''
   - name: setPrompt(prompt)
-    uid: 'ExcelScript!ExcelScript.DataValidation#setPrompt:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#setPrompt:member(1)
     package: ExcelScript!
     fullName: setPrompt(prompt)
     summary: Prompt when users select a cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -189,7 +215,9 @@ methods:
       parameters:
         - id: prompt
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.DataValidationPrompt:interface" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.DataValidationPrompt:interface"
+            />
       return:
         type: void
         description: |-
@@ -218,11 +246,14 @@ methods:
           }    
           ```
   - name: setRule(rule)
-    uid: 'ExcelScript!ExcelScript.DataValidation#setRule:member(1)'
+    uid: ExcelScript!ExcelScript.DataValidation#setRule:member(1)
     package: ExcelScript!
     fullName: setRule(rule)
-    summary: Data validation rule that contains different type of data validation criteria.
+    summary: >-
+      Data validation rule that contains different type of data validation
+      criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -230,7 +261,7 @@ methods:
       parameters:
         - id: rule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.DataValidationRule:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.DataValidationRule:interface" />
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationalertstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationalertstyle.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DataValidationAlertStyle
-uid: 'ExcelScript!ExcelScript.DataValidationAlertStyle:enum'
+uid: ExcelScript!ExcelScript.DataValidationAlertStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.DataValidationAlertStyle
-summary: Represents the data validation error alert style. The default is `Stop`<!-- -->.
+summary: >-
+  Represents the data validation error alert style. The default is `Stop`<!--
+  -->.
 remarks: |-
 
 
@@ -43,18 +45,19 @@ remarks: |-
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: information
-    uid: 'ExcelScript!ExcelScript.DataValidationAlertStyle.information:member'
+    uid: ExcelScript!ExcelScript.DataValidationAlertStyle.information:member
     package: ExcelScript!
     summary: ''
   - name: stop
-    uid: 'ExcelScript!ExcelScript.DataValidationAlertStyle.stop:member'
+    uid: ExcelScript!ExcelScript.DataValidationAlertStyle.stop:member
     package: ExcelScript!
     summary: ''
   - name: warning
-    uid: 'ExcelScript!ExcelScript.DataValidationAlertStyle.warning:member'
+    uid: ExcelScript!ExcelScript.DataValidationAlertStyle.warning:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationerroralert.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationerroralert.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DataValidationErrorAlert
-uid: 'ExcelScript!ExcelScript.DataValidationErrorAlert:interface'
+uid: ExcelScript!ExcelScript.DataValidationErrorAlert:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidationErrorAlert
 summary: Represents the error alert properties for the data validation.
@@ -43,16 +43,18 @@ remarks: |-
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: message
-    uid: 'ExcelScript!ExcelScript.DataValidationErrorAlert#message:member'
+    uid: ExcelScript!ExcelScript.DataValidationErrorAlert#message:member
     package: ExcelScript!
     fullName: message
     summary: Represents the error alert message.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -60,11 +62,14 @@ properties:
       return:
         type: string
   - name: showAlert
-    uid: 'ExcelScript!ExcelScript.DataValidationErrorAlert#showAlert:member'
+    uid: ExcelScript!ExcelScript.DataValidationErrorAlert#showAlert:member
     package: ExcelScript!
     fullName: showAlert
-    summary: Specifies whether to show an error alert dialog when a user enters invalid data. The default is `true`<!-- -->.
+    summary: >-
+      Specifies whether to show an error alert dialog when a user enters invalid
+      data. The default is `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,23 +77,27 @@ properties:
       return:
         type: boolean
   - name: style
-    uid: 'ExcelScript!ExcelScript.DataValidationErrorAlert#style:member'
+    uid: ExcelScript!ExcelScript.DataValidationErrorAlert#style:member
     package: ExcelScript!
     fullName: style
-    summary: 'The data validation alert type, please see `ExcelScript.DataValidationAlertStyle` for details.'
+    summary: >-
+      The data validation alert type, please see
+      `ExcelScript.DataValidationAlertStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'style: DataValidationAlertStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationAlertStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationAlertStyle:enum" />
   - name: title
-    uid: 'ExcelScript!ExcelScript.DataValidationErrorAlert#title:member'
+    uid: ExcelScript!ExcelScript.DataValidationErrorAlert#title:member
     package: ExcelScript!
     fullName: title
     summary: Represents the error alert dialog title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationoperator.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationoperator.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DataValidationOperator
-uid: 'ExcelScript!ExcelScript.DataValidationOperator:enum'
+uid: ExcelScript!ExcelScript.DataValidationOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.DataValidationOperator
 summary: Represents the data validation operator enum.
@@ -33,38 +33,39 @@ remarks: |-
     rangeDataValidation.setRule(positiveNumberOnlyRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: between
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.between:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.between:member
     package: ExcelScript!
     summary: ''
   - name: equalTo
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.equalTo:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.equalTo:member
     package: ExcelScript!
     summary: ''
   - name: greaterThan
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.greaterThan:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.greaterThan:member
     package: ExcelScript!
     summary: ''
   - name: greaterThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.greaterThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.greaterThanOrEqualTo:member
     package: ExcelScript!
     summary: ''
   - name: lessThan
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.lessThan:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.lessThan:member
     package: ExcelScript!
     summary: ''
   - name: lessThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.lessThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.lessThanOrEqualTo:member
     package: ExcelScript!
     summary: ''
   - name: notBetween
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.notBetween:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.notBetween:member
     package: ExcelScript!
     summary: ''
   - name: notEqualTo
-    uid: 'ExcelScript!ExcelScript.DataValidationOperator.notEqualTo:member'
+    uid: ExcelScript!ExcelScript.DataValidationOperator.notEqualTo:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationprompt.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationprompt.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DataValidationPrompt
-uid: 'ExcelScript!ExcelScript.DataValidationPrompt:interface'
+uid: ExcelScript!ExcelScript.DataValidationPrompt:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidationPrompt
 summary: Represents the user prompt properties for the data validation.
@@ -30,16 +30,18 @@ remarks: |-
       dataValidation.setPrompt(prompt);
   }    
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: message
-    uid: 'ExcelScript!ExcelScript.DataValidationPrompt#message:member'
+    uid: ExcelScript!ExcelScript.DataValidationPrompt#message:member
     package: ExcelScript!
     fullName: message
     summary: Specifies the message of the prompt.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -47,11 +49,14 @@ properties:
       return:
         type: string
   - name: showPrompt
-    uid: 'ExcelScript!ExcelScript.DataValidationPrompt#showPrompt:member'
+    uid: ExcelScript!ExcelScript.DataValidationPrompt#showPrompt:member
     package: ExcelScript!
     fullName: showPrompt
-    summary: Specifies if a prompt is shown when a user selects a cell with data validation.
+    summary: >-
+      Specifies if a prompt is shown when a user selects a cell with data
+      validation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -59,11 +64,12 @@ properties:
       return:
         type: boolean
   - name: title
-    uid: 'ExcelScript!ExcelScript.DataValidationPrompt#title:member'
+    uid: ExcelScript!ExcelScript.DataValidationPrompt#title:member
     package: ExcelScript!
     fullName: title
     summary: Specifies the title for the prompt.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationrule.yml
@@ -1,28 +1,31 @@
 ### YamlMime:TSType
 name: ExcelScript.DataValidationRule
-uid: 'ExcelScript!ExcelScript.DataValidationRule:interface'
+uid: ExcelScript!ExcelScript.DataValidationRule:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidationRule
 summary: >-
-  A data validation rule contains different types of data validation. You can only use one of them at a time according
-  the `ExcelScript.DataValidationType`<!-- -->.
+  A data validation rule contains different types of data validation. You can
+  only use one of them at a time according the
+  `ExcelScript.DataValidationType`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: custom
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#custom:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#custom:member
     package: ExcelScript!
     fullName: custom
     summary: Custom data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'custom?: CustomDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomDataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.CustomDataValidation:interface" />
         description: |-
 
 
@@ -50,41 +53,46 @@ properties:
           }
           ```
   - name: date
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#date:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#date:member
     package: ExcelScript!
     fullName: date
     summary: Date data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'date?: DateTimeDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DateTimeDataValidation:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.DateTimeDataValidation:interface"
+          />
   - name: decimal
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#decimal:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#decimal:member
     package: ExcelScript!
     fullName: decimal
     summary: Decimal data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'decimal?: BasicDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />
   - name: list
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#list:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#list:member
     package: ExcelScript!
     fullName: list
     summary: List data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'list?: ListDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ListDataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ListDataValidation:interface" />
         description: |-
 
 
@@ -127,41 +135,46 @@ properties:
           }
           ```
   - name: textLength
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#textLength:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#textLength:member
     package: ExcelScript!
     fullName: textLength
     summary: Text length data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'textLength?: BasicDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />
   - name: time
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#time:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#time:member
     package: ExcelScript!
     fullName: time
     summary: Time data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'time?: DateTimeDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DateTimeDataValidation:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.DateTimeDataValidation:interface"
+          />
   - name: wholeNumber
-    uid: 'ExcelScript!ExcelScript.DataValidationRule#wholeNumber:member'
+    uid: ExcelScript!ExcelScript.DataValidationRule#wholeNumber:member
     package: ExcelScript!
     fullName: wholeNumber
     summary: Whole number data validation criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'wholeNumber?: BasicDataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.BasicDataValidation:interface" />
         description: |-
 
 

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationtype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datavalidationtype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DataValidationType
-uid: 'ExcelScript!ExcelScript.DataValidationType:enum'
+uid: ExcelScript!ExcelScript.DataValidationType:enum
 package: ExcelScript!
 fullName: ExcelScript.DataValidationType
 summary: Represents the data validation type enum.
@@ -29,48 +29,53 @@ remarks: |-
     console.log(validationType.toString());
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: custom
-    uid: 'ExcelScript!ExcelScript.DataValidationType.custom:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.custom:member
     package: ExcelScript!
     summary: The custom data validation type.
   - name: date
-    uid: 'ExcelScript!ExcelScript.DataValidationType.date:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.date:member
     package: ExcelScript!
     summary: The date data validation type.
   - name: decimal
-    uid: 'ExcelScript!ExcelScript.DataValidationType.decimal:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.decimal:member
     package: ExcelScript!
     summary: The decimal data validation type.
   - name: inconsistent
-    uid: 'ExcelScript!ExcelScript.DataValidationType.inconsistent:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.inconsistent:member
     package: ExcelScript!
     summary: >-
-      Inconsistent means that the range has inconsistent data validation, indicating that there are different rules on
-      different cells.
+      Inconsistent means that the range has inconsistent data validation,
+      indicating that there are different rules on different cells.
   - name: list
-    uid: 'ExcelScript!ExcelScript.DataValidationType.list:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.list:member
     package: ExcelScript!
     summary: The list data validation type.
   - name: mixedCriteria
-    uid: 'ExcelScript!ExcelScript.DataValidationType.mixedCriteria:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.mixedCriteria:member
     package: ExcelScript!
-    summary: Mixed criteria means that the range has data validation present on some but not all cells.
+    summary: >-
+      Mixed criteria means that the range has data validation present on some
+      but not all cells.
   - name: none
-    uid: 'ExcelScript!ExcelScript.DataValidationType.none:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.none:member
     package: ExcelScript!
-    summary: 'None means allow any value, indicating that there is no data validation in the range.'
+    summary: >-
+      None means allow any value, indicating that there is no data validation in
+      the range.
   - name: textLength
-    uid: 'ExcelScript!ExcelScript.DataValidationType.textLength:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.textLength:member
     package: ExcelScript!
     summary: The text length data validation type.
   - name: time
-    uid: 'ExcelScript!ExcelScript.DataValidationType.time:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.time:member
     package: ExcelScript!
     summary: The time data validation type.
   - name: wholeNumber
-    uid: 'ExcelScript!ExcelScript.DataValidationType.wholeNumber:member'
+    uid: ExcelScript!ExcelScript.DataValidationType.wholeNumber:member
     package: ExcelScript!
     summary: The whole number data validation type.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datefiltercondition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datefiltercondition.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DateFilterCondition
-uid: 'ExcelScript!ExcelScript.DateFilterCondition:enum'
+uid: ExcelScript!ExcelScript.DateFilterCondition:enum
 package: ExcelScript!
 fullName: ExcelScript.DateFilterCondition
 summary: >-
-  Enum representing all accepted conditions by which a date filter can be applied. Used to configure the type of
-  PivotFilter that is applied to the field.
+  Enum representing all accepted conditions by which a date filter can be
+  applied. Used to configure the type of PivotFilter that is applied to the
+  field.
 remarks: |-
 
 
@@ -33,184 +34,201 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: after
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.after:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.after:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Date is after comparator date.
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->}<!-- -->.
+
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`wholeDays`<!-- -->}<!-- -->.
   - name: afterOrEqualTo
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.afterOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.afterOrEqualTo:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Date is after or equal to comparator date.
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->}<!-- -->.
+
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`wholeDays`<!-- -->}<!-- -->.
   - name: allDatesInPeriodApril
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodApril:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodApril:member
     package: ExcelScript!
     summary: Date is in April.
   - name: allDatesInPeriodAugust
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodAugust:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodAugust:member
     package: ExcelScript!
     summary: Date is in August.
   - name: allDatesInPeriodDecember
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodDecember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodDecember:member
     package: ExcelScript!
     summary: Date is in December.
   - name: allDatesInPeriodFebruary
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodFebruary:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodFebruary:member
     package: ExcelScript!
     summary: Date is in February.
   - name: allDatesInPeriodJanuary
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJanuary:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJanuary:member
     package: ExcelScript!
     summary: Date is in January.
   - name: allDatesInPeriodJuly
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJuly:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJuly:member
     package: ExcelScript!
     summary: Date is in July.
   - name: allDatesInPeriodJune
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJune:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodJune:member
     package: ExcelScript!
     summary: Date is in June.
   - name: allDatesInPeriodMarch
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodMarch:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodMarch:member
     package: ExcelScript!
     summary: Date is in March.
   - name: allDatesInPeriodMay
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodMay:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodMay:member
     package: ExcelScript!
     summary: Date is in May.
   - name: allDatesInPeriodNovember
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodNovember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodNovember:member
     package: ExcelScript!
     summary: Date is in November.
   - name: allDatesInPeriodOctober
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodOctober:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodOctober:member
     package: ExcelScript!
     summary: Date is in October.
   - name: allDatesInPeriodQuarter1
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter1:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter1:member
     package: ExcelScript!
     summary: Date is in Quarter 1.
   - name: allDatesInPeriodQuarter2
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter2:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter2:member
     package: ExcelScript!
     summary: Date is in Quarter 2.
   - name: allDatesInPeriodQuarter3
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter3:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter3:member
     package: ExcelScript!
     summary: Date is in Quarter 3.
   - name: allDatesInPeriodQuarter4
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter4:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodQuarter4:member
     package: ExcelScript!
     summary: Date is in Quarter 4.
   - name: allDatesInPeriodSeptember
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodSeptember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DateFilterCondition.allDatesInPeriodSeptember:member
     package: ExcelScript!
     summary: Date is in September.
   - name: before
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.before:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.before:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Date is before comparator date.
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->}<!-- -->.
+
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`wholeDays`<!-- -->}<!-- -->.
   - name: beforeOrEqualTo
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.beforeOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.beforeOrEqualTo:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Date is before or equal to comparator date.
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->}<!-- -->.
+
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`wholeDays`<!-- -->}<!-- -->.
   - name: between
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.between:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.between:member
     package: ExcelScript!
     summary: >-
       Between `lowerBound` and `upperBound` dates.
 
 
-      Required Criteria: {`lowerBound`<!-- -->, `upperBound`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->,
-      `exclusive`<!-- -->}<!-- -->.
+      Required Criteria: {`lowerBound`<!-- -->, `upperBound`<!-- -->}<!-- -->.
+      Optional Criteria: {`wholeDays`<!-- -->, `exclusive`<!-- -->}<!-- -->.
   - name: equals
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.equals:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.equals:member
     package: ExcelScript!
     summary: >-
       Equals comparator criterion.
 
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`wholeDays`<!-- -->, `exclusive`<!--
-      -->}<!-- -->.
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`wholeDays`<!-- -->, `exclusive`<!-- -->}<!-- -->.
   - name: lastMonth
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.lastMonth:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.lastMonth:member
     package: ExcelScript!
     summary: Date is last month.
   - name: lastQuarter
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.lastQuarter:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.lastQuarter:member
     package: ExcelScript!
     summary: Date is last quarter.
   - name: lastWeek
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.lastWeek:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.lastWeek:member
     package: ExcelScript!
     summary: Date is last week.
   - name: lastYear
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.lastYear:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.lastYear:member
     package: ExcelScript!
     summary: Date is last year.
   - name: nextMonth
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.nextMonth:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.nextMonth:member
     package: ExcelScript!
     summary: Date is next month.
   - name: nextQuarter
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.nextQuarter:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.nextQuarter:member
     package: ExcelScript!
     summary: Date is next quarter.
   - name: nextWeek
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.nextWeek:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.nextWeek:member
     package: ExcelScript!
     summary: Date is next week.
   - name: nextYear
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.nextYear:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.nextYear:member
     package: ExcelScript!
     summary: Date is next year.
   - name: thisMonth
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.thisMonth:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.thisMonth:member
     package: ExcelScript!
     summary: Date is this month.
   - name: thisQuarter
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.thisQuarter:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.thisQuarter:member
     package: ExcelScript!
     summary: Date is this quarter.
   - name: thisWeek
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.thisWeek:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.thisWeek:member
     package: ExcelScript!
     summary: Date is this week.
   - name: thisYear
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.thisYear:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.thisYear:member
     package: ExcelScript!
     summary: Date is this year.
   - name: today
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.today:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.today:member
     package: ExcelScript!
     summary: Date is today.
   - name: tomorrow
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.tomorrow:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.tomorrow:member
     package: ExcelScript!
     summary: Date is tomorrow.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.unknown:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.unknown:member
     package: ExcelScript!
     summary: '`DateFilterCondition` is unknown or unsupported.'
   - name: yearToDate
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.yearToDate:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.yearToDate:member
     package: ExcelScript!
     summary: Date is in the same year to date.
   - name: yesterday
-    uid: 'ExcelScript!ExcelScript.DateFilterCondition.yesterday:member'
+    uid: ExcelScript!ExcelScript.DateFilterCondition.yesterday:member
     package: ExcelScript!
     summary: Date is yesterday.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datetimedatavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datetimedatavalidation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DateTimeDataValidation
-uid: 'ExcelScript!ExcelScript.DateTimeDataValidation:interface'
+uid: ExcelScript!ExcelScript.DateTimeDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.DateTimeDataValidation
 summary: Represents the date data validation criteria.
@@ -36,54 +36,63 @@ remarks: |-
       });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: formula1
-    uid: 'ExcelScript!ExcelScript.DateTimeDataValidation#formula1:member'
+    uid: ExcelScript!ExcelScript.DateTimeDataValidation#formula1:member
     package: ExcelScript!
     fullName: formula1
     summary: >-
-      Specifies the right-hand operand when the operator property is set to a binary operator such as GreaterThan (the
-      left-hand operand is the value the user tries to enter in the cell). With the ternary operators Between and
-      NotBetween, specifies the lower bound operand. When setting the value, it can be passed in as a Date, a Range
-      object, or a string formula (where the string is either a stringified date/time in ISO8601 format, a cell
-      reference like "=A1", or a formula like "=MIN(A1, B1)"). When retrieving the value, it will always be returned as
-      a string formula, for example: "=10", "=A1", "=SUM(A1:B5)", etc.
+      Specifies the right-hand operand when the operator property is set to a
+      binary operator such as GreaterThan (the left-hand operand is the value
+      the user tries to enter in the cell). With the ternary operators Between
+      and NotBetween, specifies the lower bound operand. When setting the value,
+      it can be passed in as a Date, a Range object, or a string formula (where
+      the string is either a stringified date/time in ISO8601 format, a cell
+      reference like "=A1", or a formula like "=MIN(A1, B1)"). When retrieving
+      the value, it will always be returned as a string formula, for example:
+      "=10", "=A1", "=SUM(A1:B5)", etc.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'formula1: string | Date | Range;'
       return:
-        type: 'string | Date | <xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: string | Date | <xref uid="ExcelScript!ExcelScript.Range:interface" />
   - name: formula2
-    uid: 'ExcelScript!ExcelScript.DateTimeDataValidation#formula2:member'
+    uid: ExcelScript!ExcelScript.DateTimeDataValidation#formula2:member
     package: ExcelScript!
     fullName: formula2
     summary: >-
-      With the ternary operators Between and NotBetween, specifies the upper bound operand. Is not used with the binary
-      operators, such as GreaterThan. When setting the value, it can be passed in as a Date, a Range object, or a string
-      (where the string is either a stringified date/time in ISO8601 format, a cell reference like "=A1", or a formula
-      like "=MIN(A1, B1)"). When retrieving the value, it will always be returned as a string formula, for example:
-      "=10", "=A1", "=SUM(A1:B5)", etc.
+      With the ternary operators Between and NotBetween, specifies the upper
+      bound operand. Is not used with the binary operators, such as GreaterThan.
+      When setting the value, it can be passed in as a Date, a Range object, or
+      a string (where the string is either a stringified date/time in ISO8601
+      format, a cell reference like "=A1", or a formula like "=MIN(A1, B1)").
+      When retrieving the value, it will always be returned as a string formula,
+      for example: "=10", "=A1", "=SUM(A1:B5)", etc.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'formula2?: string | Date | Range;'
       return:
-        type: 'string | Date | <xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: string | Date | <xref uid="ExcelScript!ExcelScript.Range:interface" />
   - name: operator
-    uid: 'ExcelScript!ExcelScript.DateTimeDataValidation#operator:member'
+    uid: ExcelScript!ExcelScript.DateTimeDataValidation#operator:member
     package: ExcelScript!
     fullName: operator
     summary: The operator to use for validating the data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator: DataValidationOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidationOperator:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidationOperator:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.datetimeformatinfo.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.datetimeformatinfo.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.DatetimeFormatInfo
-uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo:interface'
+uid: ExcelScript!ExcelScript.DatetimeFormatInfo:interface
 package: ExcelScript!
 fullName: ExcelScript.DatetimeFormatInfo
-summary: Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+summary: >-
+  Defines the culturally appropriate format of displaying numbers. This is based
+  on current system culture settings.
 remarks: |-
 
 
@@ -31,16 +33,20 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getDateSeparator()
-    uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo#getDateSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.DatetimeFormatInfo#getDateSeparator:member(1)
     package: ExcelScript!
     fullName: getDateSeparator()
-    summary: Gets the string used as the date separator. This is based on current system settings.
+    summary: >-
+      Gets the string used as the date separator. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -74,11 +80,14 @@ methods:
           }
           ```
   - name: getLongDatePattern()
-    uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo#getLongDatePattern:member(1)'
+    uid: ExcelScript!ExcelScript.DatetimeFormatInfo#getLongDatePattern:member(1)
     package: ExcelScript!
     fullName: getLongDatePattern()
-    summary: Gets the format string for a long date value. This is based on current system settings.
+    summary: >-
+      Gets the format string for a long date value. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -103,11 +112,14 @@ methods:
           }
           ```
   - name: getLongTimePattern()
-    uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo#getLongTimePattern:member(1)'
+    uid: ExcelScript!ExcelScript.DatetimeFormatInfo#getLongTimePattern:member(1)
     package: ExcelScript!
     fullName: getLongTimePattern()
-    summary: Gets the format string for a long time value. This is based on current system settings.
+    summary: >-
+      Gets the format string for a long time value. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,11 +128,14 @@ methods:
         type: string
         description: ''
   - name: getShortDatePattern()
-    uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo#getShortDatePattern:member(1)'
+    uid: ExcelScript!ExcelScript.DatetimeFormatInfo#getShortDatePattern:member(1)
     package: ExcelScript!
     fullName: getShortDatePattern()
-    summary: Gets the format string for a short date value. This is based on current system settings.
+    summary: >-
+      Gets the format string for a short date value. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -129,11 +144,14 @@ methods:
         type: string
         description: ''
   - name: getTimeSeparator()
-    uid: 'ExcelScript!ExcelScript.DatetimeFormatInfo#getTimeSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.DatetimeFormatInfo#getTimeSeparator:member(1)
     package: ExcelScript!
     fullName: getTimeSeparator()
-    summary: Gets the string used as the time separator. This is based on current system settings.
+    summary: >-
+      Gets the string used as the time separator. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.deleteshiftdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.deleteshiftdirection.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DeleteShiftDirection
-uid: 'ExcelScript!ExcelScript.DeleteShiftDirection:enum'
+uid: ExcelScript!ExcelScript.DeleteShiftDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.DeleteShiftDirection
 summary: ''
@@ -41,14 +41,15 @@ remarks: |-
     console.log(currentSheet.getRange("A1:D4").getValues()); 
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: left
-    uid: 'ExcelScript!ExcelScript.DeleteShiftDirection.left:member'
+    uid: ExcelScript!ExcelScript.DeleteShiftDirection.left:member
     package: ExcelScript!
     summary: ''
   - name: up
-    uid: 'ExcelScript!ExcelScript.DeleteShiftDirection.up:member'
+    uid: ExcelScript!ExcelScript.DeleteShiftDirection.up:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.documentproperties.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.documentproperties.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.DocumentProperties
-uid: 'ExcelScript!ExcelScript.DocumentProperties:interface'
+uid: ExcelScript!ExcelScript.DocumentProperties:interface
 package: ExcelScript!
 fullName: ExcelScript.DocumentProperties
 summary: Represents workbook properties.
@@ -30,16 +30,18 @@ remarks: |-
       newWorksheet.getRange("A1:B3").setValues(values);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'addCustomProperty(key, value)'
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#addCustomProperty:member(1)'
+  - name: addCustomProperty(key, value)
+    uid: ExcelScript!ExcelScript.DocumentProperties#addCustomProperty:member(1)
     package: ExcelScript!
-    fullName: 'addCustomProperty(key, value)'
+    fullName: addCustomProperty(key, value)
     summary: Creates a new or sets an existing custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -47,16 +49,19 @@ methods:
       parameters:
         - id: key
           description: >-
-            Required. The custom property's key, which is case-insensitive. The key is limited to 255 characters outside
-            of Excel on the web (larger keys are automatically trimmed to 255 characters on other platforms).
+            Required. The custom property's key, which is case-insensitive. The
+            key is limited to 255 characters outside of Excel on the web (larger
+            keys are automatically trimmed to 255 characters on other
+            platforms).
           type: string
         - id: value
           description: >-
-            Required. The custom property's value. The value is limited to 255 characters outside of Excel on the web
-            (larger values are automatically trimmed to 255 characters on other platforms).
+            Required. The custom property's value. The value is limited to 255
+            characters outside of Excel on the web (larger values are
+            automatically trimmed to 255 characters on other platforms).
           type: any
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomProperty:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.CustomProperty:interface" />
         description: |-
 
 
@@ -75,11 +80,13 @@ methods:
           }
           ```
   - name: deleteAllCustomProperties()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#deleteAllCustomProperties:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.DocumentProperties#deleteAllCustomProperties:member(1)
     package: ExcelScript!
     fullName: deleteAllCustomProperties()
     summary: Deletes all custom properties in this collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,11 +95,12 @@ methods:
         type: void
         description: ''
   - name: getAuthor()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getAuthor:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getAuthor:member(1)
     package: ExcelScript!
     fullName: getAuthor()
     summary: The author of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,11 +109,12 @@ methods:
         type: string
         description: ''
   - name: getCategory()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getCategory:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getCategory:member(1)
     package: ExcelScript!
     fullName: getCategory()
     summary: The category of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -114,13 +123,14 @@ methods:
         type: string
         description: ''
   - name: getComments()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getComments:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getComments:member(1)
     package: ExcelScript!
     fullName: getComments()
     summary: >-
-      The Comments field in the metadata of the workbook. These have no connection to comments by users made in the
-      workbook.
+      The Comments field in the metadata of the workbook. These have no
+      connection to comments by users made in the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -129,11 +139,12 @@ methods:
         type: string
         description: ''
   - name: getCompany()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getCompany:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getCompany:member(1)
     package: ExcelScript!
     fullName: getCompany()
     summary: The company of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -142,11 +153,12 @@ methods:
         type: string
         description: ''
   - name: getCreationDate()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getCreationDate:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getCreationDate:member(1)
     package: ExcelScript!
     fullName: getCreationDate()
     summary: Gets the creation date of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -155,26 +167,29 @@ methods:
         type: Date
         description: ''
   - name: getCustom()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getCustom:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getCustom:member(1)
     package: ExcelScript!
     fullName: getCustom()
     summary: Gets the collection of custom properties of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCustom(): CustomProperty[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomProperty:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CustomProperty:interface" />[]
         description: ''
   - name: getCustomProperty(key)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getCustomProperty:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getCustomProperty:member(1)
     package: ExcelScript!
     fullName: getCustomProperty(key)
     summary: >-
-      Gets a custom property object by its key, which is case-insensitive. If the custom property doesn't exist, then
-      this method returns `undefined`<!-- -->.
+      Gets a custom property object by its key, which is case-insensitive. If
+      the custom property doesn't exist, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -184,7 +199,9 @@ methods:
           description: Required. The key that identifies the custom property object.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomProperty:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.CustomProperty:interface" /> |
+          undefined
         description: |-
 
 
@@ -206,11 +223,12 @@ methods:
           }
           ```
   - name: getKeywords()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getKeywords:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getKeywords:member(1)
     package: ExcelScript!
     fullName: getKeywords()
     summary: The keywords of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -219,11 +237,12 @@ methods:
         type: string
         description: ''
   - name: getLastAuthor()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getLastAuthor:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getLastAuthor:member(1)
     package: ExcelScript!
     fullName: getLastAuthor()
     summary: Gets the last author of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -232,11 +251,12 @@ methods:
         type: string
         description: ''
   - name: getManager()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getManager:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getManager:member(1)
     package: ExcelScript!
     fullName: getManager()
     summary: The manager of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -245,11 +265,12 @@ methods:
         type: string
         description: ''
   - name: getRevisionNumber()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getRevisionNumber:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getRevisionNumber:member(1)
     package: ExcelScript!
     fullName: getRevisionNumber()
     summary: Gets the revision number of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -258,11 +279,12 @@ methods:
         type: number
         description: ''
   - name: getSubject()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getSubject:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getSubject:member(1)
     package: ExcelScript!
     fullName: getSubject()
     summary: The subject of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -271,11 +293,12 @@ methods:
         type: string
         description: ''
   - name: getTitle()
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#getTitle:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#getTitle:member(1)
     package: ExcelScript!
     fullName: getTitle()
     summary: The title of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -284,11 +307,12 @@ methods:
         type: string
         description: ''
   - name: setAuthor(author)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setAuthor:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setAuthor:member(1)
     package: ExcelScript!
     fullName: setAuthor(author)
     summary: The author of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -301,11 +325,12 @@ methods:
         type: void
         description: ''
   - name: setCategory(category)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setCategory:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setCategory:member(1)
     package: ExcelScript!
     fullName: setCategory(category)
     summary: The category of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -318,13 +343,14 @@ methods:
         type: void
         description: ''
   - name: setComments(comments)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setComments:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setComments:member(1)
     package: ExcelScript!
     fullName: setComments(comments)
     summary: >-
-      The Comments field in the metadata of the workbook. These have no connection to comments by users made in the
-      workbook.
+      The Comments field in the metadata of the workbook. These have no
+      connection to comments by users made in the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -337,11 +363,12 @@ methods:
         type: void
         description: ''
   - name: setCompany(company)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setCompany:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setCompany:member(1)
     package: ExcelScript!
     fullName: setCompany(company)
     summary: The company of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -354,11 +381,12 @@ methods:
         type: void
         description: ''
   - name: setKeywords(keywords)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setKeywords:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setKeywords:member(1)
     package: ExcelScript!
     fullName: setKeywords(keywords)
     summary: The keywords of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -371,11 +399,12 @@ methods:
         type: void
         description: ''
   - name: setManager(manager)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setManager:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setManager:member(1)
     package: ExcelScript!
     fullName: setManager(manager)
     summary: The manager of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -388,11 +417,12 @@ methods:
         type: void
         description: ''
   - name: setRevisionNumber(revisionNumber)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setRevisionNumber:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setRevisionNumber:member(1)
     package: ExcelScript!
     fullName: setRevisionNumber(revisionNumber)
     summary: Gets the revision number of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -405,11 +435,12 @@ methods:
         type: void
         description: ''
   - name: setSubject(subject)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setSubject:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setSubject:member(1)
     package: ExcelScript!
     fullName: setSubject(subject)
     summary: The subject of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -422,11 +453,12 @@ methods:
         type: void
         description: ''
   - name: setTitle(title)
-    uid: 'ExcelScript!ExcelScript.DocumentProperties#setTitle:member(1)'
+    uid: ExcelScript!ExcelScript.DocumentProperties#setTitle:member(1)
     package: ExcelScript!
     fullName: setTitle(title)
     summary: The title of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.documentpropertytype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.documentpropertytype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DocumentPropertyType
-uid: 'ExcelScript!ExcelScript.DocumentPropertyType:enum'
+uid: ExcelScript!ExcelScript.DocumentPropertyType:enum
 package: ExcelScript!
 fullName: ExcelScript.DocumentPropertyType
 summary: ''
@@ -33,26 +33,27 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: boolean
-    uid: 'ExcelScript!ExcelScript.DocumentPropertyType.boolean:member'
+    uid: ExcelScript!ExcelScript.DocumentPropertyType.boolean:member
     package: ExcelScript!
     summary: ''
   - name: date
-    uid: 'ExcelScript!ExcelScript.DocumentPropertyType.date:member'
+    uid: ExcelScript!ExcelScript.DocumentPropertyType.date:member
     package: ExcelScript!
     summary: ''
   - name: float
-    uid: 'ExcelScript!ExcelScript.DocumentPropertyType.float:member'
+    uid: ExcelScript!ExcelScript.DocumentPropertyType.float:member
     package: ExcelScript!
     summary: ''
   - name: number
-    uid: 'ExcelScript!ExcelScript.DocumentPropertyType.number:member'
+    uid: ExcelScript!ExcelScript.DocumentPropertyType.number:member
     package: ExcelScript!
     summary: ''
   - name: string
-    uid: 'ExcelScript!ExcelScript.DocumentPropertyType.string:member'
+    uid: ExcelScript!ExcelScript.DocumentPropertyType.string:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.dynamicfiltercriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.dynamicfiltercriteria.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.DynamicFilterCriteria
-uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria:enum'
+uid: ExcelScript!ExcelScript.DynamicFilterCriteria:enum
 package: ExcelScript!
 fullName: ExcelScript.DynamicFilterCriteria
 summary: ''
@@ -26,146 +26,158 @@ remarks: |-
     dateColumn.getFilter().applyDynamicFilter(ExcelScript.DynamicFilterCriteria.lastMonth);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: aboveAverage
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.aboveAverage:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.aboveAverage:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodApril
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodApril:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodApril:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodAugust
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodAugust:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodAugust:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodDecember
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodDecember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodDecember:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodFebruary
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodFebruary:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodFebruary:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodJanuary
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJanuary:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJanuary:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodJuly
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJuly:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJuly:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodJune
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJune:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodJune:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodMarch
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodMarch:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodMarch:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodMay
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodMay:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodMay:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodNovember
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodNovember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodNovember:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodOctober
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodOctober:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodOctober:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodQuarter1
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter1:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter1:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodQuarter2
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter2:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter2:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodQuarter3
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter3:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter3:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodQuarter4
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter4:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodQuarter4:member
     package: ExcelScript!
     summary: ''
   - name: allDatesInPeriodSeptember
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodSeptember:member'
+    uid: >-
+      ExcelScript!ExcelScript.DynamicFilterCriteria.allDatesInPeriodSeptember:member
     package: ExcelScript!
     summary: ''
   - name: belowAverage
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.belowAverage:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.belowAverage:member
     package: ExcelScript!
     summary: ''
   - name: lastMonth
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.lastMonth:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.lastMonth:member
     package: ExcelScript!
     summary: ''
   - name: lastQuarter
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.lastQuarter:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.lastQuarter:member
     package: ExcelScript!
     summary: ''
   - name: lastWeek
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.lastWeek:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.lastWeek:member
     package: ExcelScript!
     summary: ''
   - name: lastYear
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.lastYear:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.lastYear:member
     package: ExcelScript!
     summary: ''
   - name: nextMonth
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.nextMonth:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.nextMonth:member
     package: ExcelScript!
     summary: ''
   - name: nextQuarter
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.nextQuarter:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.nextQuarter:member
     package: ExcelScript!
     summary: ''
   - name: nextWeek
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.nextWeek:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.nextWeek:member
     package: ExcelScript!
     summary: ''
   - name: nextYear
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.nextYear:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.nextYear:member
     package: ExcelScript!
     summary: ''
   - name: thisMonth
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.thisMonth:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.thisMonth:member
     package: ExcelScript!
     summary: ''
   - name: thisQuarter
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.thisQuarter:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.thisQuarter:member
     package: ExcelScript!
     summary: ''
   - name: thisWeek
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.thisWeek:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.thisWeek:member
     package: ExcelScript!
     summary: ''
   - name: thisYear
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.thisYear:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.thisYear:member
     package: ExcelScript!
     summary: ''
   - name: today
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.today:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.today:member
     package: ExcelScript!
     summary: ''
   - name: tomorrow
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.tomorrow:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.tomorrow:member
     package: ExcelScript!
     summary: ''
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.unknown:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.unknown:member
     package: ExcelScript!
     summary: ''
   - name: yearToDate
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.yearToDate:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.yearToDate:member
     package: ExcelScript!
     summary: ''
   - name: yesterday
-    uid: 'ExcelScript!ExcelScript.DynamicFilterCriteria.yesterday:member'
+    uid: ExcelScript!ExcelScript.DynamicFilterCriteria.yesterday:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.emptycellcontrol.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.emptycellcontrol.yml
@@ -1,23 +1,27 @@
 ### YamlMime:TSType
 name: ExcelScript.EmptyCellControl
-uid: 'ExcelScript!ExcelScript.EmptyCellControl:interface'
+uid: ExcelScript!ExcelScript.EmptyCellControl:interface
 package: ExcelScript!
 fullName: ExcelScript.EmptyCellControl
-summary: Represents an empty cell control. This represents the state where a cell does not have a control.
+summary: >-
+  Represents an empty cell control. This represents the state where a cell does
+  not have a control.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: type
-    uid: 'ExcelScript!ExcelScript.EmptyCellControl#type:member'
+    uid: ExcelScript!ExcelScript.EmptyCellControl#type:member
     package: ExcelScript!
     fullName: type
     summary: ''
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: CellControlType.empty;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellControlType.empty:member" />'
+        type: <xref uid="ExcelScript!ExcelScript.CellControlType.empty:member" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.fillpattern.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.fillpattern.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.FillPattern
-uid: 'ExcelScript!ExcelScript.FillPattern:enum'
+uid: ExcelScript!ExcelScript.FillPattern:enum
 package: ExcelScript!
 fullName: ExcelScript.FillPattern
 summary: ''
@@ -19,90 +19,91 @@ remarks: |-
     selected.getFormat().getFill().setPatternColor("black");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: checker
-    uid: 'ExcelScript!ExcelScript.FillPattern.checker:member'
+    uid: ExcelScript!ExcelScript.FillPattern.checker:member
     package: ExcelScript!
     summary: ''
   - name: crissCross
-    uid: 'ExcelScript!ExcelScript.FillPattern.crissCross:member'
+    uid: ExcelScript!ExcelScript.FillPattern.crissCross:member
     package: ExcelScript!
     summary: ''
   - name: down
-    uid: 'ExcelScript!ExcelScript.FillPattern.down:member'
+    uid: ExcelScript!ExcelScript.FillPattern.down:member
     package: ExcelScript!
     summary: ''
   - name: gray16
-    uid: 'ExcelScript!ExcelScript.FillPattern.gray16:member'
+    uid: ExcelScript!ExcelScript.FillPattern.gray16:member
     package: ExcelScript!
     summary: ''
   - name: gray25
-    uid: 'ExcelScript!ExcelScript.FillPattern.gray25:member'
+    uid: ExcelScript!ExcelScript.FillPattern.gray25:member
     package: ExcelScript!
     summary: ''
   - name: gray50
-    uid: 'ExcelScript!ExcelScript.FillPattern.gray50:member'
+    uid: ExcelScript!ExcelScript.FillPattern.gray50:member
     package: ExcelScript!
     summary: ''
   - name: gray75
-    uid: 'ExcelScript!ExcelScript.FillPattern.gray75:member'
+    uid: ExcelScript!ExcelScript.FillPattern.gray75:member
     package: ExcelScript!
     summary: ''
   - name: gray8
-    uid: 'ExcelScript!ExcelScript.FillPattern.gray8:member'
+    uid: ExcelScript!ExcelScript.FillPattern.gray8:member
     package: ExcelScript!
     summary: ''
   - name: grid
-    uid: 'ExcelScript!ExcelScript.FillPattern.grid:member'
+    uid: ExcelScript!ExcelScript.FillPattern.grid:member
     package: ExcelScript!
     summary: ''
   - name: horizontal
-    uid: 'ExcelScript!ExcelScript.FillPattern.horizontal:member'
+    uid: ExcelScript!ExcelScript.FillPattern.horizontal:member
     package: ExcelScript!
     summary: ''
   - name: lightDown
-    uid: 'ExcelScript!ExcelScript.FillPattern.lightDown:member'
+    uid: ExcelScript!ExcelScript.FillPattern.lightDown:member
     package: ExcelScript!
     summary: ''
   - name: lightHorizontal
-    uid: 'ExcelScript!ExcelScript.FillPattern.lightHorizontal:member'
+    uid: ExcelScript!ExcelScript.FillPattern.lightHorizontal:member
     package: ExcelScript!
     summary: ''
   - name: lightUp
-    uid: 'ExcelScript!ExcelScript.FillPattern.lightUp:member'
+    uid: ExcelScript!ExcelScript.FillPattern.lightUp:member
     package: ExcelScript!
     summary: ''
   - name: lightVertical
-    uid: 'ExcelScript!ExcelScript.FillPattern.lightVertical:member'
+    uid: ExcelScript!ExcelScript.FillPattern.lightVertical:member
     package: ExcelScript!
     summary: ''
   - name: linearGradient
-    uid: 'ExcelScript!ExcelScript.FillPattern.linearGradient:member'
+    uid: ExcelScript!ExcelScript.FillPattern.linearGradient:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.FillPattern.none:member'
+    uid: ExcelScript!ExcelScript.FillPattern.none:member
     package: ExcelScript!
     summary: ''
   - name: rectangularGradient
-    uid: 'ExcelScript!ExcelScript.FillPattern.rectangularGradient:member'
+    uid: ExcelScript!ExcelScript.FillPattern.rectangularGradient:member
     package: ExcelScript!
     summary: ''
   - name: semiGray75
-    uid: 'ExcelScript!ExcelScript.FillPattern.semiGray75:member'
+    uid: ExcelScript!ExcelScript.FillPattern.semiGray75:member
     package: ExcelScript!
     summary: ''
   - name: solid
-    uid: 'ExcelScript!ExcelScript.FillPattern.solid:member'
+    uid: ExcelScript!ExcelScript.FillPattern.solid:member
     package: ExcelScript!
     summary: ''
   - name: up
-    uid: 'ExcelScript!ExcelScript.FillPattern.up:member'
+    uid: ExcelScript!ExcelScript.FillPattern.up:member
     package: ExcelScript!
     summary: ''
   - name: vertical
-    uid: 'ExcelScript!ExcelScript.FillPattern.vertical:member'
+    uid: ExcelScript!ExcelScript.FillPattern.vertical:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filter.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.Filter
-uid: 'ExcelScript!ExcelScript.Filter:interface'
+uid: ExcelScript!ExcelScript.Filter:interface
 package: ExcelScript!
 fullName: ExcelScript.Filter
 summary: Manages the filtering of a table's column.
@@ -25,16 +25,18 @@ remarks: |-
       pageViewFilter.applyTopPercentFilter(10);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: apply(criteria)
-    uid: 'ExcelScript!ExcelScript.Filter#apply:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#apply:member(1)
     package: ExcelScript!
     fullName: apply(criteria)
     summary: Apply the given filter criteria on the given column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,16 +44,19 @@ methods:
       parameters:
         - id: criteria
           description: The criteria to apply.
-          type: '<xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />
       return:
         type: void
         description: ''
   - name: applyBottomItemsFilter(count)
-    uid: 'ExcelScript!ExcelScript.Filter#applyBottomItemsFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyBottomItemsFilter:member(1)
     package: ExcelScript!
     fullName: applyBottomItemsFilter(count)
-    summary: Apply a "Bottom Item" filter to the column for the given number of elements.
+    summary: >-
+      Apply a "Bottom Item" filter to the column for the given number of
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,11 +69,14 @@ methods:
         type: void
         description: ''
   - name: applyBottomPercentFilter(percent)
-    uid: 'ExcelScript!ExcelScript.Filter#applyBottomPercentFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyBottomPercentFilter:member(1)
     package: ExcelScript!
     fullName: applyBottomPercentFilter(percent)
-    summary: Apply a "Bottom Percent" filter to the column for the given percentage of elements.
+    summary: >-
+      Apply a "Bottom Percent" filter to the column for the given percentage of
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -81,11 +89,12 @@ methods:
         type: void
         description: ''
   - name: applyCellColorFilter(color)
-    uid: 'ExcelScript!ExcelScript.Filter#applyCellColorFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyCellColorFilter:member(1)
     package: ExcelScript!
     fullName: applyCellColorFilter(color)
     summary: Apply a "Cell Color" filter to the column for the given color.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -97,12 +106,13 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'applyCustomFilter(criteria1, criteria2, oper)'
-    uid: 'ExcelScript!ExcelScript.Filter#applyCustomFilter:member(1)'
+  - name: applyCustomFilter(criteria1, criteria2, oper)
+    uid: ExcelScript!ExcelScript.Filter#applyCustomFilter:member(1)
     package: ExcelScript!
-    fullName: 'applyCustomFilter(criteria1, criteria2, oper)'
+    fullName: applyCustomFilter(criteria1, criteria2, oper)
     summary: Apply an "Icon" filter to the column for the given criteria strings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -120,8 +130,10 @@ methods:
           description: Optional. The second criteria string.
           type: string
         - id: oper
-          description: Optional. The operator that describes how the two criteria are joined.
-          type: '<xref uid="ExcelScript!ExcelScript.FilterOperator:enum" />'
+          description: >-
+            Optional. The operator that describes how the two criteria are
+            joined.
+          type: <xref uid="ExcelScript!ExcelScript.FilterOperator:enum" />
       return:
         type: void
         description: |-
@@ -144,11 +156,12 @@ methods:
           }
           ```
   - name: applyDynamicFilter(criteria)
-    uid: 'ExcelScript!ExcelScript.Filter#applyDynamicFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyDynamicFilter:member(1)
     package: ExcelScript!
     fullName: applyDynamicFilter(criteria)
     summary: Apply a "Dynamic" filter to the column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -156,7 +169,7 @@ methods:
       parameters:
         - id: criteria
           description: The dynamic criteria to apply.
-          type: '<xref uid="ExcelScript!ExcelScript.DynamicFilterCriteria:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.DynamicFilterCriteria:enum" />
       return:
         type: void
         description: |-
@@ -182,11 +195,12 @@ methods:
           }
           ```
   - name: applyFontColorFilter(color)
-    uid: 'ExcelScript!ExcelScript.Filter#applyFontColorFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyFontColorFilter:member(1)
     package: ExcelScript!
     fullName: applyFontColorFilter(color)
     summary: Apply a "Font Color" filter to the column for the given color.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -199,11 +213,12 @@ methods:
         type: void
         description: ''
   - name: applyIconFilter(icon)
-    uid: 'ExcelScript!ExcelScript.Filter#applyIconFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyIconFilter:member(1)
     package: ExcelScript!
     fullName: applyIconFilter(icon)
     summary: Apply an "Icon" filter to the column for the given icon.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -211,16 +226,17 @@ methods:
       parameters:
         - id: icon
           description: The icons of the cells to show.
-          type: '<xref uid="ExcelScript!ExcelScript.Icon:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Icon:interface" />
       return:
         type: void
         description: ''
   - name: applyTopItemsFilter(count)
-    uid: 'ExcelScript!ExcelScript.Filter#applyTopItemsFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyTopItemsFilter:member(1)
     package: ExcelScript!
     fullName: applyTopItemsFilter(count)
     summary: Apply a "Top Item" filter to the column for the given number of elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -233,11 +249,14 @@ methods:
         type: void
         description: ''
   - name: applyTopPercentFilter(percent)
-    uid: 'ExcelScript!ExcelScript.Filter#applyTopPercentFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyTopPercentFilter:member(1)
     package: ExcelScript!
     fullName: applyTopPercentFilter(percent)
-    summary: Apply a "Top Percent" filter to the column for the given percentage of elements.
+    summary: >-
+      Apply a "Top Percent" filter to the column for the given percentage of
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -250,11 +269,12 @@ methods:
         type: void
         description: ''
   - name: applyValuesFilter(values)
-    uid: 'ExcelScript!ExcelScript.Filter#applyValuesFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#applyValuesFilter:member(1)
     package: ExcelScript!
     fullName: applyValuesFilter(values)
     summary: Apply a "Values" filter to the column for the given values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -262,9 +282,11 @@ methods:
       parameters:
         - id: values
           description: >-
-            The list of values to show. This must be an array of strings or an array of `ExcelScript.FilterDateTime`
-            objects.
-          type: 'Array&lt;string | <xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />&gt;'
+            The list of values to show. This must be an array of strings or an
+            array of `ExcelScript.FilterDateTime` objects.
+          type: >-
+            Array&lt;string | <xref
+            uid="ExcelScript!ExcelScript.FilterDatetime:interface" />&gt;
       return:
         type: void
         description: |-
@@ -286,11 +308,12 @@ methods:
           }
           ```
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.Filter#clear:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clear the filter on the given column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -316,15 +339,16 @@ methods:
           }
           ```
   - name: getCriteria()
-    uid: 'ExcelScript!ExcelScript.Filter#getCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.Filter#getCriteria:member(1)
     package: ExcelScript!
     fullName: getCriteria()
     summary: The currently applied filter on the given column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCriteria(): FilterCriteria;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterCriteria:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filtercriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filtercriteria.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.FilterCriteria
-uid: 'ExcelScript!ExcelScript.FilterCriteria:interface'
+uid: ExcelScript!ExcelScript.FilterCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterCriteria
 summary: Represents the filtering criteria applied to a column.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: color
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#color:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#color:member
     package: ExcelScript!
     fullName: color
-    summary: The HTML color string used to filter cells. Used with `cellColor` and `fontColor` filtering.
+    summary: >-
+      The HTML color string used to filter cells. Used with `cellColor` and
+      `fontColor` filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,17 +26,19 @@ properties:
       return:
         type: string
   - name: criterion1
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#criterion1:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#criterion1:member
     package: ExcelScript!
     fullName: criterion1
     summary: >-
-      The first criterion used to filter data. Used as an operator in the case of `custom` filtering. For example "<!--
-      -->&gt;<!-- -->50" for numbers greater than 50, or "=*s" for values ending in "s".
+      The first criterion used to filter data. Used as an operator in the case
+      of `custom` filtering. For example "<!-- -->&gt;<!-- -->50" for numbers
+      greater than 50, or "=*s" for values ending in "s".
 
 
-      Used as a number in the case of top/bottom items/percents (e.g., "5" for the top 5 items if `filterOn` is set to
-      `topItems`<!-- -->).
+      Used as a number in the case of top/bottom items/percents (e.g., "5" for
+      the top 5 items if `filterOn` is set to `topItems`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,11 +70,14 @@ properties:
           }
           ```
   - name: criterion2
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#criterion2:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#criterion2:member
     package: ExcelScript!
     fullName: criterion2
-    summary: The second criterion used to filter data. Only used as an operator in the case of `custom` filtering.
+    summary: >-
+      The second criterion used to filter data. Only used as an operator in the
+      case of `custom` filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -76,61 +85,70 @@ properties:
       return:
         type: string
   - name: dynamicCriteria
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#dynamicCriteria:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#dynamicCriteria:member
     package: ExcelScript!
     fullName: dynamicCriteria
     summary: >-
-      The dynamic criteria from the `ExcelScript.DynamicFilterCriteria` set to apply on this column. Used with `dynamic`
-      filtering.
+      The dynamic criteria from the `ExcelScript.DynamicFilterCriteria` set to
+      apply on this column. Used with `dynamic` filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'dynamicCriteria?: DynamicFilterCriteria;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DynamicFilterCriteria:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DynamicFilterCriteria:enum" />
   - name: filterOn
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#filterOn:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#filterOn:member
     package: ExcelScript!
     fullName: filterOn
-    summary: The property used by the filter to determine whether the values should stay visible.
+    summary: >-
+      The property used by the filter to determine whether the values should
+      stay visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'filterOn: FilterOn;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterOn:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterOn:enum" />
   - name: icon
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#icon:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#icon:member
     package: ExcelScript!
     fullName: icon
     summary: The icon used to filter cells. Used with `icon` filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'icon?: Icon;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Icon:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Icon:interface" />
   - name: operator
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#operator:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#operator:member
     package: ExcelScript!
     fullName: operator
-    summary: The operator used to combine criterion 1 and 2 when using `custom` filtering.
+    summary: >-
+      The operator used to combine criterion 1 and 2 when using `custom`
+      filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'operator?: FilterOperator;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterOperator:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterOperator:enum" />
   - name: subField
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#subField:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#subField:member
     package: ExcelScript!
     fullName: subField
     summary: The property used by the filter to do a rich filter on rich values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -138,14 +156,17 @@ properties:
       return:
         type: string
   - name: values
-    uid: 'ExcelScript!ExcelScript.FilterCriteria#values:member'
+    uid: ExcelScript!ExcelScript.FilterCriteria#values:member
     package: ExcelScript!
     fullName: values
     summary: The set of values to be used as part of `values` filtering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'values?: Array<string | FilterDatetime>;'
       return:
-        type: 'Array&lt;string | <xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />&gt;'
+        type: >-
+          Array&lt;string | <xref
+          uid="ExcelScript!ExcelScript.FilterDatetime:interface" />&gt;

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filterdatetime.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filterdatetime.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.FilterDatetime
-uid: 'ExcelScript!ExcelScript.FilterDatetime:interface'
+uid: ExcelScript!ExcelScript.FilterDatetime:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterDatetime
 summary: Represents how to filter a date when filtering on values.
@@ -41,16 +41,18 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: date
-    uid: 'ExcelScript!ExcelScript.FilterDatetime#date:member'
+    uid: ExcelScript!ExcelScript.FilterDatetime#date:member
     package: ExcelScript!
     fullName: date
     summary: The date in ISO8601 format used to filter data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -58,16 +60,18 @@ properties:
       return:
         type: string
   - name: specificity
-    uid: 'ExcelScript!ExcelScript.FilterDatetime#specificity:member'
+    uid: ExcelScript!ExcelScript.FilterDatetime#specificity:member
     package: ExcelScript!
     fullName: specificity
     summary: >-
-      How specific the date should be used to keep data. For example, if the date is 2005-04-02 and the specificity is
-      set to "month", the filter operation will keep all rows with a date in the month of April 2005.
+      How specific the date should be used to keep data. For example, if the
+      date is 2005-04-02 and the specificity is set to "month", the filter
+      operation will keep all rows with a date in the month of April 2005.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'specificity: FilterDatetimeSpecificity;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filterdatetimespecificity.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filterdatetimespecificity.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.FilterDatetimeSpecificity
-uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum'
+uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterDatetimeSpecificity
 summary: ''
@@ -41,30 +41,31 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: day
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.day:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.day:member
     package: ExcelScript!
     summary: ''
   - name: hour
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.hour:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.hour:member
     package: ExcelScript!
     summary: ''
   - name: minute
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.minute:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.minute:member
     package: ExcelScript!
     summary: ''
   - name: month
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.month:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.month:member
     package: ExcelScript!
     summary: ''
   - name: second
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.second:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.second:member
     package: ExcelScript!
     summary: ''
   - name: year
-    uid: 'ExcelScript!ExcelScript.FilterDatetimeSpecificity.year:member'
+    uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity.year:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filteron.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filteron.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.FilterOn
-uid: 'ExcelScript!ExcelScript.FilterOn:enum'
+uid: ExcelScript!ExcelScript.FilterOn:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterOn
 summary: ''
@@ -29,46 +29,47 @@ remarks: |-
     autoFilter.apply(table.getRange(), 1, filterCriteria);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottomItems
-    uid: 'ExcelScript!ExcelScript.FilterOn.bottomItems:member'
+    uid: ExcelScript!ExcelScript.FilterOn.bottomItems:member
     package: ExcelScript!
     summary: ''
   - name: bottomPercent
-    uid: 'ExcelScript!ExcelScript.FilterOn.bottomPercent:member'
+    uid: ExcelScript!ExcelScript.FilterOn.bottomPercent:member
     package: ExcelScript!
     summary: ''
   - name: cellColor
-    uid: 'ExcelScript!ExcelScript.FilterOn.cellColor:member'
+    uid: ExcelScript!ExcelScript.FilterOn.cellColor:member
     package: ExcelScript!
     summary: ''
   - name: custom
-    uid: 'ExcelScript!ExcelScript.FilterOn.custom:member'
+    uid: ExcelScript!ExcelScript.FilterOn.custom:member
     package: ExcelScript!
     summary: ''
   - name: dynamic
-    uid: 'ExcelScript!ExcelScript.FilterOn.dynamic:member'
+    uid: ExcelScript!ExcelScript.FilterOn.dynamic:member
     package: ExcelScript!
     summary: ''
   - name: fontColor
-    uid: 'ExcelScript!ExcelScript.FilterOn.fontColor:member'
+    uid: ExcelScript!ExcelScript.FilterOn.fontColor:member
     package: ExcelScript!
     summary: ''
   - name: icon
-    uid: 'ExcelScript!ExcelScript.FilterOn.icon:member'
+    uid: ExcelScript!ExcelScript.FilterOn.icon:member
     package: ExcelScript!
     summary: ''
   - name: topItems
-    uid: 'ExcelScript!ExcelScript.FilterOn.topItems:member'
+    uid: ExcelScript!ExcelScript.FilterOn.topItems:member
     package: ExcelScript!
     summary: ''
   - name: topPercent
-    uid: 'ExcelScript!ExcelScript.FilterOn.topPercent:member'
+    uid: ExcelScript!ExcelScript.FilterOn.topPercent:member
     package: ExcelScript!
     summary: ''
   - name: values
-    uid: 'ExcelScript!ExcelScript.FilterOn.values:member'
+    uid: ExcelScript!ExcelScript.FilterOn.values:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filteroperator.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filteroperator.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.FilterOperator
-uid: 'ExcelScript!ExcelScript.FilterOperator:enum'
+uid: ExcelScript!ExcelScript.FilterOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterOperator
 summary: ''
@@ -23,14 +23,15 @@ remarks: |-
     table.getColumnByName("Exam Score").getFilter().applyCustomFilter(">0", "<=60", ExcelScript.FilterOperator.and);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: and
-    uid: 'ExcelScript!ExcelScript.FilterOperator.and:member'
+    uid: ExcelScript!ExcelScript.FilterOperator.and:member
     package: ExcelScript!
     summary: ''
   - name: or
-    uid: 'ExcelScript!ExcelScript.FilterOperator.or:member'
+    uid: ExcelScript!ExcelScript.FilterOperator.or:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.filterpivothierarchy.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.FilterPivotHierarchy
-uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy:interface'
+uid: ExcelScript!ExcelScript.FilterPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterPivotHierarchy
 summary: Represents the Excel FilterPivotHierarchy.
@@ -31,16 +31,19 @@ remarks: |-
     // Add other hierarchies...
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getEnableMultipleFilterItems()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getEnableMultipleFilterItems:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.FilterPivotHierarchy#getEnableMultipleFilterItems:member(1)
     package: ExcelScript!
     fullName: getEnableMultipleFilterItems()
     summary: Determines whether to allow multiple filter items.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,24 +52,26 @@ methods:
         type: boolean
         description: ''
   - name: getFields()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getFields:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#getFields:member(1)
     package: ExcelScript!
     fullName: getFields()
     summary: Returns the PivotFields associated with the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFields(): PivotField[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getId:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +80,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getName:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -106,11 +112,14 @@ methods:
           }
           ```
   - name: getPivotField(name)
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getPivotField:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#getPivotField:member(1)
     package: ExcelScript!
     fullName: getPivotField(name)
-    summary: 'Gets a PivotField by name. If the PivotField does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotField by name. If the PivotField does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -120,14 +129,17 @@ methods:
           description: Name of the PivotField to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotField:interface" /> |
+          undefined
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: Position of the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -136,11 +148,13 @@ methods:
         type: number
         description: ''
   - name: setEnableMultipleFilterItems(enableMultipleFilterItems)
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#setEnableMultipleFilterItems:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.FilterPivotHierarchy#setEnableMultipleFilterItems:member(1)
     package: ExcelScript!
     fullName: setEnableMultipleFilterItems(enableMultipleFilterItems)
     summary: Determines whether to allow multiple filter items.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -153,11 +167,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#setName:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -170,11 +185,12 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: Position of the FilterPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -187,11 +203,12 @@ methods:
         type: void
         description: ''
   - name: setToDefault()
-    uid: 'ExcelScript!ExcelScript.FilterPivotHierarchy#setToDefault:member(1)'
+    uid: ExcelScript!ExcelScript.FilterPivotHierarchy#setToDefault:member(1)
     package: ExcelScript!
     fullName: setToDefault()
     summary: Reset the FilterPivotHierarchy back to its default values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.formatprotection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.formatprotection.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSType
 name: ExcelScript.FormatProtection
-uid: 'ExcelScript!ExcelScript.FormatProtection:interface'
+uid: ExcelScript!ExcelScript.FormatProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.FormatProtection
 summary: Represents the format protection of a range object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormulaHidden()
-    uid: 'ExcelScript!ExcelScript.FormatProtection#getFormulaHidden:member(1)'
+    uid: ExcelScript!ExcelScript.FormatProtection#getFormulaHidden:member(1)
     package: ExcelScript!
     fullName: getFormulaHidden()
     summary: >-
-      Specifies if Excel hides the formula for the cells in the range. A `null` value indicates that the entire range
-      doesn't have a uniform formula hidden setting.
+      Specifies if Excel hides the formula for the cells in the range. A `null`
+      value indicates that the entire range doesn't have a uniform formula
+      hidden setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,13 +28,14 @@ methods:
         type: boolean
         description: ''
   - name: getLocked()
-    uid: 'ExcelScript!ExcelScript.FormatProtection#getLocked:member(1)'
+    uid: ExcelScript!ExcelScript.FormatProtection#getLocked:member(1)
     package: ExcelScript!
     fullName: getLocked()
     summary: >-
-      Specifies if Excel locks the cells in the object. A `null` value indicates that the entire range doesn't have a
-      uniform lock setting.
+      Specifies if Excel locks the cells in the object. A `null` value indicates
+      that the entire range doesn't have a uniform lock setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,13 +44,15 @@ methods:
         type: boolean
         description: ''
   - name: setFormulaHidden(formulaHidden)
-    uid: 'ExcelScript!ExcelScript.FormatProtection#setFormulaHidden:member(1)'
+    uid: ExcelScript!ExcelScript.FormatProtection#setFormulaHidden:member(1)
     package: ExcelScript!
     fullName: setFormulaHidden(formulaHidden)
     summary: >-
-      Specifies if Excel hides the formula for the cells in the range. A `null` value indicates that the entire range
-      doesn't have a uniform formula hidden setting.
+      Specifies if Excel hides the formula for the cells in the range. A `null`
+      value indicates that the entire range doesn't have a uniform formula
+      hidden setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -59,13 +65,14 @@ methods:
         type: void
         description: ''
   - name: setLocked(locked)
-    uid: 'ExcelScript!ExcelScript.FormatProtection#setLocked:member(1)'
+    uid: ExcelScript!ExcelScript.FormatProtection#setLocked:member(1)
     package: ExcelScript!
     fullName: setLocked(locked)
     summary: >-
-      Specifies if Excel locks the cells in the object. A `null` value indicates that the entire range doesn't have a
-      uniform lock setting.
+      Specifies if Excel locks the cells in the object. A `null` value indicates
+      that the entire range doesn't have a uniform lock setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.geometricshape.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.geometricshape.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSType
 name: ExcelScript.GeometricShape
-uid: 'ExcelScript!ExcelScript.GeometricShape:interface'
+uid: ExcelScript!ExcelScript.GeometricShape:interface
 package: ExcelScript!
 fullName: ExcelScript.GeometricShape
 summary: >-
-  Represents a geometric shape inside a worksheet. A geometric shape can be a rectangle, block arrow, equation symbol,
-  flowchart item, star, banner, callout, or any other basic shape in Excel.
+  Represents a geometric shape inside a worksheet. A geometric shape can be a
+  rectangle, block arrow, equation symbol, flowchart item, star, banner,
+  callout, or any other basic shape in Excel.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.GeometricShape#getId:member(1)'
+    uid: ExcelScript!ExcelScript.GeometricShape#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Returns the shape identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.geometricshapetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.geometricshapetype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.GeometricShapeType
-uid: 'ExcelScript!ExcelScript.GeometricShapeType:enum'
+uid: ExcelScript!ExcelScript.GeometricShapeType:enum
 package: ExcelScript!
 fullName: ExcelScript.GeometricShapeType
 summary: Specifies the shape type for a `GeometricShape` object.
@@ -27,714 +27,718 @@ remarks: |-
     hexagon.setTop(100);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: accentBorderCallout1
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout1:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout1:member
     package: ExcelScript!
     summary: ''
   - name: accentBorderCallout2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout2:member
     package: ExcelScript!
     summary: ''
   - name: accentBorderCallout3
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout3:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentBorderCallout3:member
     package: ExcelScript!
     summary: ''
   - name: accentCallout1
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentCallout1:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentCallout1:member
     package: ExcelScript!
     summary: ''
   - name: accentCallout2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentCallout2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentCallout2:member
     package: ExcelScript!
     summary: ''
   - name: accentCallout3
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.accentCallout3:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.accentCallout3:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonBackPrevious
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonBackPrevious:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonBackPrevious:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonBeginning
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonBeginning:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonBeginning:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonBlank
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonBlank:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonBlank:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonDocument
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonDocument:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonDocument:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonEnd
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonEnd:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonEnd:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonForwardNext
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonForwardNext:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonForwardNext:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonHelp
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonHelp:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonHelp:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonHome
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonHome:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonHome:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonInformation
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonInformation:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonInformation:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonMovie
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonMovie:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonMovie:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonReturn
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonReturn:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonReturn:member
     package: ExcelScript!
     summary: ''
   - name: actionButtonSound
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.actionButtonSound:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.actionButtonSound:member
     package: ExcelScript!
     summary: ''
   - name: arc
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.arc:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.arc:member
     package: ExcelScript!
     summary: ''
   - name: bentArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.bentArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.bentArrow:member
     package: ExcelScript!
     summary: ''
   - name: bentUpArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.bentUpArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.bentUpArrow:member
     package: ExcelScript!
     summary: ''
   - name: bevel
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.bevel:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.bevel:member
     package: ExcelScript!
     summary: ''
   - name: blockArc
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.blockArc:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.blockArc:member
     package: ExcelScript!
     summary: ''
   - name: borderCallout1
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.borderCallout1:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.borderCallout1:member
     package: ExcelScript!
     summary: ''
   - name: borderCallout2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.borderCallout2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.borderCallout2:member
     package: ExcelScript!
     summary: ''
   - name: borderCallout3
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.borderCallout3:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.borderCallout3:member
     package: ExcelScript!
     summary: ''
   - name: bracePair
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.bracePair:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.bracePair:member
     package: ExcelScript!
     summary: ''
   - name: bracketPair
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.bracketPair:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.bracketPair:member
     package: ExcelScript!
     summary: ''
   - name: callout1
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.callout1:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.callout1:member
     package: ExcelScript!
     summary: ''
   - name: callout2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.callout2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.callout2:member
     package: ExcelScript!
     summary: ''
   - name: callout3
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.callout3:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.callout3:member
     package: ExcelScript!
     summary: ''
   - name: can
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.can:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.can:member
     package: ExcelScript!
     summary: ''
   - name: chartPlus
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.chartPlus:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.chartPlus:member
     package: ExcelScript!
     summary: ''
   - name: chartStar
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.chartStar:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.chartStar:member
     package: ExcelScript!
     summary: ''
   - name: chartX
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.chartX:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.chartX:member
     package: ExcelScript!
     summary: ''
   - name: chevron
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.chevron:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.chevron:member
     package: ExcelScript!
     summary: ''
   - name: chord
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.chord:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.chord:member
     package: ExcelScript!
     summary: ''
   - name: circularArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.circularArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.circularArrow:member
     package: ExcelScript!
     summary: ''
   - name: cloud
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.cloud:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.cloud:member
     package: ExcelScript!
     summary: ''
   - name: cloudCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.cloudCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.cloudCallout:member
     package: ExcelScript!
     summary: ''
   - name: corner
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.corner:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.corner:member
     package: ExcelScript!
     summary: ''
   - name: cornerTabs
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.cornerTabs:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.cornerTabs:member
     package: ExcelScript!
     summary: ''
   - name: cube
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.cube:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.cube:member
     package: ExcelScript!
     summary: ''
   - name: curvedDownArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.curvedDownArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.curvedDownArrow:member
     package: ExcelScript!
     summary: ''
   - name: curvedLeftArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.curvedLeftArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.curvedLeftArrow:member
     package: ExcelScript!
     summary: ''
   - name: curvedRightArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.curvedRightArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.curvedRightArrow:member
     package: ExcelScript!
     summary: ''
   - name: curvedUpArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.curvedUpArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.curvedUpArrow:member
     package: ExcelScript!
     summary: ''
   - name: decagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.decagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.decagon:member
     package: ExcelScript!
     summary: ''
   - name: diagonalStripe
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.diagonalStripe:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.diagonalStripe:member
     package: ExcelScript!
     summary: ''
   - name: diamond
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.diamond:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.diamond:member
     package: ExcelScript!
     summary: ''
   - name: dodecagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.dodecagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.dodecagon:member
     package: ExcelScript!
     summary: ''
   - name: donut
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.donut:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.donut:member
     package: ExcelScript!
     summary: ''
   - name: doubleWave
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.doubleWave:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.doubleWave:member
     package: ExcelScript!
     summary: ''
   - name: downArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.downArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.downArrow:member
     package: ExcelScript!
     summary: ''
   - name: downArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.downArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.downArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: ellipse
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.ellipse:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.ellipse:member
     package: ExcelScript!
     summary: ''
   - name: ellipseRibbon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.ellipseRibbon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.ellipseRibbon:member
     package: ExcelScript!
     summary: ''
   - name: ellipseRibbon2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.ellipseRibbon2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.ellipseRibbon2:member
     package: ExcelScript!
     summary: ''
   - name: flowChartAlternateProcess
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartAlternateProcess:member'
+    uid: >-
+      ExcelScript!ExcelScript.GeometricShapeType.flowChartAlternateProcess:member
     package: ExcelScript!
     summary: ''
   - name: flowChartCollate
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartCollate:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartCollate:member
     package: ExcelScript!
     summary: ''
   - name: flowChartConnector
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartConnector:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartConnector:member
     package: ExcelScript!
     summary: ''
   - name: flowChartDecision
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartDecision:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartDecision:member
     package: ExcelScript!
     summary: ''
   - name: flowChartDelay
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartDelay:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartDelay:member
     package: ExcelScript!
     summary: ''
   - name: flowChartDisplay
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartDisplay:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartDisplay:member
     package: ExcelScript!
     summary: ''
   - name: flowChartDocument
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartDocument:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartDocument:member
     package: ExcelScript!
     summary: ''
   - name: flowChartExtract
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartExtract:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartExtract:member
     package: ExcelScript!
     summary: ''
   - name: flowChartInputOutput
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartInputOutput:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartInputOutput:member
     package: ExcelScript!
     summary: ''
   - name: flowChartInternalStorage
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartInternalStorage:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartInternalStorage:member
     package: ExcelScript!
     summary: ''
   - name: flowChartMagneticDisk
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticDisk:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticDisk:member
     package: ExcelScript!
     summary: ''
   - name: flowChartMagneticDrum
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticDrum:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticDrum:member
     package: ExcelScript!
     summary: ''
   - name: flowChartMagneticTape
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticTape:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartMagneticTape:member
     package: ExcelScript!
     summary: ''
   - name: flowChartManualInput
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartManualInput:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartManualInput:member
     package: ExcelScript!
     summary: ''
   - name: flowChartManualOperation
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartManualOperation:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartManualOperation:member
     package: ExcelScript!
     summary: ''
   - name: flowChartMerge
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartMerge:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartMerge:member
     package: ExcelScript!
     summary: ''
   - name: flowChartMultidocument
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartMultidocument:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartMultidocument:member
     package: ExcelScript!
     summary: ''
   - name: flowChartOfflineStorage
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartOfflineStorage:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartOfflineStorage:member
     package: ExcelScript!
     summary: ''
   - name: flowChartOffpageConnector
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartOffpageConnector:member'
+    uid: >-
+      ExcelScript!ExcelScript.GeometricShapeType.flowChartOffpageConnector:member
     package: ExcelScript!
     summary: ''
   - name: flowChartOnlineStorage
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartOnlineStorage:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartOnlineStorage:member
     package: ExcelScript!
     summary: ''
   - name: flowChartOr
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartOr:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartOr:member
     package: ExcelScript!
     summary: ''
   - name: flowChartPredefinedProcess
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartPredefinedProcess:member'
+    uid: >-
+      ExcelScript!ExcelScript.GeometricShapeType.flowChartPredefinedProcess:member
     package: ExcelScript!
     summary: ''
   - name: flowChartPreparation
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartPreparation:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartPreparation:member
     package: ExcelScript!
     summary: ''
   - name: flowChartProcess
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartProcess:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartProcess:member
     package: ExcelScript!
     summary: ''
   - name: flowChartPunchedCard
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartPunchedCard:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartPunchedCard:member
     package: ExcelScript!
     summary: ''
   - name: flowChartPunchedTape
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartPunchedTape:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartPunchedTape:member
     package: ExcelScript!
     summary: ''
   - name: flowChartSort
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartSort:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartSort:member
     package: ExcelScript!
     summary: ''
   - name: flowChartSummingJunction
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartSummingJunction:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartSummingJunction:member
     package: ExcelScript!
     summary: ''
   - name: flowChartTerminator
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.flowChartTerminator:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.flowChartTerminator:member
     package: ExcelScript!
     summary: ''
   - name: foldedCorner
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.foldedCorner:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.foldedCorner:member
     package: ExcelScript!
     summary: ''
   - name: frame
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.frame:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.frame:member
     package: ExcelScript!
     summary: ''
   - name: funnel
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.funnel:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.funnel:member
     package: ExcelScript!
     summary: ''
   - name: gear6
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.gear6:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.gear6:member
     package: ExcelScript!
     summary: ''
   - name: gear9
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.gear9:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.gear9:member
     package: ExcelScript!
     summary: ''
   - name: halfFrame
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.halfFrame:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.halfFrame:member
     package: ExcelScript!
     summary: ''
   - name: heart
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.heart:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.heart:member
     package: ExcelScript!
     summary: ''
   - name: heptagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.heptagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.heptagon:member
     package: ExcelScript!
     summary: ''
   - name: hexagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.hexagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.hexagon:member
     package: ExcelScript!
     summary: ''
   - name: homePlate
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.homePlate:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.homePlate:member
     package: ExcelScript!
     summary: ''
   - name: horizontalScroll
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.horizontalScroll:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.horizontalScroll:member
     package: ExcelScript!
     summary: ''
   - name: irregularSeal1
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.irregularSeal1:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.irregularSeal1:member
     package: ExcelScript!
     summary: ''
   - name: irregularSeal2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.irregularSeal2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.irregularSeal2:member
     package: ExcelScript!
     summary: ''
   - name: leftArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftArrow:member
     package: ExcelScript!
     summary: ''
   - name: leftArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: leftBrace
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftBrace:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftBrace:member
     package: ExcelScript!
     summary: ''
   - name: leftBracket
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftBracket:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftBracket:member
     package: ExcelScript!
     summary: ''
   - name: leftCircularArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftCircularArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftCircularArrow:member
     package: ExcelScript!
     summary: ''
   - name: leftRightArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftRightArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftRightArrow:member
     package: ExcelScript!
     summary: ''
   - name: leftRightArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftRightArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftRightArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: leftRightCircularArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftRightCircularArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftRightCircularArrow:member
     package: ExcelScript!
     summary: ''
   - name: leftRightRibbon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftRightRibbon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftRightRibbon:member
     package: ExcelScript!
     summary: ''
   - name: leftRightUpArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftRightUpArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftRightUpArrow:member
     package: ExcelScript!
     summary: ''
   - name: leftUpArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.leftUpArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.leftUpArrow:member
     package: ExcelScript!
     summary: ''
   - name: lightningBolt
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.lightningBolt:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.lightningBolt:member
     package: ExcelScript!
     summary: ''
   - name: lineInverse
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.lineInverse:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.lineInverse:member
     package: ExcelScript!
     summary: ''
   - name: mathDivide
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathDivide:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathDivide:member
     package: ExcelScript!
     summary: ''
   - name: mathEqual
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathEqual:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathEqual:member
     package: ExcelScript!
     summary: ''
   - name: mathMinus
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathMinus:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathMinus:member
     package: ExcelScript!
     summary: ''
   - name: mathMultiply
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathMultiply:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathMultiply:member
     package: ExcelScript!
     summary: ''
   - name: mathNotEqual
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathNotEqual:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathNotEqual:member
     package: ExcelScript!
     summary: ''
   - name: mathPlus
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.mathPlus:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.mathPlus:member
     package: ExcelScript!
     summary: ''
   - name: moon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.moon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.moon:member
     package: ExcelScript!
     summary: ''
   - name: nonIsoscelesTrapezoid
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.nonIsoscelesTrapezoid:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.nonIsoscelesTrapezoid:member
     package: ExcelScript!
     summary: ''
   - name: noSmoking
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.noSmoking:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.noSmoking:member
     package: ExcelScript!
     summary: ''
   - name: notchedRightArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.notchedRightArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.notchedRightArrow:member
     package: ExcelScript!
     summary: ''
   - name: octagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.octagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.octagon:member
     package: ExcelScript!
     summary: ''
   - name: parallelogram
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.parallelogram:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.parallelogram:member
     package: ExcelScript!
     summary: ''
   - name: pentagon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.pentagon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.pentagon:member
     package: ExcelScript!
     summary: ''
   - name: pie
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.pie:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.pie:member
     package: ExcelScript!
     summary: ''
   - name: pieWedge
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.pieWedge:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.pieWedge:member
     package: ExcelScript!
     summary: ''
   - name: plaque
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.plaque:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.plaque:member
     package: ExcelScript!
     summary: ''
   - name: plaqueTabs
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.plaqueTabs:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.plaqueTabs:member
     package: ExcelScript!
     summary: ''
   - name: plus
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.plus:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.plus:member
     package: ExcelScript!
     summary: ''
   - name: quadArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.quadArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.quadArrow:member
     package: ExcelScript!
     summary: ''
   - name: quadArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.quadArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.quadArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: rectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rectangle:member
     package: ExcelScript!
     summary: ''
   - name: ribbon
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.ribbon:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.ribbon:member
     package: ExcelScript!
     summary: ''
   - name: ribbon2
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.ribbon2:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.ribbon2:member
     package: ExcelScript!
     summary: ''
   - name: rightArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rightArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rightArrow:member
     package: ExcelScript!
     summary: ''
   - name: rightArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rightArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rightArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: rightBrace
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rightBrace:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rightBrace:member
     package: ExcelScript!
     summary: ''
   - name: rightBracket
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rightBracket:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rightBracket:member
     package: ExcelScript!
     summary: ''
   - name: rightTriangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.rightTriangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.rightTriangle:member
     package: ExcelScript!
     summary: ''
   - name: round1Rectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.round1Rectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.round1Rectangle:member
     package: ExcelScript!
     summary: ''
   - name: round2DiagonalRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.round2DiagonalRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.round2DiagonalRectangle:member
     package: ExcelScript!
     summary: ''
   - name: round2SameRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.round2SameRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.round2SameRectangle:member
     package: ExcelScript!
     summary: ''
   - name: roundRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.roundRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.roundRectangle:member
     package: ExcelScript!
     summary: ''
   - name: smileyFace
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.smileyFace:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.smileyFace:member
     package: ExcelScript!
     summary: ''
   - name: snip1Rectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.snip1Rectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.snip1Rectangle:member
     package: ExcelScript!
     summary: ''
   - name: snip2DiagonalRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.snip2DiagonalRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.snip2DiagonalRectangle:member
     package: ExcelScript!
     summary: ''
   - name: snip2SameRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.snip2SameRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.snip2SameRectangle:member
     package: ExcelScript!
     summary: ''
   - name: snipRoundRectangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.snipRoundRectangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.snipRoundRectangle:member
     package: ExcelScript!
     summary: ''
   - name: squareTabs
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.squareTabs:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.squareTabs:member
     package: ExcelScript!
     summary: ''
   - name: star10
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star10:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star10:member
     package: ExcelScript!
     summary: ''
   - name: star12
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star12:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star12:member
     package: ExcelScript!
     summary: ''
   - name: star16
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star16:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star16:member
     package: ExcelScript!
     summary: ''
   - name: star24
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star24:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star24:member
     package: ExcelScript!
     summary: ''
   - name: star32
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star32:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star32:member
     package: ExcelScript!
     summary: ''
   - name: star4
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star4:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star4:member
     package: ExcelScript!
     summary: ''
   - name: star5
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star5:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star5:member
     package: ExcelScript!
     summary: ''
   - name: star6
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star6:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star6:member
     package: ExcelScript!
     summary: ''
   - name: star7
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star7:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star7:member
     package: ExcelScript!
     summary: ''
   - name: star8
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.star8:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.star8:member
     package: ExcelScript!
     summary: ''
   - name: stripedRightArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.stripedRightArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.stripedRightArrow:member
     package: ExcelScript!
     summary: ''
   - name: sun
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.sun:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.sun:member
     package: ExcelScript!
     summary: ''
   - name: swooshArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.swooshArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.swooshArrow:member
     package: ExcelScript!
     summary: ''
   - name: teardrop
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.teardrop:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.teardrop:member
     package: ExcelScript!
     summary: ''
   - name: trapezoid
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.trapezoid:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.trapezoid:member
     package: ExcelScript!
     summary: ''
   - name: triangle
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.triangle:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.triangle:member
     package: ExcelScript!
     summary: ''
   - name: upArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.upArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.upArrow:member
     package: ExcelScript!
     summary: ''
   - name: upArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.upArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.upArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: upDownArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.upDownArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.upDownArrow:member
     package: ExcelScript!
     summary: ''
   - name: upDownArrowCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.upDownArrowCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.upDownArrowCallout:member
     package: ExcelScript!
     summary: ''
   - name: uturnArrow
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.uturnArrow:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.uturnArrow:member
     package: ExcelScript!
     summary: ''
   - name: verticalScroll
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.verticalScroll:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.verticalScroll:member
     package: ExcelScript!
     summary: ''
   - name: wave
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.wave:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.wave:member
     package: ExcelScript!
     summary: ''
   - name: wedgeEllipseCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.wedgeEllipseCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.wedgeEllipseCallout:member
     package: ExcelScript!
     summary: ''
   - name: wedgeRectCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.wedgeRectCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.wedgeRectCallout:member
     package: ExcelScript!
     summary: ''
   - name: wedgeRRectCallout
-    uid: 'ExcelScript!ExcelScript.GeometricShapeType.wedgeRRectCallout:member'
+    uid: ExcelScript!ExcelScript.GeometricShapeType.wedgeRRectCallout:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.groupoption.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.groupoption.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.GroupOption
-uid: 'ExcelScript!ExcelScript.GroupOption:enum'
+uid: ExcelScript!ExcelScript.GroupOption:enum
 package: ExcelScript!
 fullName: ExcelScript.GroupOption
 summary: ''
@@ -24,14 +24,15 @@ remarks: |-
     sheet.getRange("D:E").group(ExcelScript.GroupOption.byColumns);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: byColumns
-    uid: 'ExcelScript!ExcelScript.GroupOption.byColumns:member'
+    uid: ExcelScript!ExcelScript.GroupOption.byColumns:member
     package: ExcelScript!
     summary: Group by columns.
   - name: byRows
-    uid: 'ExcelScript!ExcelScript.GroupOption.byRows:member'
+    uid: ExcelScript!ExcelScript.GroupOption.byRows:member
     package: ExcelScript!
     summary: Group by rows.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfooter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfooter.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSType
 name: ExcelScript.HeaderFooter
-uid: 'ExcelScript!ExcelScript.HeaderFooter:interface'
+uid: ExcelScript!ExcelScript.HeaderFooter:interface
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooter
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCenterFooter()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getCenterFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getCenterFooter:member(1)
     package: ExcelScript!
     fullName: getCenterFooter()
     summary: >-
-      The center footer of the worksheet. To apply font formatting or insert a variable value, use format codes
-      specified here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The center footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,13 +28,15 @@ methods:
         type: string
         description: ''
   - name: getCenterHeader()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getCenterHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getCenterHeader:member(1)
     package: ExcelScript!
     fullName: getCenterHeader()
     summary: >-
-      The center header of the worksheet. To apply font formatting or insert a variable value, use format codes
-      specified here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The center header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -40,13 +45,15 @@ methods:
         type: string
         description: ''
   - name: getLeftFooter()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getLeftFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getLeftFooter:member(1)
     package: ExcelScript!
     fullName: getLeftFooter()
     summary: >-
-      The left footer of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The left footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -55,13 +62,15 @@ methods:
         type: string
         description: ''
   - name: getLeftHeader()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getLeftHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getLeftHeader:member(1)
     package: ExcelScript!
     fullName: getLeftHeader()
     summary: >-
-      The left header of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The left header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -70,13 +79,15 @@ methods:
         type: string
         description: ''
   - name: getRightFooter()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getRightFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getRightFooter:member(1)
     package: ExcelScript!
     fullName: getRightFooter()
     summary: >-
-      The right footer of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The right footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -85,13 +96,15 @@ methods:
         type: string
         description: ''
   - name: getRightHeader()
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#getRightHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#getRightHeader:member(1)
     package: ExcelScript!
     fullName: getRightHeader()
     summary: >-
-      The right header of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The right header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -100,13 +113,15 @@ methods:
         type: string
         description: ''
   - name: setCenterFooter(centerFooter)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setCenterFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setCenterFooter:member(1)
     package: ExcelScript!
     fullName: setCenterFooter(centerFooter)
     summary: >-
-      The center footer of the worksheet. To apply font formatting or insert a variable value, use format codes
-      specified here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The center footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -119,13 +134,15 @@ methods:
         type: void
         description: ''
   - name: setCenterHeader(centerHeader)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setCenterHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setCenterHeader:member(1)
     package: ExcelScript!
     fullName: setCenterHeader(centerHeader)
     summary: >-
-      The center header of the worksheet. To apply font formatting or insert a variable value, use format codes
-      specified here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The center header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -138,13 +155,15 @@ methods:
         type: void
         description: ''
   - name: setLeftFooter(leftFooter)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setLeftFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setLeftFooter:member(1)
     package: ExcelScript!
     fullName: setLeftFooter(leftFooter)
     summary: >-
-      The left footer of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The left footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,13 +176,15 @@ methods:
         type: void
         description: ''
   - name: setLeftHeader(leftHeader)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setLeftHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setLeftHeader:member(1)
     package: ExcelScript!
     fullName: setLeftHeader(leftHeader)
     summary: >-
-      The left header of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The left header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -176,13 +197,15 @@ methods:
         type: void
         description: ''
   - name: setRightFooter(rightFooter)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setRightFooter:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setRightFooter:member(1)
     package: ExcelScript!
     fullName: setRightFooter(rightFooter)
     summary: >-
-      The right footer of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The right footer of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -195,13 +218,15 @@ methods:
         type: void
         description: ''
   - name: setRightHeader(rightHeader)
-    uid: 'ExcelScript!ExcelScript.HeaderFooter#setRightHeader:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooter#setRightHeader:member(1)
     package: ExcelScript!
     fullName: setRightHeader(rightHeader)
     summary: >-
-      The right header of the worksheet. To apply font formatting or insert a variable value, use format codes specified
-      here: https://msdn.microsoft.com/library/bb225426.aspx.
+      The right header of the worksheet. To apply font formatting or insert a
+      variable value, use format codes specified here:
+      https://msdn.microsoft.com/library/bb225426.aspx.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfootergroup.yml
@@ -1,87 +1,104 @@
 ### YamlMime:TSType
 name: ExcelScript.HeaderFooterGroup
-uid: 'ExcelScript!ExcelScript.HeaderFooterGroup:interface'
+uid: ExcelScript!ExcelScript.HeaderFooterGroup:interface
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooterGroup
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getDefaultForAllPages()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getDefaultForAllPages:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getDefaultForAllPages:member(1)
     package: ExcelScript!
     fullName: getDefaultForAllPages()
-    summary: 'The general header/footer, used for all pages unless even/odd or first page is specified.'
+    summary: >-
+      The general header/footer, used for all pages unless even/odd or first
+      page is specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDefaultForAllPages(): HeaderFooter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />
         description: ''
   - name: getEvenPages()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getEvenPages:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getEvenPages:member(1)
     package: ExcelScript!
     fullName: getEvenPages()
-    summary: 'The header/footer to use for even pages, odd header/footer needs to be specified for odd pages.'
+    summary: >-
+      The header/footer to use for even pages, odd header/footer needs to be
+      specified for odd pages.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEvenPages(): HeaderFooter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />
         description: ''
   - name: getFirstPage()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getFirstPage:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getFirstPage:member(1)
     package: ExcelScript!
     fullName: getFirstPage()
-    summary: 'The first page header/footer, for all other pages general or even/odd is used.'
+    summary: >-
+      The first page header/footer, for all other pages general or even/odd is
+      used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFirstPage(): HeaderFooter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />
         description: ''
   - name: getOddPages()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getOddPages:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getOddPages:member(1)
     package: ExcelScript!
     fullName: getOddPages()
-    summary: 'The header/footer to use for odd pages, even header/footer needs to be specified for even pages.'
+    summary: >-
+      The header/footer to use for odd pages, even header/footer needs to be
+      specified for even pages.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getOddPages(): HeaderFooter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooter:interface" />
         description: ''
   - name: getState()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getState:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getState:member(1)
     package: ExcelScript!
     fullName: getState()
-    summary: The state by which headers/footers are set. See `ExcelScript.HeaderFooterState` for details.
+    summary: >-
+      The state by which headers/footers are set. See
+      `ExcelScript.HeaderFooterState` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getState(): HeaderFooterState;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooterState:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooterState:enum" />
         description: ''
   - name: getUseSheetMargins()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getUseSheetMargins:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getUseSheetMargins:member(1)
     package: ExcelScript!
     fullName: getUseSheetMargins()
     summary: >-
-      Specifies a flag indicating if headers/footers are aligned with the page margins set in the page layout options
-      for the worksheet.
+      Specifies a flag indicating if headers/footers are aligned with the page
+      margins set in the page layout options for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,13 +107,14 @@ methods:
         type: boolean
         description: ''
   - name: getUseSheetScale()
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#getUseSheetScale:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#getUseSheetScale:member(1)
     package: ExcelScript!
     fullName: getUseSheetScale()
     summary: >-
-      Specifies a flag indicating if headers/footers should be scaled by the page percentage scale set in the page
-      layout options for the worksheet.
+      Specifies a flag indicating if headers/footers should be scaled by the
+      page percentage scale set in the page layout options for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -105,11 +123,14 @@ methods:
         type: boolean
         description: ''
   - name: setState(state)
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#setState:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#setState:member(1)
     package: ExcelScript!
     fullName: setState(state)
-    summary: The state by which headers/footers are set. See `ExcelScript.HeaderFooterState` for details.
+    summary: >-
+      The state by which headers/footers are set. See
+      `ExcelScript.HeaderFooterState` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -117,18 +138,19 @@ methods:
       parameters:
         - id: state
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.HeaderFooterState:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.HeaderFooterState:enum" />
       return:
         type: void
         description: ''
   - name: setUseSheetMargins(useSheetMargins)
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#setUseSheetMargins:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#setUseSheetMargins:member(1)
     package: ExcelScript!
     fullName: setUseSheetMargins(useSheetMargins)
     summary: >-
-      Specifies a flag indicating if headers/footers are aligned with the page margins set in the page layout options
-      for the worksheet.
+      Specifies a flag indicating if headers/footers are aligned with the page
+      margins set in the page layout options for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -141,13 +163,14 @@ methods:
         type: void
         description: ''
   - name: setUseSheetScale(useSheetScale)
-    uid: 'ExcelScript!ExcelScript.HeaderFooterGroup#setUseSheetScale:member(1)'
+    uid: ExcelScript!ExcelScript.HeaderFooterGroup#setUseSheetScale:member(1)
     package: ExcelScript!
     fullName: setUseSheetScale(useSheetScale)
     summary: >-
-      Specifies a flag indicating if headers/footers should be scaled by the page percentage scale set in the page
-      layout options for the worksheet.
+      Specifies a flag indicating if headers/footers should be scaled by the
+      page percentage scale set in the page layout options for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfooterstate.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.headerfooterstate.yml
@@ -1,26 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.HeaderFooterState
-uid: 'ExcelScript!ExcelScript.HeaderFooterState:enum'
+uid: ExcelScript!ExcelScript.HeaderFooterState:enum
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooterState
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: default
-    uid: 'ExcelScript!ExcelScript.HeaderFooterState.default:member'
+    uid: ExcelScript!ExcelScript.HeaderFooterState.default:member
     package: ExcelScript!
     summary: Only one general header/footer is used for all pages printed.
   - name: firstAndDefault
-    uid: 'ExcelScript!ExcelScript.HeaderFooterState.firstAndDefault:member'
+    uid: ExcelScript!ExcelScript.HeaderFooterState.firstAndDefault:member
     package: ExcelScript!
-    summary: 'There is a separate first page header/footer, and a general header/footer used for all other pages.'
+    summary: >-
+      There is a separate first page header/footer, and a general header/footer
+      used for all other pages.
   - name: firstOddAndEven
-    uid: 'ExcelScript!ExcelScript.HeaderFooterState.firstOddAndEven:member'
+    uid: ExcelScript!ExcelScript.HeaderFooterState.firstOddAndEven:member
     package: ExcelScript!
-    summary: 'There is a separate first page header/footer, then there is a separate header/footer for odd and even pages.'
+    summary: >-
+      There is a separate first page header/footer, then there is a separate
+      header/footer for odd and even pages.
   - name: oddAndEven
-    uid: 'ExcelScript!ExcelScript.HeaderFooterState.oddAndEven:member'
+    uid: ExcelScript!ExcelScript.HeaderFooterState.oddAndEven:member
     package: ExcelScript!
     summary: There is a different header/footer for odd and even pages.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.horizontalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.horizontalalignment.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.HorizontalAlignment
-uid: 'ExcelScript!ExcelScript.HorizontalAlignment:enum'
+uid: ExcelScript!ExcelScript.HorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.HorizontalAlignment
 summary: ''
@@ -25,38 +25,39 @@ remarks: |-
     headerRange.getFormat().setHorizontalAlignment(ExcelScript.HorizontalAlignment.center);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: center
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.center:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: centerAcrossSelection
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.centerAcrossSelection:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.centerAcrossSelection:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: fill
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.fill:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.fill:member
     package: ExcelScript!
     summary: ''
   - name: general
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.general:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.general:member
     package: ExcelScript!
     summary: ''
   - name: justify
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.justify:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.justify:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.left:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.HorizontalAlignment.right:member'
+    uid: ExcelScript!ExcelScript.HorizontalAlignment.right:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.icon.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.icon.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.Icon
-uid: 'ExcelScript!ExcelScript.Icon:interface'
+uid: ExcelScript!ExcelScript.Icon:interface
 package: ExcelScript!
 fullName: ExcelScript.Icon
 summary: Represents a cell icon.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: index
-    uid: 'ExcelScript!ExcelScript.Icon#index:member'
+    uid: ExcelScript!ExcelScript.Icon#index:member
     package: ExcelScript!
     fullName: index
     summary: Specifies the index of the icon in the given set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,14 +24,15 @@ properties:
       return:
         type: number
   - name: set
-    uid: 'ExcelScript!ExcelScript.Icon#set:member'
+    uid: ExcelScript!ExcelScript.Icon#set:member
     package: ExcelScript!
     fullName: set
     summary: Specifies the set that the icon is part of.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'set: IconSet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.IconSet:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.IconSet:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.iconset.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.iconset.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.IconSet
-uid: 'ExcelScript!ExcelScript.IconSet:enum'
+uid: ExcelScript!ExcelScript.IconSet:enum
 package: ExcelScript!
 fullName: ExcelScript.IconSet
 summary: ''
@@ -39,90 +39,91 @@ remarks: |-
       }]);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: fiveArrows
-    uid: 'ExcelScript!ExcelScript.IconSet.fiveArrows:member'
+    uid: ExcelScript!ExcelScript.IconSet.fiveArrows:member
     package: ExcelScript!
     summary: ''
   - name: fiveArrowsGray
-    uid: 'ExcelScript!ExcelScript.IconSet.fiveArrowsGray:member'
+    uid: ExcelScript!ExcelScript.IconSet.fiveArrowsGray:member
     package: ExcelScript!
     summary: ''
   - name: fiveBoxes
-    uid: 'ExcelScript!ExcelScript.IconSet.fiveBoxes:member'
+    uid: ExcelScript!ExcelScript.IconSet.fiveBoxes:member
     package: ExcelScript!
     summary: ''
   - name: fiveQuarters
-    uid: 'ExcelScript!ExcelScript.IconSet.fiveQuarters:member'
+    uid: ExcelScript!ExcelScript.IconSet.fiveQuarters:member
     package: ExcelScript!
     summary: ''
   - name: fiveRating
-    uid: 'ExcelScript!ExcelScript.IconSet.fiveRating:member'
+    uid: ExcelScript!ExcelScript.IconSet.fiveRating:member
     package: ExcelScript!
     summary: ''
   - name: fourArrows
-    uid: 'ExcelScript!ExcelScript.IconSet.fourArrows:member'
+    uid: ExcelScript!ExcelScript.IconSet.fourArrows:member
     package: ExcelScript!
     summary: ''
   - name: fourArrowsGray
-    uid: 'ExcelScript!ExcelScript.IconSet.fourArrowsGray:member'
+    uid: ExcelScript!ExcelScript.IconSet.fourArrowsGray:member
     package: ExcelScript!
     summary: ''
   - name: fourRating
-    uid: 'ExcelScript!ExcelScript.IconSet.fourRating:member'
+    uid: ExcelScript!ExcelScript.IconSet.fourRating:member
     package: ExcelScript!
     summary: ''
   - name: fourRedToBlack
-    uid: 'ExcelScript!ExcelScript.IconSet.fourRedToBlack:member'
+    uid: ExcelScript!ExcelScript.IconSet.fourRedToBlack:member
     package: ExcelScript!
     summary: ''
   - name: fourTrafficLights
-    uid: 'ExcelScript!ExcelScript.IconSet.fourTrafficLights:member'
+    uid: ExcelScript!ExcelScript.IconSet.fourTrafficLights:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.IconSet.invalid:member'
+    uid: ExcelScript!ExcelScript.IconSet.invalid:member
     package: ExcelScript!
     summary: ''
   - name: threeArrows
-    uid: 'ExcelScript!ExcelScript.IconSet.threeArrows:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeArrows:member
     package: ExcelScript!
     summary: ''
   - name: threeArrowsGray
-    uid: 'ExcelScript!ExcelScript.IconSet.threeArrowsGray:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeArrowsGray:member
     package: ExcelScript!
     summary: ''
   - name: threeFlags
-    uid: 'ExcelScript!ExcelScript.IconSet.threeFlags:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeFlags:member
     package: ExcelScript!
     summary: ''
   - name: threeSigns
-    uid: 'ExcelScript!ExcelScript.IconSet.threeSigns:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeSigns:member
     package: ExcelScript!
     summary: ''
   - name: threeStars
-    uid: 'ExcelScript!ExcelScript.IconSet.threeStars:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeStars:member
     package: ExcelScript!
     summary: ''
   - name: threeSymbols
-    uid: 'ExcelScript!ExcelScript.IconSet.threeSymbols:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeSymbols:member
     package: ExcelScript!
     summary: ''
   - name: threeSymbols2
-    uid: 'ExcelScript!ExcelScript.IconSet.threeSymbols2:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeSymbols2:member
     package: ExcelScript!
     summary: ''
   - name: threeTrafficLights1
-    uid: 'ExcelScript!ExcelScript.IconSet.threeTrafficLights1:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeTrafficLights1:member
     package: ExcelScript!
     summary: ''
   - name: threeTrafficLights2
-    uid: 'ExcelScript!ExcelScript.IconSet.threeTrafficLights2:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeTrafficLights2:member
     package: ExcelScript!
     summary: ''
   - name: threeTriangles
-    uid: 'ExcelScript!ExcelScript.IconSet.threeTriangles:member'
+    uid: ExcelScript!ExcelScript.IconSet.threeTriangles:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.iconsetconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.IconSetConditionalFormat
-uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.IconSetConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.IconSetConditionalFormat
 summary: Represents an icon set criteria for conditional formatting.
@@ -39,34 +39,41 @@ remarks: |-
       }]);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCriteria()
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#getCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#getCriteria:member(1)
     package: ExcelScript!
     fullName: getCriteria()
     summary: >-
-      An array of criteria and icon sets for the rules and potential custom icons for conditional icons. Note that for
-      the first criterion only the custom icon can be modified, while type, formula, and operator will be ignored when
-      set.
+      An array of criteria and icon sets for the rules and potential custom
+      icons for conditional icons. Note that for the first criterion only the
+      custom icon can be modified, while type, formula, and operator will be
+      ignored when set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCriteria(): ConditionalIconCriterion[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalIconCriterion:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalIconCriterion:interface"
+          />[]
         description: ''
   - name: getReverseIconOrder()
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#getReverseIconOrder:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.IconSetConditionalFormat#getReverseIconOrder:member(1)
     package: ExcelScript!
     fullName: getReverseIconOrder()
     summary: >-
-      If `true`<!-- -->, reverses the icon orders for the icon set. Note that this cannot be set if custom icons are
-      used.
+      If `true`<!-- -->, reverses the icon orders for the icon set. Note that
+      this cannot be set if custom icons are used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,11 +82,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowIconOnly()
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#getShowIconOnly:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#getShowIconOnly:member(1)
     package: ExcelScript!
     fullName: getShowIconOnly()
-    summary: 'If `true`<!-- -->, hides the values and only shows icons.'
+    summary: If `true`<!-- -->, hides the values and only shows icons.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -88,27 +96,30 @@ methods:
         type: boolean
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
-    summary: 'If set, displays the icon set option for the conditional format.'
+    summary: If set, displays the icon set option for the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getStyle(): IconSet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.IconSet:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.IconSet:enum" />
         description: ''
   - name: setCriteria(criteria)
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#setCriteria:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#setCriteria:member(1)
     package: ExcelScript!
     fullName: setCriteria(criteria)
     summary: >-
-      An array of criteria and icon sets for the rules and potential custom icons for conditional icons. Note that for
-      the first criterion only the custom icon can be modified, while type, formula, and operator will be ignored when
-      set.
+      An array of criteria and icon sets for the rules and potential custom
+      icons for conditional icons. Note that for the first criterion only the
+      custom icon can be modified, while type, formula, and operator will be
+      ignored when set.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,18 +127,23 @@ methods:
       parameters:
         - id: criteria
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalIconCriterion:interface" />[]'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalIconCriterion:interface"
+            />[]
       return:
         type: void
         description: ''
   - name: setReverseIconOrder(reverseIconOrder)
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#setReverseIconOrder:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.IconSetConditionalFormat#setReverseIconOrder:member(1)
     package: ExcelScript!
     fullName: setReverseIconOrder(reverseIconOrder)
     summary: >-
-      If `true`<!-- -->, reverses the icon orders for the icon set. Note that this cannot be set if custom icons are
-      used.
+      If `true`<!-- -->, reverses the icon orders for the icon set. Note that
+      this cannot be set if custom icons are used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,11 +156,12 @@ methods:
         type: void
         description: ''
   - name: setShowIconOnly(showIconOnly)
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#setShowIconOnly:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#setShowIconOnly:member(1)
     package: ExcelScript!
     fullName: setShowIconOnly(showIconOnly)
-    summary: 'If `true`<!-- -->, hides the values and only shows icons.'
+    summary: If `true`<!-- -->, hides the values and only shows icons.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,11 +174,12 @@ methods:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.IconSetConditionalFormat#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.IconSetConditionalFormat#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
-    summary: 'If set, displays the icon set option for the conditional format.'
+    summary: If set, displays the icon set option for the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -169,7 +187,7 @@ methods:
       parameters:
         - id: style
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.IconSet:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.IconSet:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.image.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.image.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.Image
-uid: 'ExcelScript!ExcelScript.Image:interface'
+uid: ExcelScript!ExcelScript.Image:interface
 package: ExcelScript!
 fullName: ExcelScript.Image
-summary: 'Represents an image in the worksheet. To get the corresponding `Shape` object, use `Image.getShape`<!-- -->.'
+summary: >-
+  Represents an image in the worksheet. To get the corresponding `Shape` object,
+  use `Image.getShape`<!-- -->.
 remarks: |-
 
 
@@ -31,29 +33,32 @@ remarks: |-
     image.getShape().copyTo("SecondSheet");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.Image#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Image#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: Returns the format of the image.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): PictureFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Image#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Image#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the shape identifier for the image object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,15 +67,16 @@ methods:
         type: string
         description: ''
   - name: getShape()
-    uid: 'ExcelScript!ExcelScript.Image#getShape:member(1)'
+    uid: ExcelScript!ExcelScript.Image#getShape:member(1)
     package: ExcelScript!
     fullName: getShape()
     summary: Returns the `Shape` object associated with the image.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getShape(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.imagefittingmode.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.imagefittingmode.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ImageFittingMode
-uid: 'ExcelScript!ExcelScript.ImageFittingMode:enum'
+uid: ExcelScript!ExcelScript.ImageFittingMode:enum
 package: ExcelScript!
 fullName: ExcelScript.ImageFittingMode
 summary: ''
@@ -31,18 +31,19 @@ remarks: |-
     return base64String;
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: fill
-    uid: 'ExcelScript!ExcelScript.ImageFittingMode.fill:member'
+    uid: ExcelScript!ExcelScript.ImageFittingMode.fill:member
     package: ExcelScript!
     summary: ''
   - name: fit
-    uid: 'ExcelScript!ExcelScript.ImageFittingMode.fit:member'
+    uid: ExcelScript!ExcelScript.ImageFittingMode.fit:member
     package: ExcelScript!
     summary: ''
   - name: fitAndCenter
-    uid: 'ExcelScript!ExcelScript.ImageFittingMode.fitAndCenter:member'
+    uid: ExcelScript!ExcelScript.ImageFittingMode.fitAndCenter:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.insertshiftdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.insertshiftdirection.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSEnum
 name: ExcelScript.InsertShiftDirection
-uid: 'ExcelScript!ExcelScript.InsertShiftDirection:enum'
+uid: ExcelScript!ExcelScript.InsertShiftDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.InsertShiftDirection
-summary: Determines the direction in which existing cells will be shifted to accommodate what is being inserted.
+summary: >-
+  Determines the direction in which existing cells will be shifted to
+  accommodate what is being inserted.
 remarks: |-
 
 
@@ -28,14 +30,15 @@ remarks: |-
     currentSheet.getRange("A1:C1").setValues(myHeaders);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: down
-    uid: 'ExcelScript!ExcelScript.InsertShiftDirection.down:member'
+    uid: ExcelScript!ExcelScript.InsertShiftDirection.down:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.InsertShiftDirection.right:member'
+    uid: ExcelScript!ExcelScript.InsertShiftDirection.right:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.iterativecalculation.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.IterativeCalculation
-uid: 'ExcelScript!ExcelScript.IterativeCalculation:interface'
+uid: ExcelScript!ExcelScript.IterativeCalculation:interface
 package: ExcelScript!
 fullName: ExcelScript.IterativeCalculation
 summary: Represents the iterative calculation settings.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getEnabled()
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#getEnabled:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#getEnabled:member(1)
     package: ExcelScript!
     fullName: getEnabled()
     summary: True if Excel will use iteration to resolve circular references.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,14 @@ methods:
         type: boolean
         description: ''
   - name: getMaxChange()
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#getMaxChange:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#getMaxChange:member(1)
     package: ExcelScript!
     fullName: getMaxChange()
-    summary: Specifies the maximum amount of change between each iteration as Excel resolves circular references.
+    summary: >-
+      Specifies the maximum amount of change between each iteration as Excel
+      resolves circular references.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +41,14 @@ methods:
         type: number
         description: ''
   - name: getMaxIteration()
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#getMaxIteration:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#getMaxIteration:member(1)
     package: ExcelScript!
     fullName: getMaxIteration()
-    summary: Specifies the maximum number of iterations that Excel can use to resolve a circular reference.
+    summary: >-
+      Specifies the maximum number of iterations that Excel can use to resolve a
+      circular reference.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: number
         description: ''
   - name: setEnabled(enabled)
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#setEnabled:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#setEnabled:member(1)
     package: ExcelScript!
     fullName: setEnabled(enabled)
     summary: True if Excel will use iteration to resolve circular references.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -66,11 +75,14 @@ methods:
         type: void
         description: ''
   - name: setMaxChange(maxChange)
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#setMaxChange:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#setMaxChange:member(1)
     package: ExcelScript!
     fullName: setMaxChange(maxChange)
-    summary: Specifies the maximum amount of change between each iteration as Excel resolves circular references.
+    summary: >-
+      Specifies the maximum amount of change between each iteration as Excel
+      resolves circular references.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -83,11 +95,14 @@ methods:
         type: void
         description: ''
   - name: setMaxIteration(maxIteration)
-    uid: 'ExcelScript!ExcelScript.IterativeCalculation#setMaxIteration:member(1)'
+    uid: ExcelScript!ExcelScript.IterativeCalculation#setMaxIteration:member(1)
     package: ExcelScript!
     fullName: setMaxIteration(maxIteration)
-    summary: Specifies the maximum number of iterations that Excel can use to resolve a circular reference.
+    summary: >-
+      Specifies the maximum number of iterations that Excel can use to resolve a
+      circular reference.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.keyboarddirection.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.KeyboardDirection
-uid: 'ExcelScript!ExcelScript.KeyboardDirection:enum'
+uid: ExcelScript!ExcelScript.KeyboardDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.KeyboardDirection
 summary: ''
@@ -28,22 +28,23 @@ remarks: |-
     firstColumn.getFormat().getFont().setBold(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: down
-    uid: 'ExcelScript!ExcelScript.KeyboardDirection.down:member'
+    uid: ExcelScript!ExcelScript.KeyboardDirection.down:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.KeyboardDirection.left:member'
+    uid: ExcelScript!ExcelScript.KeyboardDirection.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.KeyboardDirection.right:member'
+    uid: ExcelScript!ExcelScript.KeyboardDirection.right:member
     package: ExcelScript!
     summary: ''
   - name: up
-    uid: 'ExcelScript!ExcelScript.KeyboardDirection.up:member'
+    uid: ExcelScript!ExcelScript.KeyboardDirection.up:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.labelfiltercondition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.labelfiltercondition.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSEnum
 name: ExcelScript.LabelFilterCondition
-uid: 'ExcelScript!ExcelScript.LabelFilterCondition:enum'
+uid: ExcelScript!ExcelScript.LabelFilterCondition:enum
 package: ExcelScript!
 fullName: ExcelScript.LabelFilterCondition
 summary: >-
-  Enum representing all accepted conditions by which a label filter can be applied. Used to configure the type of
-  PivotFilter that is applied to the field. `PivotFilter.criteria.exclusive` can be set to `true` to invert many of
+  Enum representing all accepted conditions by which a label filter can be
+  applied. Used to configure the type of PivotFilter that is applied to the
+  field. `PivotFilter.criteria.exclusive` can be set to `true` to invert many of
   these conditions.
 remarks: |-
 
@@ -35,75 +36,84 @@ remarks: |-
     field.applyFilter({ labelFilter: filter });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: beginsWith
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.beginsWith:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.beginsWith:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Label begins with substring criterion.
 
-      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
+
+      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria:
+      {`exclusive`<!-- -->}<!-- -->.
   - name: between
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.between:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.between:member
     package: ExcelScript!
     summary: >-
       Between `lowerBound` and `upperBound` criteria.
 
 
-      Required Criteria: {`lowerBound`<!-- -->, `upperBound`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!--
-      -->}<!-- -->.
+      Required Criteria: {`lowerBound`<!-- -->, `upperBound`<!-- -->}<!-- -->.
+      Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
   - name: contains
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.contains:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.contains:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Label contains substring criterion.
 
-      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
+
+      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria:
+      {`exclusive`<!-- -->}<!-- -->.
   - name: endsWith
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.endsWith:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.endsWith:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Label ends with substring criterion.
 
-      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
+
+      Required Criteria: {`substring`<!-- -->}<!-- -->. Optional Criteria:
+      {`exclusive`<!-- -->}<!-- -->.
   - name: equals
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.equals:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.equals:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       Equals comparator criterion.
 
-      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
+
+      Required Criteria: {`comparator`<!-- -->}<!-- -->. Optional Criteria:
+      {`exclusive`<!-- -->}<!-- -->.
   - name: greaterThan
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.greaterThan:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.greaterThan:member
     package: ExcelScript!
     summary: |-
       Greater than comparator criterion.
 
       Required Criteria: {`comparator`<!-- -->}<!-- -->.
   - name: greaterThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.greaterThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.greaterThanOrEqualTo:member
     package: ExcelScript!
     summary: |-
       Greater than or equal to comparator criterion.
 
       Required Criteria: {`comparator`<!-- -->}<!-- -->.
   - name: lessThan
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.lessThan:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.lessThan:member
     package: ExcelScript!
     summary: |-
       Less than comparator criterion.
 
       Required Criteria: {`comparator`<!-- -->}<!-- -->.
   - name: lessThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.lessThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.lessThanOrEqualTo:member
     package: ExcelScript!
     summary: |-
       Less than or equal to comparator criterion.
 
       Required Criteria: {`comparator`<!-- -->}<!-- -->.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.LabelFilterCondition.unknown:member'
+    uid: ExcelScript!ExcelScript.LabelFilterCondition.unknown:member
     package: ExcelScript!
     summary: '`LabelFilterCondition` is unknown or unsupported.'

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.line.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.line.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.Line
-uid: 'ExcelScript!ExcelScript.Line:interface'
+uid: ExcelScript!ExcelScript.Line:interface
 package: ExcelScript!
 fullName: ExcelScript.Line
-summary: 'Represents a line inside a worksheet. To get the corresponding `Shape` object, use `Line.shape`<!-- -->.'
+summary: >-
+  Represents a line inside a worksheet. To get the corresponding `Shape` object,
+  use `Line.shape`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'connectBeginShape(shape, connectionSite)'
-    uid: 'ExcelScript!ExcelScript.Line#connectBeginShape:member(1)'
+  - name: connectBeginShape(shape, connectionSite)
+    uid: ExcelScript!ExcelScript.Line#connectBeginShape:member(1)
     package: ExcelScript!
-    fullName: 'connectBeginShape(shape, connectionSite)'
+    fullName: connectBeginShape(shape, connectionSite)
     summary: Attaches the beginning of the specified connector to a specified shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,21 +26,23 @@ methods:
       parameters:
         - id: shape
           description: The shape to connect.
-          type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         - id: connectionSite
           description: >-
-            The connection site on the shape to which the beginning of the connector is attached. Must be an integer
-            between 0 (inclusive) and the connection-site count of the specified shape (exclusive).
+            The connection site on the shape to which the beginning of the
+            connector is attached. Must be an integer between 0 (inclusive) and
+            the connection-site count of the specified shape (exclusive).
           type: number
       return:
         type: void
         description: ''
-  - name: 'connectEndShape(shape, connectionSite)'
-    uid: 'ExcelScript!ExcelScript.Line#connectEndShape:member(1)'
+  - name: connectEndShape(shape, connectionSite)
+    uid: ExcelScript!ExcelScript.Line#connectEndShape:member(1)
     package: ExcelScript!
-    fullName: 'connectEndShape(shape, connectionSite)'
+    fullName: connectEndShape(shape, connectionSite)
     summary: Attaches the end of the specified connector to a specified shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -44,21 +50,23 @@ methods:
       parameters:
         - id: shape
           description: The shape to connect.
-          type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         - id: connectionSite
           description: >-
-            The connection site on the shape to which the end of the connector is attached. Must be an integer between 0
-            (inclusive) and the connection-site count of the specified shape (exclusive).
+            The connection site on the shape to which the end of the connector
+            is attached. Must be an integer between 0 (inclusive) and the
+            connection-site count of the specified shape (exclusive).
           type: number
       return:
         type: void
         description: ''
   - name: disconnectBeginShape()
-    uid: 'ExcelScript!ExcelScript.Line#disconnectBeginShape:member(1)'
+    uid: ExcelScript!ExcelScript.Line#disconnectBeginShape:member(1)
     package: ExcelScript!
     fullName: disconnectBeginShape()
     summary: Detaches the beginning of the specified connector from a shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -67,11 +75,12 @@ methods:
         type: void
         description: ''
   - name: disconnectEndShape()
-    uid: 'ExcelScript!ExcelScript.Line#disconnectEndShape:member(1)'
+    uid: ExcelScript!ExcelScript.Line#disconnectEndShape:member(1)
     package: ExcelScript!
     fullName: disconnectEndShape()
     summary: Detaches the end of the specified connector from a shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,65 +89,79 @@ methods:
         type: void
         description: ''
   - name: getBeginArrowheadLength()
-    uid: 'ExcelScript!ExcelScript.Line#getBeginArrowheadLength:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getBeginArrowheadLength:member(1)
     package: ExcelScript!
     fullName: getBeginArrowheadLength()
-    summary: Represents the length of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the length of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBeginArrowheadLength(): ArrowheadLength;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />
         description: ''
   - name: getBeginArrowheadStyle()
-    uid: 'ExcelScript!ExcelScript.Line#getBeginArrowheadStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getBeginArrowheadStyle:member(1)
     package: ExcelScript!
     fullName: getBeginArrowheadStyle()
-    summary: Represents the style of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the style of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBeginArrowheadStyle(): ArrowheadStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />
         description: ''
   - name: getBeginArrowheadWidth()
-    uid: 'ExcelScript!ExcelScript.Line#getBeginArrowheadWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getBeginArrowheadWidth:member(1)
     package: ExcelScript!
     fullName: getBeginArrowheadWidth()
-    summary: Represents the width of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the width of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBeginArrowheadWidth(): ArrowheadWidth;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />
         description: ''
   - name: getBeginConnectedShape()
-    uid: 'ExcelScript!ExcelScript.Line#getBeginConnectedShape:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getBeginConnectedShape:member(1)
     package: ExcelScript!
     fullName: getBeginConnectedShape()
-    summary: Represents the shape to which the beginning of the specified line is attached.
+    summary: >-
+      Represents the shape to which the beginning of the specified line is
+      attached.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBeginConnectedShape(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: getBeginConnectedSite()
-    uid: 'ExcelScript!ExcelScript.Line#getBeginConnectedSite:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getBeginConnectedSite:member(1)
     package: ExcelScript!
     fullName: getBeginConnectedSite()
     summary: >-
-      Represents the connection site to which the beginning of a connector is connected. Returns `null` when the
-      beginning of the line is not attached to any shape.
+      Represents the connection site to which the beginning of a connector is
+      connected. Returns `null` when the beginning of the line is not attached
+      to any shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -147,78 +170,85 @@ methods:
         type: number
         description: ''
   - name: getConnectorType()
-    uid: 'ExcelScript!ExcelScript.Line#getConnectorType:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getConnectorType:member(1)
     package: ExcelScript!
     fullName: getConnectorType()
     summary: Represents the connector type for the line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConnectorType(): ConnectorType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />
         description: ''
   - name: getEndArrowheadLength()
-    uid: 'ExcelScript!ExcelScript.Line#getEndArrowheadLength:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getEndArrowheadLength:member(1)
     package: ExcelScript!
     fullName: getEndArrowheadLength()
     summary: Represents the length of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEndArrowheadLength(): ArrowheadLength;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />
         description: ''
   - name: getEndArrowheadStyle()
-    uid: 'ExcelScript!ExcelScript.Line#getEndArrowheadStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getEndArrowheadStyle:member(1)
     package: ExcelScript!
     fullName: getEndArrowheadStyle()
     summary: Represents the style of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEndArrowheadStyle(): ArrowheadStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />
         description: ''
   - name: getEndArrowheadWidth()
-    uid: 'ExcelScript!ExcelScript.Line#getEndArrowheadWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getEndArrowheadWidth:member(1)
     package: ExcelScript!
     fullName: getEndArrowheadWidth()
     summary: Represents the width of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEndArrowheadWidth(): ArrowheadWidth;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />
         description: ''
   - name: getEndConnectedShape()
-    uid: 'ExcelScript!ExcelScript.Line#getEndConnectedShape:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getEndConnectedShape:member(1)
     package: ExcelScript!
     fullName: getEndConnectedShape()
     summary: Represents the shape to which the end of the specified line is attached.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEndConnectedShape(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: getEndConnectedSite()
-    uid: 'ExcelScript!ExcelScript.Line#getEndConnectedSite:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getEndConnectedSite:member(1)
     package: ExcelScript!
     fullName: getEndConnectedSite()
     summary: >-
-      Represents the connection site to which the end of a connector is connected. Returns `null` when the end of the
-      line is not attached to any shape.
+      Represents the connection site to which the end of a connector is
+      connected. Returns `null` when the end of the line is not attached to any
+      shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -227,11 +257,12 @@ methods:
         type: number
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Line#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the shape identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -240,11 +271,12 @@ methods:
         type: string
         description: ''
   - name: getIsBeginConnected()
-    uid: 'ExcelScript!ExcelScript.Line#getIsBeginConnected:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getIsBeginConnected:member(1)
     package: ExcelScript!
     fullName: getIsBeginConnected()
     summary: Specifies if the beginning of the specified line is connected to a shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -253,11 +285,12 @@ methods:
         type: boolean
         description: ''
   - name: getIsEndConnected()
-    uid: 'ExcelScript!ExcelScript.Line#getIsEndConnected:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getIsEndConnected:member(1)
     package: ExcelScript!
     fullName: getIsEndConnected()
     summary: Specifies if the end of the specified line is connected to a shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -266,24 +299,28 @@ methods:
         type: boolean
         description: ''
   - name: getShape()
-    uid: 'ExcelScript!ExcelScript.Line#getShape:member(1)'
+    uid: ExcelScript!ExcelScript.Line#getShape:member(1)
     package: ExcelScript!
     fullName: getShape()
     summary: Returns the `Shape` object associated with the line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getShape(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: setBeginArrowheadLength(beginArrowheadLength)
-    uid: 'ExcelScript!ExcelScript.Line#setBeginArrowheadLength:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setBeginArrowheadLength:member(1)
     package: ExcelScript!
     fullName: setBeginArrowheadLength(beginArrowheadLength)
-    summary: Represents the length of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the length of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -291,16 +328,19 @@ methods:
       parameters:
         - id: beginArrowheadLength
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />
       return:
         type: void
         description: ''
   - name: setBeginArrowheadStyle(beginArrowheadStyle)
-    uid: 'ExcelScript!ExcelScript.Line#setBeginArrowheadStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setBeginArrowheadStyle:member(1)
     package: ExcelScript!
     fullName: setBeginArrowheadStyle(beginArrowheadStyle)
-    summary: Represents the style of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the style of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -308,16 +348,19 @@ methods:
       parameters:
         - id: beginArrowheadStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />
       return:
         type: void
         description: ''
   - name: setBeginArrowheadWidth(beginArrowheadWidth)
-    uid: 'ExcelScript!ExcelScript.Line#setBeginArrowheadWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setBeginArrowheadWidth:member(1)
     package: ExcelScript!
     fullName: setBeginArrowheadWidth(beginArrowheadWidth)
-    summary: Represents the width of the arrowhead at the beginning of the specified line.
+    summary: >-
+      Represents the width of the arrowhead at the beginning of the specified
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -325,16 +368,17 @@ methods:
       parameters:
         - id: beginArrowheadWidth
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />
       return:
         type: void
         description: ''
   - name: setConnectorType(connectorType)
-    uid: 'ExcelScript!ExcelScript.Line#setConnectorType:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setConnectorType:member(1)
     package: ExcelScript!
     fullName: setConnectorType(connectorType)
     summary: Represents the connector type for the line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -342,16 +386,17 @@ methods:
       parameters:
         - id: connectorType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />
       return:
         type: void
         description: ''
   - name: setEndArrowheadLength(endArrowheadLength)
-    uid: 'ExcelScript!ExcelScript.Line#setEndArrowheadLength:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setEndArrowheadLength:member(1)
     package: ExcelScript!
     fullName: setEndArrowheadLength(endArrowheadLength)
     summary: Represents the length of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -359,16 +404,17 @@ methods:
       parameters:
         - id: endArrowheadLength
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadLength:enum" />
       return:
         type: void
         description: ''
   - name: setEndArrowheadStyle(endArrowheadStyle)
-    uid: 'ExcelScript!ExcelScript.Line#setEndArrowheadStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setEndArrowheadStyle:member(1)
     package: ExcelScript!
     fullName: setEndArrowheadStyle(endArrowheadStyle)
     summary: Represents the style of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -376,16 +422,17 @@ methods:
       parameters:
         - id: endArrowheadStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadStyle:enum" />
       return:
         type: void
         description: ''
   - name: setEndArrowheadWidth(endArrowheadWidth)
-    uid: 'ExcelScript!ExcelScript.Line#setEndArrowheadWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Line#setEndArrowheadWidth:member(1)
     package: ExcelScript!
     fullName: setEndArrowheadWidth(endArrowheadWidth)
     summary: Represents the width of the arrowhead at the end of the specified line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -393,7 +440,7 @@ methods:
       parameters:
         - id: endArrowheadWidth
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ArrowheadWidth:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.linkeddatatypestate.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.linkeddatatypestate.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.LinkedDataTypeState
-uid: 'ExcelScript!ExcelScript.LinkedDataTypeState:enum'
+uid: ExcelScript!ExcelScript.LinkedDataTypeState:enum
 package: ExcelScript!
 fullName: ExcelScript.LinkedDataTypeState
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: brokenLinkedData
-    uid: 'ExcelScript!ExcelScript.LinkedDataTypeState.brokenLinkedData:member'
+    uid: ExcelScript!ExcelScript.LinkedDataTypeState.brokenLinkedData:member
     package: ExcelScript!
     summary: ''
   - name: disambiguationNeeded
-    uid: 'ExcelScript!ExcelScript.LinkedDataTypeState.disambiguationNeeded:member'
+    uid: ExcelScript!ExcelScript.LinkedDataTypeState.disambiguationNeeded:member
     package: ExcelScript!
     summary: ''
   - name: fetchingData
-    uid: 'ExcelScript!ExcelScript.LinkedDataTypeState.fetchingData:member'
+    uid: ExcelScript!ExcelScript.LinkedDataTypeState.fetchingData:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.LinkedDataTypeState.none:member'
+    uid: ExcelScript!ExcelScript.LinkedDataTypeState.none:member
     package: ExcelScript!
     summary: ''
   - name: validLinkedData
-    uid: 'ExcelScript!ExcelScript.LinkedDataTypeState.validLinkedData:member'
+    uid: ExcelScript!ExcelScript.LinkedDataTypeState.validLinkedData:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.linkedworkbook.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.linkedworkbook.yml
@@ -1,25 +1,30 @@
 ### YamlMime:TSType
 name: ExcelScript.LinkedWorkbook
-uid: 'ExcelScript!ExcelScript.LinkedWorkbook:interface'
+uid: ExcelScript!ExcelScript.LinkedWorkbook:interface
 package: ExcelScript!
 fullName: ExcelScript.LinkedWorkbook
 summary: >-
-  Contains information about a linked workbook. If a workbook has links pointing to data in another workbook, the second
-  workbook is linked to the first workbook. In this scenario, the second workbook is called the "linked workbook".
+  Contains information about a linked workbook. If a workbook has links pointing
+  to data in another workbook, the second workbook is linked to the first
+  workbook. In this scenario, the second workbook is called the "linked
+  workbook".
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: breakLinks()
-    uid: 'ExcelScript!ExcelScript.LinkedWorkbook#breakLinks:member(1)'
+    uid: ExcelScript!ExcelScript.LinkedWorkbook#breakLinks:member(1)
     package: ExcelScript!
     fullName: breakLinks()
     summary: >-
-      Makes a request to break the links pointing to the linked workbook. Links in formulas are replaced with the latest
-      fetched data. The current `LinkedWorkbook` object is invalidated and removed from `LinkedWorkbookCollection`<!--
-      -->.
+      Makes a request to break the links pointing to the linked workbook. Links
+      in formulas are replaced with the latest fetched data. The current
+      `LinkedWorkbook` object is invalidated and removed from
+      `LinkedWorkbookCollection`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -48,11 +53,14 @@ methods:
           }
           ```
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.LinkedWorkbook#getId:member(1)'
+    uid: ExcelScript!ExcelScript.LinkedWorkbook#getId:member(1)
     package: ExcelScript!
     fullName: getId()
-    summary: The original URL pointing to the linked workbook. It is unique across all linked workbooks in the collection.
+    summary: >-
+      The original URL pointing to the linked workbook. It is unique across all
+      linked workbooks in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,11 +69,12 @@ methods:
         type: string
         description: ''
   - name: refreshLinks()
-    uid: 'ExcelScript!ExcelScript.LinkedWorkbook#refreshLinks:member(1)'
+    uid: ExcelScript!ExcelScript.LinkedWorkbook#refreshLinks:member(1)
     package: ExcelScript!
     fullName: refreshLinks()
     summary: Makes a request to refresh the data retrieved from the linked workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.listdatavalidation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.listdatavalidation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ListDataValidation
-uid: 'ExcelScript!ExcelScript.ListDataValidation:interface'
+uid: ExcelScript!ExcelScript.ListDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.ListDataValidation
 summary: Represents the List data validation criteria.
@@ -45,16 +45,20 @@ remarks: |-
       dataValidation.setRule(validationRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: inCellDropDown
-    uid: 'ExcelScript!ExcelScript.ListDataValidation#inCellDropDown:member'
+    uid: ExcelScript!ExcelScript.ListDataValidation#inCellDropDown:member
     package: ExcelScript!
     fullName: inCellDropDown
-    summary: Specifies whether to display the list in a cell drop-down. The default is `true`<!-- -->.
+    summary: >-
+      Specifies whether to display the list in a cell drop-down. The default is
+      `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,16 +66,18 @@ properties:
       return:
         type: boolean
   - name: source
-    uid: 'ExcelScript!ExcelScript.ListDataValidation#source:member'
+    uid: ExcelScript!ExcelScript.ListDataValidation#source:member
     package: ExcelScript!
     fullName: source
     summary: >-
-      Source of the list for data validation When setting the value, it can be passed in as a `Range` object, or a
-      string that contains a comma-separated number, boolean, or date.
+      Source of the list for data validation When setting the value, it can be
+      passed in as a `Range` object, or a string that contains a comma-separated
+      number, boolean, or date.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'source: string | Range;'
       return:
-        type: 'string | <xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: string | <xref uid="ExcelScript!ExcelScript.Range:interface" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.loadtotype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.loadtotype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.LoadToType
-uid: 'ExcelScript!ExcelScript.LoadToType:enum'
+uid: ExcelScript!ExcelScript.LoadToType:enum
 package: ExcelScript!
 fullName: ExcelScript.LoadToType
 summary: An enum that specifies the query load to destination.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: connectionOnly
-    uid: 'ExcelScript!ExcelScript.LoadToType.connectionOnly:member'
+    uid: ExcelScript!ExcelScript.LoadToType.connectionOnly:member
     package: ExcelScript!
     summary: Load to connection only.
   - name: pivotChart
-    uid: 'ExcelScript!ExcelScript.LoadToType.pivotChart:member'
+    uid: ExcelScript!ExcelScript.LoadToType.pivotChart:member
     package: ExcelScript!
     summary: Load to PivotChart.
   - name: pivotTable
-    uid: 'ExcelScript!ExcelScript.LoadToType.pivotTable:member'
+    uid: ExcelScript!ExcelScript.LoadToType.pivotTable:member
     package: ExcelScript!
     summary: Load to PivotTable.
   - name: table
-    uid: 'ExcelScript!ExcelScript.LoadToType.table:member'
+    uid: ExcelScript!ExcelScript.LoadToType.table:member
     package: ExcelScript!
     summary: Load to a table.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.mixedcellcontrol.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.mixedcellcontrol.yml
@@ -1,25 +1,28 @@
 ### YamlMime:TSType
 name: ExcelScript.MixedCellControl
-uid: 'ExcelScript!ExcelScript.MixedCellControl:interface'
+uid: ExcelScript!ExcelScript.MixedCellControl:interface
 package: ExcelScript!
 fullName: ExcelScript.MixedCellControl
 summary: >-
-  Represents the result of a query that resulted in multiple cell controls. If the result has multiple controls, then
-  they can't be represented as a single result.
+  Represents the result of a query that resulted in multiple cell controls. If
+  the result has multiple controls, then they can't be represented as a single
+  result.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: type
-    uid: 'ExcelScript!ExcelScript.MixedCellControl#type:member'
+    uid: ExcelScript!ExcelScript.MixedCellControl#type:member
     package: ExcelScript!
     fullName: type
     summary: ''
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: CellControlType.mixed;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellControlType.mixed:member" />'
+        type: <xref uid="ExcelScript!ExcelScript.CellControlType.mixed:member" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditem.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditem.yml
@@ -1,11 +1,13 @@
 ### YamlMime:TSType
 name: ExcelScript.NamedItem
-uid: 'ExcelScript!ExcelScript.NamedItem:interface'
+uid: ExcelScript!ExcelScript.NamedItem:interface
 package: ExcelScript!
 fullName: ExcelScript.NamedItem
 summary: >-
-  Represents a defined name for a range of cells or value. Names can be primitive named objects (as seen in the type
-  below), range object, or a reference to a range. This object can be used to obtain range object associated with names.
+  Represents a defined name for a range of cells or value. Names can be
+  primitive named objects (as seen in the type below), range object, or a
+  reference to a range. This object can be used to obtain range object
+  associated with names.
 remarks: |-
 
 
@@ -32,16 +34,18 @@ remarks: |-
     otherSheet.activate();
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.NamedItem#delete:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the given name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,24 +54,26 @@ methods:
         type: void
         description: ''
   - name: getArrayValues()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getArrayValues:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getArrayValues:member(1)
     package: ExcelScript!
     fullName: getArrayValues()
     summary: Returns an object containing values and types of the named item.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getArrayValues(): NamedItemArrayValues;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItemArrayValues:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItemArrayValues:interface" />
         description: ''
   - name: getComment()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getComment:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getComment:member(1)
     package: ExcelScript!
     fullName: getComment()
     summary: Specifies the comment associated with this name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -76,11 +82,14 @@ methods:
         type: string
         description: ''
   - name: getFormula()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getFormula:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getFormula:member(1)
     package: ExcelScript!
     fullName: getFormula()
-    summary: The formula of the named item. Formulas always start with an equal sign ("=").
+    summary: >-
+      The formula of the named item. Formulas always start with an equal sign
+      ("=").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -89,11 +98,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getName:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: The name of the object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -102,47 +112,52 @@ methods:
         type: string
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: >-
-      Returns the range object that is associated with the name. If the named item's type is not a range, then this
-      method returns `undefined`<!-- -->.
+      Returns the range object that is associated with the name. If the named
+      item's type is not a range, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getScope()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getScope:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getScope:member(1)
     package: ExcelScript!
     fullName: getScope()
     summary: >-
-      Specifies if the name is scoped to the workbook or to a specific worksheet. Possible values are: Worksheet,
-      Workbook.
+      Specifies if the name is scoped to the workbook or to a specific
+      worksheet. Possible values are: Worksheet, Workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getScope(): NamedItemScope;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItemScope:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItemScope:enum" />
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getType:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getType:member(1)
     package: ExcelScript!
     fullName: getType()
-    summary: Specifies the type of the value returned by the name's formula. See `ExcelScript.NamedItemType` for details.
+    summary: >-
+      Specifies the type of the value returned by the name's formula. See
+      `ExcelScript.NamedItemType` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): NamedItemType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItemType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItemType:enum" />
         description: |-
 
 
@@ -169,13 +184,15 @@ methods:
           }
           ```
   - name: getValue()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getValue:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getValue:member(1)
     package: ExcelScript!
     fullName: getValue()
     summary: >-
-      Represents the value computed by the name's formula. For a named range, it will return the range address. This API
-      returns the \#VALUE! error in the Excel UI if it refers to a user-defined function.
+      Represents the value computed by the name's formula. For a named range, it
+      will return the range address. This API returns the \#VALUE! error in the
+      Excel UI if it refers to a user-defined function.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -184,11 +201,12 @@ methods:
         type: string | number
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the object is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,26 +215,29 @@ methods:
         type: boolean
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.NamedItem#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: >-
-      Returns the worksheet to which the named item is scoped. If the item is scoped to the workbook instead, then this
-      method returns `undefined`<!-- -->.
+      Returns the worksheet to which the named item is scoped. If the item is
+      scoped to the workbook instead, then this method returns `undefined`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet | undefined;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | undefined
         description: ''
   - name: setComment(comment)
-    uid: 'ExcelScript!ExcelScript.NamedItem#setComment:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#setComment:member(1)
     package: ExcelScript!
     fullName: setComment(comment)
     summary: Specifies the comment associated with this name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -229,11 +250,14 @@ methods:
         type: void
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.NamedItem#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
-    summary: The formula of the named item. Formulas always start with an equal sign ("=").
+    summary: >-
+      The formula of the named item. Formulas always start with an equal sign
+      ("=").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -246,11 +270,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.NamedItem#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItem#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the object is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemarrayvalues.yml
@@ -1,37 +1,40 @@
 ### YamlMime:TSType
 name: ExcelScript.NamedItemArrayValues
-uid: 'ExcelScript!ExcelScript.NamedItemArrayValues:interface'
+uid: ExcelScript!ExcelScript.NamedItemArrayValues:interface
 package: ExcelScript!
 fullName: ExcelScript.NamedItemArrayValues
 summary: Represents an object containing values and types of a named item.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getTypes()
-    uid: 'ExcelScript!ExcelScript.NamedItemArrayValues#getTypes:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItemArrayValues#getTypes:member(1)
     package: ExcelScript!
     fullName: getTypes()
     summary: Represents the types for each item in the named item array
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTypes(): RangeValueType[][];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]
         description: ''
   - name: getValues()
-    uid: 'ExcelScript!ExcelScript.NamedItemArrayValues#getValues:member(1)'
+    uid: ExcelScript!ExcelScript.NamedItemArrayValues#getValues:member(1)
     package: ExcelScript!
     fullName: getValues()
     summary: Represents the values of each item in the named item array.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValues(): (string | number | boolean)[][];'
       return:
-        type: '(string | number | boolean)[][]'
+        type: (string | number | boolean)[][]
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemscope.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemscope.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.NamedItemScope
-uid: 'ExcelScript!ExcelScript.NamedItemScope:enum'
+uid: ExcelScript!ExcelScript.NamedItemScope:enum
 package: ExcelScript!
 fullName: ExcelScript.NamedItemScope
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: workbook
-    uid: 'ExcelScript!ExcelScript.NamedItemScope.workbook:member'
+    uid: ExcelScript!ExcelScript.NamedItemScope.workbook:member
     package: ExcelScript!
     summary: ''
   - name: worksheet
-    uid: 'ExcelScript!ExcelScript.NamedItemScope.worksheet:member'
+    uid: ExcelScript!ExcelScript.NamedItemScope.worksheet:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemtype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.nameditemtype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.NamedItemType
-uid: 'ExcelScript!ExcelScript.NamedItemType:enum'
+uid: ExcelScript!ExcelScript.NamedItemType:enum
 package: ExcelScript!
 fullName: ExcelScript.NamedItemType
 summary: ''
@@ -29,34 +29,35 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: array
-    uid: 'ExcelScript!ExcelScript.NamedItemType.array:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.array:member
     package: ExcelScript!
     summary: ''
   - name: boolean
-    uid: 'ExcelScript!ExcelScript.NamedItemType.boolean:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.boolean:member
     package: ExcelScript!
     summary: ''
   - name: double
-    uid: 'ExcelScript!ExcelScript.NamedItemType.double:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.double:member
     package: ExcelScript!
     summary: ''
   - name: error
-    uid: 'ExcelScript!ExcelScript.NamedItemType.error:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.error:member
     package: ExcelScript!
     summary: ''
   - name: integer
-    uid: 'ExcelScript!ExcelScript.NamedItemType.integer:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.integer:member
     package: ExcelScript!
     summary: ''
   - name: range
-    uid: 'ExcelScript!ExcelScript.NamedItemType.range:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.range:member
     package: ExcelScript!
     summary: ''
   - name: string
-    uid: 'ExcelScript!ExcelScript.NamedItemType.string:member'
+    uid: ExcelScript!ExcelScript.NamedItemType.string:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.namedsheetview.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.namedsheetview.yml
@@ -1,23 +1,28 @@
 ### YamlMime:TSType
 name: ExcelScript.NamedSheetView
-uid: 'ExcelScript!ExcelScript.NamedSheetView:interface'
+uid: ExcelScript!ExcelScript.NamedSheetView:interface
 package: ExcelScript!
 fullName: ExcelScript.NamedSheetView
 summary: >-
-  Represents a named sheet view of a worksheet. A sheet view stores the sort and filter rules for a particular
-  worksheet. Every sheet view (even a temporary sheet view) has a unique, worksheet-scoped name that is used to access
-  the view.
+  Represents a named sheet view of a worksheet. A sheet view stores the sort and
+  filter rules for a particular worksheet. Every sheet view (even a temporary
+  sheet view) has a unique, worksheet-scoped name that is used to access the
+  view.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: activate()
-    uid: 'ExcelScript!ExcelScript.NamedSheetView#activate:member(1)'
+    uid: ExcelScript!ExcelScript.NamedSheetView#activate:member(1)
     package: ExcelScript!
     fullName: activate()
-    summary: Activates this sheet view. This is equivalent to using "Switch To" in the Excel UI.
+    summary: >-
+      Activates this sheet view. This is equivalent to using "Switch To" in the
+      Excel UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -26,11 +31,12 @@ methods:
         type: void
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.NamedSheetView#delete:member(1)'
+    uid: ExcelScript!ExcelScript.NamedSheetView#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Removes the sheet view from the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -39,30 +45,35 @@ methods:
         type: void
         description: ''
   - name: duplicate(name)
-    uid: 'ExcelScript!ExcelScript.NamedSheetView#duplicate:member(1)'
+    uid: ExcelScript!ExcelScript.NamedSheetView#duplicate:member(1)
     package: ExcelScript!
     fullName: duplicate(name)
     summary: Creates a copy of this sheet view.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'duplicate(name?: string): NamedSheetView;'
       parameters:
         - id: name
-          description: 'The name of the duplicated sheet view. If no name is provided, one will be generated.'
+          description: >-
+            The name of the duplicated sheet view. If no name is provided, one
+            will be generated.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.NamedSheetView#getName:member(1)'
+    uid: ExcelScript!ExcelScript.NamedSheetView#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: >-
-      Specifies the name of the sheet view. The temporary sheet view name is the empty string (""). Naming the view by
-      using the name property causes the sheet view to be saved.
+      Specifies the name of the sheet view. The temporary sheet view name is the
+      empty string (""). Naming the view by using the name property causes the
+      sheet view to be saved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -71,13 +82,15 @@ methods:
         type: string
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.NamedSheetView#setName:member(1)'
+    uid: ExcelScript!ExcelScript.NamedSheetView#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: >-
-      Specifies the name of the sheet view. The temporary sheet view name is the empty string (""). Naming the view by
-      using the name property causes the sheet view to be saved.
+      Specifies the name of the sheet view. The temporary sheet view name is the
+      empty string (""). Naming the view by using the name property causes the
+      sheet view to be saved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatcategory.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatcategory.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.NumberFormatCategory
-uid: 'ExcelScript!ExcelScript.NumberFormatCategory:enum'
+uid: ExcelScript!ExcelScript.NumberFormatCategory:enum
 package: ExcelScript!
 fullName: ExcelScript.NumberFormatCategory
 summary: Represents a category of number formats.
@@ -31,64 +31,77 @@ remarks: |-
     }); 
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: accounting
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.accounting:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.accounting:member
     package: ExcelScript!
-    summary: Accounting formats line up the currency symbols and decimal points in a column.
+    summary: >-
+      Accounting formats line up the currency symbols and decimal points in a
+      column.
   - name: currency
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.currency:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.currency:member
     package: ExcelScript!
-    summary: Currency formats are used for general monetary values. Use Accounting formats to align decimal points in a column.
+    summary: >-
+      Currency formats are used for general monetary values. Use Accounting
+      formats to align decimal points in a column.
   - name: custom
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.custom:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.custom:member
     package: ExcelScript!
     summary: A custom format that is not a part of any category.
   - name: date
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.date:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.date:member
     package: ExcelScript!
     summary: >-
-      Date formats display date and time serial numbers as date values. Date formats that begin with an asterisk (*)
-      respond to changes in regional date and time settings that are specified for the operating system. Formats without
-      an asterisk are not affected by operating system settings.
+      Date formats display date and time serial numbers as date values. Date
+      formats that begin with an asterisk (*) respond to changes in regional
+      date and time settings that are specified for the operating system.
+      Formats without an asterisk are not affected by operating system settings.
   - name: fraction
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.fraction:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.fraction:member
     package: ExcelScript!
     summary: >-
-      Fraction formats display the cell value as a whole number with the remainder rounded to the nearest fraction
-      value.
+      Fraction formats display the cell value as a whole number with the
+      remainder rounded to the nearest fraction value.
   - name: general
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.general:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.general:member
     package: ExcelScript!
     summary: General format cells have no specific number format.
   - name: number
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.number:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.number:member
     package: ExcelScript!
     summary: >-
-      Number is used for general display of numbers. Currency and Accounting offer specialized formatting for monetary
-      value.
+      Number is used for general display of numbers. Currency and Accounting
+      offer specialized formatting for monetary value.
   - name: percentage
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.percentage:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.percentage:member
     package: ExcelScript!
-    summary: Percentage formats multiply the cell value by 100 and displays the result with a percent symbol.
+    summary: >-
+      Percentage formats multiply the cell value by 100 and displays the result
+      with a percent symbol.
   - name: scientific
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.scientific:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.scientific:member
     package: ExcelScript!
-    summary: Scientific formats display the cell value as a number between 1 and 10 multiplied by a power of 10.
+    summary: >-
+      Scientific formats display the cell value as a number between 1 and 10
+      multiplied by a power of 10.
   - name: special
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.special:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.special:member
     package: ExcelScript!
     summary: Special formats are useful for tracking list and database values.
   - name: text
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.text:member'
-    package: ExcelScript!
-    summary: Text format cells are treated as text even when a number is in the cell. The cell is displayed exactly as entered.
-  - name: time
-    uid: 'ExcelScript!ExcelScript.NumberFormatCategory.time:member'
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.text:member
     package: ExcelScript!
     summary: >-
-      Time formats display date and time serial numbers as date values. Time formats that begin with an asterisk (*)
-      respond to changes in regional date and time settings that are specified for the operating system. Formats without
-      an asterisk are not affected by operating system settings.
+      Text format cells are treated as text even when a number is in the cell.
+      The cell is displayed exactly as entered.
+  - name: time
+    uid: ExcelScript!ExcelScript.NumberFormatCategory.time:member
+    package: ExcelScript!
+    summary: >-
+      Time formats display date and time serial numbers as date values. Time
+      formats that begin with an asterisk (*) respond to changes in regional
+      date and time settings that are specified for the operating system.
+      Formats without an asterisk are not affected by operating system settings.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatinfo.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.numberformatinfo.yml
@@ -1,20 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.NumberFormatInfo
-uid: 'ExcelScript!ExcelScript.NumberFormatInfo:interface'
+uid: ExcelScript!ExcelScript.NumberFormatInfo:interface
 package: ExcelScript!
 fullName: ExcelScript.NumberFormatInfo
-summary: Defines the culturally appropriate format of displaying numbers. This is based on current system culture settings.
+summary: >-
+  Defines the culturally appropriate format of displaying numbers. This is based
+  on current system culture settings.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCurrencySymbol()
-    uid: 'ExcelScript!ExcelScript.NumberFormatInfo#getCurrencySymbol:member(1)'
+    uid: ExcelScript!ExcelScript.NumberFormatInfo#getCurrencySymbol:member(1)
     package: ExcelScript!
     fullName: getCurrencySymbol()
-    summary: Gets the currency symbol for currency values. This is based on current system settings.
+    summary: >-
+      Gets the currency symbol for currency values. This is based on current
+      system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +29,15 @@ methods:
         type: string
         description: ''
   - name: getNumberDecimalSeparator()
-    uid: 'ExcelScript!ExcelScript.NumberFormatInfo#getNumberDecimalSeparator:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.NumberFormatInfo#getNumberDecimalSeparator:member(1)
     package: ExcelScript!
     fullName: getNumberDecimalSeparator()
-    summary: Gets the string used as the decimal separator for numeric values. This is based on current system settings.
+    summary: >-
+      Gets the string used as the decimal separator for numeric values. This is
+      based on current system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,13 +46,14 @@ methods:
         type: string
         description: ''
   - name: getNumberGroupSeparator()
-    uid: 'ExcelScript!ExcelScript.NumberFormatInfo#getNumberGroupSeparator:member(1)'
+    uid: ExcelScript!ExcelScript.NumberFormatInfo#getNumberGroupSeparator:member(1)
     package: ExcelScript!
     fullName: getNumberGroupSeparator()
     summary: >-
-      Gets the string used to separate groups of digits to the left of the decimal for numeric values. This is based on
-      current system settings.
+      Gets the string used to separate groups of digits to the left of the
+      decimal for numeric values. This is based on current system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pagebreak.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pagebreak.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.PageBreak
-uid: 'ExcelScript!ExcelScript.PageBreak:interface'
+uid: ExcelScript!ExcelScript.PageBreak:interface
 package: ExcelScript!
 fullName: ExcelScript.PageBreak
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.PageBreak#delete:member(1)'
+    uid: ExcelScript!ExcelScript.PageBreak#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes a page break object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +25,26 @@ methods:
         type: void
         description: ''
   - name: getCellAfterBreak()
-    uid: 'ExcelScript!ExcelScript.PageBreak#getCellAfterBreak:member(1)'
+    uid: ExcelScript!ExcelScript.PageBreak#getCellAfterBreak:member(1)
     package: ExcelScript!
     fullName: getCellAfterBreak()
     summary: Gets the first cell after the page break.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCellAfterBreak(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getColumnIndex()
-    uid: 'ExcelScript!ExcelScript.PageBreak#getColumnIndex:member(1)'
+    uid: ExcelScript!ExcelScript.PageBreak#getColumnIndex:member(1)
     package: ExcelScript!
     fullName: getColumnIndex()
     summary: Specifies the column index for the page break.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +53,12 @@ methods:
         type: number
         description: ''
   - name: getRowIndex()
-    uid: 'ExcelScript!ExcelScript.PageBreak#getRowIndex:member(1)'
+    uid: ExcelScript!ExcelScript.PageBreak#getRowIndex:member(1)
     package: ExcelScript!
     fullName: getRowIndex()
     summary: Specifies the row index for the page break.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayout.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayout.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSType
 name: ExcelScript.PageLayout
-uid: 'ExcelScript!ExcelScript.PageLayout:interface'
+uid: ExcelScript!ExcelScript.PageLayout:interface
 package: ExcelScript!
 fullName: ExcelScript.PageLayout
 summary: >-
-  Represents layout and print settings that are not dependent on any printer-specific implementation. These settings
-  include margins, orientation, page numbering, title rows, and print area.
+  Represents layout and print settings that are not dependent on any
+  printer-specific implementation. These settings include margins, orientation,
+  page numbering, title rows, and print area.
 remarks: |-
 
 
@@ -31,16 +32,18 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBlackAndWhite()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getBlackAndWhite:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getBlackAndWhite:member(1)
     package: ExcelScript!
     fullName: getBlackAndWhite()
     summary: The worksheet's black and white print option.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +52,12 @@ methods:
         type: boolean
         description: ''
   - name: getBottomMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getBottomMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getBottomMargin:member(1)
     package: ExcelScript!
     fullName: getBottomMargin()
     summary: The worksheet's bottom page margin to use for printing in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,13 +66,14 @@ methods:
         type: number
         description: ''
   - name: getCenterHorizontally()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getCenterHorizontally:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getCenterHorizontally:member(1)
     package: ExcelScript!
     fullName: getCenterHorizontally()
     summary: >-
-      The worksheet's center horizontally flag. This flag determines whether the worksheet will be centered horizontally
-      when it's printed.
+      The worksheet's center horizontally flag. This flag determines whether the
+      worksheet will be centered horizontally when it's printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,13 +82,14 @@ methods:
         type: boolean
         description: ''
   - name: getCenterVertically()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getCenterVertically:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getCenterVertically:member(1)
     package: ExcelScript!
     fullName: getCenterVertically()
     summary: >-
-      The worksheet's center vertically flag. This flag determines whether the worksheet will be centered vertically
-      when it's printed.
+      The worksheet's center vertically flag. This flag determines whether the
+      worksheet will be centered vertically when it's printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -92,11 +98,14 @@ methods:
         type: boolean
         description: ''
   - name: getDraftMode()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getDraftMode:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getDraftMode:member(1)
     package: ExcelScript!
     fullName: getDraftMode()
-    summary: 'The worksheet''s draft mode option. If `true`<!-- -->, the sheet will be printed without graphics.'
+    summary: >-
+      The worksheet's draft mode option. If `true`<!-- -->, the sheet will be
+      printed without graphics.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -105,11 +114,14 @@ methods:
         type: boolean
         description: ''
   - name: getFirstPageNumber()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getFirstPageNumber:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getFirstPageNumber:member(1)
     package: ExcelScript!
     fullName: getFirstPageNumber()
-    summary: The worksheet's first page number to print. A `null` value represents "auto" page numbering.
+    summary: >-
+      The worksheet's first page number to print. A `null` value represents
+      "auto" page numbering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -118,11 +130,12 @@ methods:
         type: number | ""
         description: ''
   - name: getFooterMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getFooterMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getFooterMargin:member(1)
     package: ExcelScript!
     fullName: getFooterMargin()
-    summary: 'The worksheet''s footer margin, in points, for use when printing.'
+    summary: The worksheet's footer margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -131,11 +144,12 @@ methods:
         type: number
         description: ''
   - name: getHeaderMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getHeaderMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getHeaderMargin:member(1)
     package: ExcelScript!
     fullName: getHeaderMargin()
-    summary: 'The worksheet''s header margin, in points, for use when printing.'
+    summary: The worksheet's header margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -144,24 +158,26 @@ methods:
         type: number
         description: ''
   - name: getHeadersFooters()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getHeadersFooters:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getHeadersFooters:member(1)
     package: ExcelScript!
     fullName: getHeadersFooters()
     summary: Header and footer configuration for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHeadersFooters(): HeaderFooterGroup;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HeaderFooterGroup:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.HeaderFooterGroup:interface" />
         description: ''
   - name: getLeftMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getLeftMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getLeftMargin:member(1)
     package: ExcelScript!
     fullName: getLeftMargin()
-    summary: 'The worksheet''s left margin, in points, for use when printing.'
+    summary: The worksheet's left margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -170,78 +186,85 @@ methods:
         type: number
         description: ''
   - name: getOrientation()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getOrientation:member(1)
     package: ExcelScript!
     fullName: getOrientation()
     summary: The worksheet's orientation of the page.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getOrientation(): PageOrientation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageOrientation:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PageOrientation:enum" />
         description: ''
   - name: getPaperSize()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPaperSize:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPaperSize:member(1)
     package: ExcelScript!
     fullName: getPaperSize()
     summary: The worksheet's paper size of the page.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPaperSize(): PaperType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PaperType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PaperType:enum" />
         description: ''
   - name: getPrintArea()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintArea:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintArea:member(1)
     package: ExcelScript!
     fullName: getPrintArea()
     summary: >-
-      Gets the `RangeAreas` object, comprising one or more rectangular ranges, that represents the print area for the
-      worksheet. If there is no print area, then this method returns `undefined`<!-- -->.
+      Gets the `RangeAreas` object, comprising one or more rectangular ranges,
+      that represents the print area for the worksheet. If there is no print
+      area, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintArea(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getPrintComments()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintComments:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintComments:member(1)
     package: ExcelScript!
     fullName: getPrintComments()
     summary: Specifies if the worksheet's comments should be displayed when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintComments(): PrintComments;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PrintComments:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PrintComments:enum" />
         description: ''
   - name: getPrintErrors()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintErrors:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintErrors:member(1)
     package: ExcelScript!
     fullName: getPrintErrors()
     summary: The worksheet's print errors option.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintErrors(): PrintErrorType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PrintErrorType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PrintErrorType:enum" />
         description: ''
   - name: getPrintGridlines()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintGridlines:member(1)
     package: ExcelScript!
     fullName: getPrintGridlines()
     summary: Specifies if the worksheet's gridlines will be printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -250,11 +273,12 @@ methods:
         type: boolean
         description: ''
   - name: getPrintHeadings()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintHeadings:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintHeadings:member(1)
     package: ExcelScript!
     fullName: getPrintHeadings()
     summary: Specifies if the worksheet's headings will be printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -263,50 +287,60 @@ methods:
         type: boolean
         description: ''
   - name: getPrintOrder()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintOrder:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintOrder:member(1)
     package: ExcelScript!
     fullName: getPrintOrder()
-    summary: The worksheet's page print order option. This specifies the order to use for processing the page number printed.
+    summary: >-
+      The worksheet's page print order option. This specifies the order to use
+      for processing the page number printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintOrder(): PrintOrder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PrintOrder:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PrintOrder:enum" />
         description: ''
   - name: getPrintTitleColumns()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintTitleColumns:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintTitleColumns:member(1)
     package: ExcelScript!
     fullName: getPrintTitleColumns()
-    summary: 'Gets the range object representing the title columns. If not set, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets the range object representing the title columns. If not set, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintTitleColumns(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getPrintTitleRows()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getPrintTitleRows:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getPrintTitleRows:member(1)
     package: ExcelScript!
     fullName: getPrintTitleRows()
-    summary: 'Gets the range object representing the title rows. If not set, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets the range object representing the title rows. If not set, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrintTitleRows(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRightMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getRightMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getRightMargin:member(1)
     package: ExcelScript!
     fullName: getRightMargin()
-    summary: 'The worksheet''s right margin, in points, for use when printing.'
+    summary: The worksheet's right margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -315,11 +349,12 @@ methods:
         type: number
         description: ''
   - name: getTopMargin()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getTopMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getTopMargin:member(1)
     package: ExcelScript!
     fullName: getTopMargin()
-    summary: 'The worksheet''s top margin, in points, for use when printing.'
+    summary: The worksheet's top margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -328,26 +363,29 @@ methods:
         type: number
         description: ''
   - name: getZoom()
-    uid: 'ExcelScript!ExcelScript.PageLayout#getZoom:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#getZoom:member(1)
     package: ExcelScript!
     fullName: getZoom()
     summary: >-
-      The worksheet's print zoom options. The `PageLayoutZoomOptions` object must be set as a JSON object (use `x.zoom =
-      {...}` instead of `x.zoom.scale = ...`<!-- -->).
+      The worksheet's print zoom options. The `PageLayoutZoomOptions` object
+      must be set as a JSON object (use `x.zoom = {...}` instead of
+      `x.zoom.scale = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getZoom(): PageLayoutZoomOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageLayoutZoomOptions:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PageLayoutZoomOptions:interface" />
         description: ''
   - name: setBlackAndWhite(blackAndWhite)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setBlackAndWhite:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setBlackAndWhite:member(1)
     package: ExcelScript!
     fullName: setBlackAndWhite(blackAndWhite)
     summary: The worksheet's black and white print option.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -360,11 +398,12 @@ methods:
         type: void
         description: ''
   - name: setBottomMargin(bottomMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setBottomMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setBottomMargin:member(1)
     package: ExcelScript!
     fullName: setBottomMargin(bottomMargin)
     summary: The worksheet's bottom page margin to use for printing in points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -377,13 +416,14 @@ methods:
         type: void
         description: ''
   - name: setCenterHorizontally(centerHorizontally)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setCenterHorizontally:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setCenterHorizontally:member(1)
     package: ExcelScript!
     fullName: setCenterHorizontally(centerHorizontally)
     summary: >-
-      The worksheet's center horizontally flag. This flag determines whether the worksheet will be centered horizontally
-      when it's printed.
+      The worksheet's center horizontally flag. This flag determines whether the
+      worksheet will be centered horizontally when it's printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -396,13 +436,14 @@ methods:
         type: void
         description: ''
   - name: setCenterVertically(centerVertically)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setCenterVertically:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setCenterVertically:member(1)
     package: ExcelScript!
     fullName: setCenterVertically(centerVertically)
     summary: >-
-      The worksheet's center vertically flag. This flag determines whether the worksheet will be centered vertically
-      when it's printed.
+      The worksheet's center vertically flag. This flag determines whether the
+      worksheet will be centered vertically when it's printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -415,11 +456,14 @@ methods:
         type: void
         description: ''
   - name: setDraftMode(draftMode)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setDraftMode:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setDraftMode:member(1)
     package: ExcelScript!
     fullName: setDraftMode(draftMode)
-    summary: 'The worksheet''s draft mode option. If `true`<!-- -->, the sheet will be printed without graphics.'
+    summary: >-
+      The worksheet's draft mode option. If `true`<!-- -->, the sheet will be
+      printed without graphics.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -450,11 +494,14 @@ methods:
           }
           ```
   - name: setFirstPageNumber(firstPageNumber)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setFirstPageNumber:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setFirstPageNumber:member(1)
     package: ExcelScript!
     fullName: setFirstPageNumber(firstPageNumber)
-    summary: The worksheet's first page number to print. A `null` value represents "auto" page numbering.
+    summary: >-
+      The worksheet's first page number to print. A `null` value represents
+      "auto" page numbering.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -467,11 +514,12 @@ methods:
         type: void
         description: ''
   - name: setFooterMargin(footerMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setFooterMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setFooterMargin:member(1)
     package: ExcelScript!
     fullName: setFooterMargin(footerMargin)
-    summary: 'The worksheet''s footer margin, in points, for use when printing.'
+    summary: The worksheet's footer margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -484,11 +532,12 @@ methods:
         type: void
         description: ''
   - name: setHeaderMargin(headerMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setHeaderMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setHeaderMargin:member(1)
     package: ExcelScript!
     fullName: setHeaderMargin(headerMargin)
-    summary: 'The worksheet''s header margin, in points, for use when printing.'
+    summary: The worksheet's header margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -501,11 +550,12 @@ methods:
         type: void
         description: ''
   - name: setLeftMargin(leftMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setLeftMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setLeftMargin:member(1)
     package: ExcelScript!
     fullName: setLeftMargin(leftMargin)
-    summary: 'The worksheet''s left margin, in points, for use when printing.'
+    summary: The worksheet's left margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -518,11 +568,12 @@ methods:
         type: void
         description: ''
   - name: setOrientation(orientation)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setOrientation:member(1)
     package: ExcelScript!
     fullName: setOrientation(orientation)
     summary: The worksheet's orientation of the page.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -530,7 +581,7 @@ methods:
       parameters:
         - id: orientation
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PageOrientation:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PageOrientation:enum" />
       return:
         type: void
         description: |-
@@ -553,11 +604,12 @@ methods:
           }
           ```
   - name: setPaperSize(paperSize)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPaperSize:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPaperSize:member(1)
     package: ExcelScript!
     fullName: setPaperSize(paperSize)
     summary: The worksheet's paper size of the page.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -565,7 +617,7 @@ methods:
       parameters:
         - id: paperSize
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PaperType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PaperType:enum" />
       return:
         type: void
         description: |-
@@ -587,11 +639,12 @@ methods:
           }
           ```
   - name: setPrintArea(printArea)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintArea:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintArea:member(1)
     package: ExcelScript!
     fullName: setPrintArea(printArea)
     summary: Sets the worksheet's print area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -606,11 +659,12 @@ methods:
         type: void
         description: ''
   - name: setPrintComments(printComments)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintComments:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintComments:member(1)
     package: ExcelScript!
     fullName: setPrintComments(printComments)
     summary: Specifies if the worksheet's comments should be displayed when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -618,7 +672,7 @@ methods:
       parameters:
         - id: printComments
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PrintComments:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PrintComments:enum" />
       return:
         type: void
         description: |-
@@ -643,11 +697,12 @@ methods:
           }
           ```
   - name: setPrintErrors(printErrors)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintErrors:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintErrors:member(1)
     package: ExcelScript!
     fullName: setPrintErrors(printErrors)
     summary: The worksheet's print errors option.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -655,16 +710,17 @@ methods:
       parameters:
         - id: printErrors
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PrintErrorType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PrintErrorType:enum" />
       return:
         type: void
         description: ''
   - name: setPrintGridlines(printGridlines)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintGridlines:member(1)
     package: ExcelScript!
     fullName: setPrintGridlines(printGridlines)
     summary: Specifies if the worksheet's gridlines will be printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -677,11 +733,12 @@ methods:
         type: void
         description: ''
   - name: setPrintHeadings(printHeadings)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintHeadings:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintHeadings:member(1)
     package: ExcelScript!
     fullName: setPrintHeadings(printHeadings)
     summary: Specifies if the worksheet's headings will be printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -693,12 +750,13 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'setPrintMargins(unit, marginOptions)'
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintMargins:member(1)'
+  - name: setPrintMargins(unit, marginOptions)
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintMargins:member(1)
     package: ExcelScript!
-    fullName: 'setPrintMargins(unit, marginOptions)'
+    fullName: setPrintMargins(unit, marginOptions)
     summary: Sets the worksheet's page margins with units.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -710,19 +768,24 @@ methods:
       parameters:
         - id: unit
           description: Measurement unit for the margins provided.
-          type: '<xref uid="ExcelScript!ExcelScript.PrintMarginUnit:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PrintMarginUnit:enum" />
         - id: marginOptions
           description: Margin values to set. Margins not provided remain unchanged.
-          type: '<xref uid="ExcelScript!ExcelScript.PageLayoutMarginOptions:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.PageLayoutMarginOptions:interface" />
       return:
         type: void
         description: ''
   - name: setPrintOrder(printOrder)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintOrder:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintOrder:member(1)
     package: ExcelScript!
     fullName: setPrintOrder(printOrder)
-    summary: The worksheet's page print order option. This specifies the order to use for processing the page number printed.
+    summary: >-
+      The worksheet's page print order option. This specifies the order to use
+      for processing the page number printed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -730,7 +793,7 @@ methods:
       parameters:
         - id: printOrder
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PrintOrder:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PrintOrder:enum" />
       return:
         type: void
         description: |-
@@ -756,45 +819,56 @@ methods:
           }
           ```
   - name: setPrintTitleColumns(printTitleColumns)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintTitleColumns:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintTitleColumns:member(1)
     package: ExcelScript!
     fullName: setPrintTitleColumns(printTitleColumns)
-    summary: Sets the columns that contain the cells to be repeated at the left of each page of the worksheet for printing.
+    summary: >-
+      Sets the columns that contain the cells to be repeated at the left of each
+      page of the worksheet for printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setPrintTitleColumns(printTitleColumns: Range | string): void;'
       parameters:
         - id: printTitleColumns
-          description: The columns to be repeated to the left of each page. The range must span the entire column to be valid.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            The columns to be repeated to the left of each page. The range must
+            span the entire column to be valid.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: ''
   - name: setPrintTitleRows(printTitleRows)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setPrintTitleRows:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setPrintTitleRows:member(1)
     package: ExcelScript!
     fullName: setPrintTitleRows(printTitleRows)
-    summary: Sets the rows that contain the cells to be repeated at the top of each page of the worksheet for printing.
+    summary: >-
+      Sets the rows that contain the cells to be repeated at the top of each
+      page of the worksheet for printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setPrintTitleRows(printTitleRows: Range | string): void;'
       parameters:
         - id: printTitleRows
-          description: The rows to be repeated at the top of each page. The range must span the entire row to be valid.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            The rows to be repeated at the top of each page. The range must span
+            the entire row to be valid.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: ''
   - name: setRightMargin(rightMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setRightMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setRightMargin:member(1)
     package: ExcelScript!
     fullName: setRightMargin(rightMargin)
-    summary: 'The worksheet''s right margin, in points, for use when printing.'
+    summary: The worksheet's right margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -807,11 +881,12 @@ methods:
         type: void
         description: ''
   - name: setTopMargin(topMargin)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setTopMargin:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setTopMargin:member(1)
     package: ExcelScript!
     fullName: setTopMargin(topMargin)
-    summary: 'The worksheet''s top margin, in points, for use when printing.'
+    summary: The worksheet's top margin, in points, for use when printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -824,13 +899,15 @@ methods:
         type: void
         description: ''
   - name: setZoom(zoom)
-    uid: 'ExcelScript!ExcelScript.PageLayout#setZoom:member(1)'
+    uid: ExcelScript!ExcelScript.PageLayout#setZoom:member(1)
     package: ExcelScript!
     fullName: setZoom(zoom)
     summary: >-
-      The worksheet's print zoom options. The `PageLayoutZoomOptions` object must be set as a JSON object (use `x.zoom =
-      {...}` instead of `x.zoom.scale = ...`<!-- -->).
+      The worksheet's print zoom options. The `PageLayoutZoomOptions` object
+      must be set as a JSON object (use `x.zoom = {...}` instead of
+      `x.zoom.scale = ...`<!-- -->).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -838,7 +915,9 @@ methods:
       parameters:
         - id: zoom
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PageLayoutZoomOptions:interface" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.PageLayoutZoomOptions:interface"
+            />
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayoutmarginoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayoutmarginoptions.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.PageLayoutMarginOptions
-uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions:interface'
+uid: ExcelScript!ExcelScript.PageLayoutMarginOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.PageLayoutMarginOptions
 summary: Represents the options in page layout margins.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#bottom:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#bottom:member
     package: ExcelScript!
     fullName: bottom
-    summary: Specifies the page layout bottom margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout bottom margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,11 +26,14 @@ properties:
       return:
         type: number
   - name: footer
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#footer:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#footer:member
     package: ExcelScript!
     fullName: footer
-    summary: Specifies the page layout footer margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout footer margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -34,11 +41,14 @@ properties:
       return:
         type: number
   - name: header
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#header:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#header:member
     package: ExcelScript!
     fullName: header
-    summary: Specifies the page layout header margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout header margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -46,11 +56,14 @@ properties:
       return:
         type: number
   - name: left
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#left:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#left:member
     package: ExcelScript!
     fullName: left
-    summary: Specifies the page layout left margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout left margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -58,11 +71,14 @@ properties:
       return:
         type: number
   - name: right
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#right:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#right:member
     package: ExcelScript!
     fullName: right
-    summary: Specifies the page layout right margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout right margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -70,11 +86,14 @@ properties:
       return:
         type: number
   - name: top
-    uid: 'ExcelScript!ExcelScript.PageLayoutMarginOptions#top:member'
+    uid: ExcelScript!ExcelScript.PageLayoutMarginOptions#top:member
     package: ExcelScript!
     fullName: top
-    summary: Specifies the page layout top margin in the unit specified to use for printing.
+    summary: >-
+      Specifies the page layout top margin in the unit specified to use for
+      printing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayoutzoomoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pagelayoutzoomoptions.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.PageLayoutZoomOptions
-uid: 'ExcelScript!ExcelScript.PageLayoutZoomOptions:interface'
+uid: ExcelScript!ExcelScript.PageLayoutZoomOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.PageLayoutZoomOptions
 summary: Represents page zoom properties.
@@ -25,16 +25,20 @@ remarks: |-
       layout.setZoom(zoomOptions)
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: horizontalFitToPages
-    uid: 'ExcelScript!ExcelScript.PageLayoutZoomOptions#horizontalFitToPages:member'
+    uid: ExcelScript!ExcelScript.PageLayoutZoomOptions#horizontalFitToPages:member
     package: ExcelScript!
     fullName: horizontalFitToPages
-    summary: Number of pages to fit horizontally. This value can be `null` if percentage scale is used.
+    summary: >-
+      Number of pages to fit horizontally. This value can be `null` if
+      percentage scale is used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,13 +46,14 @@ properties:
       return:
         type: number
   - name: scale
-    uid: 'ExcelScript!ExcelScript.PageLayoutZoomOptions#scale:member'
+    uid: ExcelScript!ExcelScript.PageLayoutZoomOptions#scale:member
     package: ExcelScript!
     fullName: scale
     summary: >-
-      Print page scale value can be between 10 and 400. This value can be `null` if fit to page tall or wide is
-      specified.
+      Print page scale value can be between 10 and 400. This value can be `null`
+      if fit to page tall or wide is specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -56,11 +61,14 @@ properties:
       return:
         type: number
   - name: verticalFitToPages
-    uid: 'ExcelScript!ExcelScript.PageLayoutZoomOptions#verticalFitToPages:member'
+    uid: ExcelScript!ExcelScript.PageLayoutZoomOptions#verticalFitToPages:member
     package: ExcelScript!
     fullName: verticalFitToPages
-    summary: Number of pages to fit vertically. This value can be `null` if percentage scale is used.
+    summary: >-
+      Number of pages to fit vertically. This value can be `null` if percentage
+      scale is used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pageorientation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pageorientation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PageOrientation
-uid: 'ExcelScript!ExcelScript.PageOrientation:enum'
+uid: ExcelScript!ExcelScript.PageOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.PageOrientation
 summary: ''
@@ -23,14 +23,15 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: landscape
-    uid: 'ExcelScript!ExcelScript.PageOrientation.landscape:member'
+    uid: ExcelScript!ExcelScript.PageOrientation.landscape:member
     package: ExcelScript!
     summary: ''
   - name: portrait
-    uid: 'ExcelScript!ExcelScript.PageOrientation.portrait:member'
+    uid: ExcelScript!ExcelScript.PageOrientation.portrait:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.papertype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.papertype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PaperType
-uid: 'ExcelScript!ExcelScript.PaperType:enum'
+uid: ExcelScript!ExcelScript.PaperType:enum
 package: ExcelScript!
 fullName: ExcelScript.PaperType
 summary: ''
@@ -22,170 +22,171 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: a3
-    uid: 'ExcelScript!ExcelScript.PaperType.a3:member'
+    uid: ExcelScript!ExcelScript.PaperType.a3:member
     package: ExcelScript!
     summary: ''
   - name: a4
-    uid: 'ExcelScript!ExcelScript.PaperType.a4:member'
+    uid: ExcelScript!ExcelScript.PaperType.a4:member
     package: ExcelScript!
     summary: ''
   - name: a4Small
-    uid: 'ExcelScript!ExcelScript.PaperType.a4Small:member'
+    uid: ExcelScript!ExcelScript.PaperType.a4Small:member
     package: ExcelScript!
     summary: ''
   - name: a5
-    uid: 'ExcelScript!ExcelScript.PaperType.a5:member'
+    uid: ExcelScript!ExcelScript.PaperType.a5:member
     package: ExcelScript!
     summary: ''
   - name: b4
-    uid: 'ExcelScript!ExcelScript.PaperType.b4:member'
+    uid: ExcelScript!ExcelScript.PaperType.b4:member
     package: ExcelScript!
     summary: ''
   - name: b5
-    uid: 'ExcelScript!ExcelScript.PaperType.b5:member'
+    uid: ExcelScript!ExcelScript.PaperType.b5:member
     package: ExcelScript!
     summary: ''
   - name: csheet
-    uid: 'ExcelScript!ExcelScript.PaperType.csheet:member'
+    uid: ExcelScript!ExcelScript.PaperType.csheet:member
     package: ExcelScript!
     summary: ''
   - name: dsheet
-    uid: 'ExcelScript!ExcelScript.PaperType.dsheet:member'
+    uid: ExcelScript!ExcelScript.PaperType.dsheet:member
     package: ExcelScript!
     summary: ''
   - name: envelope10
-    uid: 'ExcelScript!ExcelScript.PaperType.envelope10:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelope10:member
     package: ExcelScript!
     summary: ''
   - name: envelope11
-    uid: 'ExcelScript!ExcelScript.PaperType.envelope11:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelope11:member
     package: ExcelScript!
     summary: ''
   - name: envelope12
-    uid: 'ExcelScript!ExcelScript.PaperType.envelope12:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelope12:member
     package: ExcelScript!
     summary: ''
   - name: envelope14
-    uid: 'ExcelScript!ExcelScript.PaperType.envelope14:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelope14:member
     package: ExcelScript!
     summary: ''
   - name: envelope9
-    uid: 'ExcelScript!ExcelScript.PaperType.envelope9:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelope9:member
     package: ExcelScript!
     summary: ''
   - name: envelopeB4
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeB4:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeB4:member
     package: ExcelScript!
     summary: ''
   - name: envelopeB5
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeB5:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeB5:member
     package: ExcelScript!
     summary: ''
   - name: envelopeB6
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeB6:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeB6:member
     package: ExcelScript!
     summary: ''
   - name: envelopeC3
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeC3:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeC3:member
     package: ExcelScript!
     summary: ''
   - name: envelopeC4
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeC4:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeC4:member
     package: ExcelScript!
     summary: ''
   - name: envelopeC5
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeC5:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeC5:member
     package: ExcelScript!
     summary: ''
   - name: envelopeC6
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeC6:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeC6:member
     package: ExcelScript!
     summary: ''
   - name: envelopeC65
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeC65:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeC65:member
     package: ExcelScript!
     summary: ''
   - name: envelopeDL
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeDL:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeDL:member
     package: ExcelScript!
     summary: ''
   - name: envelopeItaly
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeItaly:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeItaly:member
     package: ExcelScript!
     summary: ''
   - name: envelopeMonarch
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopeMonarch:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopeMonarch:member
     package: ExcelScript!
     summary: ''
   - name: envelopePersonal
-    uid: 'ExcelScript!ExcelScript.PaperType.envelopePersonal:member'
+    uid: ExcelScript!ExcelScript.PaperType.envelopePersonal:member
     package: ExcelScript!
     summary: ''
   - name: esheet
-    uid: 'ExcelScript!ExcelScript.PaperType.esheet:member'
+    uid: ExcelScript!ExcelScript.PaperType.esheet:member
     package: ExcelScript!
     summary: ''
   - name: executive
-    uid: 'ExcelScript!ExcelScript.PaperType.executive:member'
+    uid: ExcelScript!ExcelScript.PaperType.executive:member
     package: ExcelScript!
     summary: ''
   - name: fanfoldLegalGerman
-    uid: 'ExcelScript!ExcelScript.PaperType.fanfoldLegalGerman:member'
+    uid: ExcelScript!ExcelScript.PaperType.fanfoldLegalGerman:member
     package: ExcelScript!
     summary: ''
   - name: fanfoldStdGerman
-    uid: 'ExcelScript!ExcelScript.PaperType.fanfoldStdGerman:member'
+    uid: ExcelScript!ExcelScript.PaperType.fanfoldStdGerman:member
     package: ExcelScript!
     summary: ''
   - name: fanfoldUS
-    uid: 'ExcelScript!ExcelScript.PaperType.fanfoldUS:member'
+    uid: ExcelScript!ExcelScript.PaperType.fanfoldUS:member
     package: ExcelScript!
     summary: ''
   - name: folio
-    uid: 'ExcelScript!ExcelScript.PaperType.folio:member'
+    uid: ExcelScript!ExcelScript.PaperType.folio:member
     package: ExcelScript!
     summary: ''
   - name: ledger
-    uid: 'ExcelScript!ExcelScript.PaperType.ledger:member'
+    uid: ExcelScript!ExcelScript.PaperType.ledger:member
     package: ExcelScript!
     summary: ''
   - name: legal
-    uid: 'ExcelScript!ExcelScript.PaperType.legal:member'
+    uid: ExcelScript!ExcelScript.PaperType.legal:member
     package: ExcelScript!
     summary: ''
   - name: letter
-    uid: 'ExcelScript!ExcelScript.PaperType.letter:member'
+    uid: ExcelScript!ExcelScript.PaperType.letter:member
     package: ExcelScript!
     summary: ''
   - name: letterSmall
-    uid: 'ExcelScript!ExcelScript.PaperType.letterSmall:member'
+    uid: ExcelScript!ExcelScript.PaperType.letterSmall:member
     package: ExcelScript!
     summary: ''
   - name: note
-    uid: 'ExcelScript!ExcelScript.PaperType.note:member'
+    uid: ExcelScript!ExcelScript.PaperType.note:member
     package: ExcelScript!
     summary: ''
   - name: paper10x14
-    uid: 'ExcelScript!ExcelScript.PaperType.paper10x14:member'
+    uid: ExcelScript!ExcelScript.PaperType.paper10x14:member
     package: ExcelScript!
     summary: ''
   - name: paper11x17
-    uid: 'ExcelScript!ExcelScript.PaperType.paper11x17:member'
+    uid: ExcelScript!ExcelScript.PaperType.paper11x17:member
     package: ExcelScript!
     summary: ''
   - name: quatro
-    uid: 'ExcelScript!ExcelScript.PaperType.quatro:member'
+    uid: ExcelScript!ExcelScript.PaperType.quatro:member
     package: ExcelScript!
     summary: ''
   - name: statement
-    uid: 'ExcelScript!ExcelScript.PaperType.statement:member'
+    uid: ExcelScript!ExcelScript.PaperType.statement:member
     package: ExcelScript!
     summary: ''
   - name: tabloid
-    uid: 'ExcelScript!ExcelScript.PaperType.tabloid:member'
+    uid: ExcelScript!ExcelScript.PaperType.tabloid:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pictureformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pictureformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PictureFormat
-uid: 'ExcelScript!ExcelScript.PictureFormat:enum'
+uid: ExcelScript!ExcelScript.PictureFormat:enum
 package: ExcelScript!
 fullName: ExcelScript.PictureFormat
 summary: The format of the image.
@@ -32,30 +32,31 @@ remarks: |-
     return star.getAsImage(ExcelScript.PictureFormat.png);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bmp
-    uid: 'ExcelScript!ExcelScript.PictureFormat.bmp:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.bmp:member
     package: ExcelScript!
     summary: Bitmap image.
   - name: gif
-    uid: 'ExcelScript!ExcelScript.PictureFormat.gif:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.gif:member
     package: ExcelScript!
     summary: Graphics Interchange Format.
   - name: jpeg
-    uid: 'ExcelScript!ExcelScript.PictureFormat.jpeg:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.jpeg:member
     package: ExcelScript!
     summary: Joint Photographic Experts Group.
   - name: png
-    uid: 'ExcelScript!ExcelScript.PictureFormat.png:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.png:member
     package: ExcelScript!
     summary: Portable Network Graphics.
   - name: svg
-    uid: 'ExcelScript!ExcelScript.PictureFormat.svg:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.svg:member
     package: ExcelScript!
     summary: Scalable Vector Graphic.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.PictureFormat.unknown:member'
+    uid: ExcelScript!ExcelScript.PictureFormat.unknown:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotaxis.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotaxis.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PivotAxis
-uid: 'ExcelScript!ExcelScript.PivotAxis:enum'
+uid: ExcelScript!ExcelScript.PivotAxis:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotAxis
 summary: Represents the axis from which to get the PivotItems.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: column
-    uid: 'ExcelScript!ExcelScript.PivotAxis.column:member'
+    uid: ExcelScript!ExcelScript.PivotAxis.column:member
     package: ExcelScript!
     summary: The column axis.
   - name: data
-    uid: 'ExcelScript!ExcelScript.PivotAxis.data:member'
+    uid: ExcelScript!ExcelScript.PivotAxis.data:member
     package: ExcelScript!
     summary: The data axis.
   - name: filter
-    uid: 'ExcelScript!ExcelScript.PivotAxis.filter:member'
+    uid: ExcelScript!ExcelScript.PivotAxis.filter:member
     package: ExcelScript!
     summary: The filter axis.
   - name: row
-    uid: 'ExcelScript!ExcelScript.PivotAxis.row:member'
+    uid: ExcelScript!ExcelScript.PivotAxis.row:member
     package: ExcelScript!
     summary: The row axis.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.PivotAxis.unknown:member'
+    uid: ExcelScript!ExcelScript.PivotAxis.unknown:member
     package: ExcelScript!
     summary: The axis or region is unknown or unsupported.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotdatefilter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotdatefilter.yml
@@ -1,42 +1,48 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotDateFilter
-uid: 'ExcelScript!ExcelScript.PivotDateFilter:interface'
+uid: ExcelScript!ExcelScript.PivotDateFilter:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotDateFilter
 summary: >-
-  Configurable template for a date filter to apply to a PivotField. The `condition` defines what criteria need to be set
-  in order for the filter to operate.
+  Configurable template for a date filter to apply to a PivotField. The
+  `condition` defines what criteria need to be set in order for the filter to
+  operate.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: comparator
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#comparator:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#comparator:member
     package: ExcelScript!
     fullName: comparator
     summary: >-
-      The comparator is the static value to which other values are compared. The type of comparison is defined by the
-      condition.
+      The comparator is the static value to which other values are compared. The
+      type of comparison is defined by the condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'comparator?: FilterDatetime;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />
   - name: condition
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#condition:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#condition:member
     package: ExcelScript!
     fullName: condition
-    summary: 'Specifies the condition for the filter, which defines the necessary filtering criteria.'
+    summary: >-
+      Specifies the condition for the filter, which defines the necessary
+      filtering criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'condition: DateFilterCondition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DateFilterCondition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DateFilterCondition:enum" />
         description: |-
 
 
@@ -65,13 +71,14 @@ properties:
           }
           ```
   - name: exclusive
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#exclusive:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#exclusive:member
     package: ExcelScript!
     fullName: exclusive
     summary: >-
-      If `true`<!-- -->, filter *excludes* items that meet criteria. The default is `false` (filter to include items
-      that meet criteria).
+      If `true`<!-- -->, filter *excludes* items that meet criteria. The
+      default is `false` (filter to include items that meet criteria).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,17 +86,18 @@ properties:
       return:
         type: boolean
   - name: lowerBound
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#lowerBound:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#lowerBound:member
     package: ExcelScript!
     fullName: lowerBound
     summary: The lower-bound of the range for the `between` filter condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'lowerBound?: FilterDatetime;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />
         description: |-
 
 
@@ -128,25 +136,27 @@ properties:
           }
           ```
   - name: upperBound
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#upperBound:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#upperBound:member
     package: ExcelScript!
     fullName: upperBound
     summary: The upper-bound of the range for the `between` filter condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'upperBound?: FilterDatetime;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterDatetime:interface" />
   - name: wholeDays
-    uid: 'ExcelScript!ExcelScript.PivotDateFilter#wholeDays:member'
+    uid: ExcelScript!ExcelScript.PivotDateFilter#wholeDays:member
     package: ExcelScript!
     fullName: wholeDays
     summary: >-
-      For `equals`<!-- -->, `before`<!-- -->, `after`<!-- -->, and `between` filter conditions, indicates if comparisons
-      should be made as whole days.
+      For `equals`<!-- -->, `before`<!-- -->, `after`<!-- -->, and `between`
+      filter conditions, indicates if comparisons should be made as whole days.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfield.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfield.yml
@@ -1,30 +1,35 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotField
-uid: 'ExcelScript!ExcelScript.PivotField:interface'
+uid: ExcelScript!ExcelScript.PivotField:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotField
 summary: Represents the Excel PivotField.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: applyFilter(filter)
-    uid: 'ExcelScript!ExcelScript.PivotField#applyFilter:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#applyFilter:member(1)
     package: ExcelScript!
     fullName: applyFilter(filter)
     summary: >-
-      Sets one or more of the field's current PivotFilters and applies them to the field. If the provided filters are
-      invalid or cannot be applied, an exception is thrown.
+      Sets one or more of the field's current PivotFilters and applies them to
+      the field. If the provided filters are invalid or cannot be applied, an
+      exception is thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'applyFilter(filter: PivotFilters): void;'
       parameters:
         - id: filter
-          description: 'A configured specific PivotFilter, or a PivotFilters interface containing multiple configured filters.'
-          type: '<xref uid="ExcelScript!ExcelScript.PivotFilters:interface" />'
+          description: >-
+            A configured specific PivotFilter, or a PivotFilters interface
+            containing multiple configured filters.
+          type: <xref uid="ExcelScript!ExcelScript.PivotFilters:interface" />
       return:
         type: void
         description: |-
@@ -61,11 +66,14 @@ methods:
           }
           ```
   - name: clearAllFilters()
-    uid: 'ExcelScript!ExcelScript.PivotField#clearAllFilters:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#clearAllFilters:member(1)
     package: ExcelScript!
     fullName: clearAllFilters()
-    summary: Clears all criteria from all of the field's filters. This removes any active filtering on the field.
+    summary: >-
+      Clears all criteria from all of the field's filters. This removes any
+      active filtering on the field.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -74,11 +82,14 @@ methods:
         type: void
         description: ''
   - name: clearFilter(filterType)
-    uid: 'ExcelScript!ExcelScript.PivotField#clearFilter:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#clearFilter:member(1)
     package: ExcelScript!
     fullName: clearFilter(filterType)
-    summary: Clears all existing criteria from the field's filter of the given type (if one is currently applied).
+    summary: >-
+      Clears all existing criteria from the field's filter of the given type (if
+      one is currently applied).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -86,7 +97,7 @@ methods:
       parameters:
         - id: filterType
           description: The type of filter on the field of which to clear all criteria.
-          type: '<xref uid="ExcelScript!ExcelScript.PivotFilterType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotFilterType:enum" />
       return:
         type: void
         description: |-
@@ -111,24 +122,26 @@ methods:
           }
           ```
   - name: getFilters()
-    uid: 'ExcelScript!ExcelScript.PivotField#getFilters:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getFilters:member(1)
     package: ExcelScript!
     fullName: getFilters()
     summary: Gets all filters currently applied on the field.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFilters(): PivotFilters;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotFilters:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotFilters:interface" />
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.PivotField#getId:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -137,24 +150,26 @@ methods:
         type: string
         description: ''
   - name: getItems()
-    uid: 'ExcelScript!ExcelScript.PivotField#getItems:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getItems:member(1)
     package: ExcelScript!
     fullName: getItems()
     summary: Returns the PivotItems associated with the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getItems(): PivotItem[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotItem:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotItem:interface" />[]
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PivotField#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -163,11 +178,14 @@ methods:
         type: string
         description: ''
   - name: getPivotItem(name)
-    uid: 'ExcelScript!ExcelScript.PivotField#getPivotItem:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getPivotItem:member(1)
     package: ExcelScript!
     fullName: getPivotItem(name)
-    summary: 'Gets a PivotItem by name. If the PivotItem does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotItem by name. If the PivotItem does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -177,14 +195,15 @@ methods:
           description: Name of the PivotItem to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotItem:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.PivotItem:interface" /> | undefined
         description: ''
   - name: getShowAllItems()
-    uid: 'ExcelScript!ExcelScript.PivotField#getShowAllItems:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getShowAllItems:member(1)
     package: ExcelScript!
     fullName: getShowAllItems()
     summary: Determines whether to show all items of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -193,41 +212,46 @@ methods:
         type: boolean
         description: ''
   - name: getSubtotals()
-    uid: 'ExcelScript!ExcelScript.PivotField#getSubtotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#getSubtotals:member(1)
     package: ExcelScript!
     fullName: getSubtotals()
     summary: Subtotals of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSubtotals(): Subtotals;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Subtotals:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Subtotals:interface" />
         description: ''
   - name: isFiltered(filterType)
-    uid: 'ExcelScript!ExcelScript.PivotField#isFiltered:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#isFiltered:member(1)
     package: ExcelScript!
     fullName: isFiltered(filterType)
     summary: Checks if there are any applied filters on the field.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'isFiltered(filterType?: PivotFilterType): boolean;'
       parameters:
         - id: filterType
-          description: 'The filter type to check. If no type is provided, this method will check if any filter is applied.'
-          type: '<xref uid="ExcelScript!ExcelScript.PivotFilterType:enum" />'
+          description: >-
+            The filter type to check. If no type is provided, this method will
+            check if any filter is applied.
+          type: <xref uid="ExcelScript!ExcelScript.PivotFilterType:enum" />
       return:
         type: boolean
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.PivotField#setName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -240,11 +264,12 @@ methods:
         type: void
         description: ''
   - name: setShowAllItems(showAllItems)
-    uid: 'ExcelScript!ExcelScript.PivotField#setShowAllItems:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#setShowAllItems:member(1)
     package: ExcelScript!
     fullName: setShowAllItems(showAllItems)
     summary: Determines whether to show all items of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -257,11 +282,12 @@ methods:
         type: void
         description: ''
   - name: setSubtotals(subtotals)
-    uid: 'ExcelScript!ExcelScript.PivotField#setSubtotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#setSubtotals:member(1)
     package: ExcelScript!
     fullName: setSubtotals(subtotals)
     summary: Subtotals of the PivotField.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -269,18 +295,20 @@ methods:
       parameters:
         - id: subtotals
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.Subtotals:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Subtotals:interface" />
       return:
         type: void
         description: ''
   - name: sortByLabels(sortBy)
-    uid: 'ExcelScript!ExcelScript.PivotField#sortByLabels:member(1)'
+    uid: ExcelScript!ExcelScript.PivotField#sortByLabels:member(1)
     package: ExcelScript!
     fullName: sortByLabels(sortBy)
     summary: >-
-      Sorts the PivotField. If a DataPivotHierarchy is specified, then sort will be applied based on it, if not sort
-      will be based on the PivotField itself.
+      Sorts the PivotField. If a DataPivotHierarchy is specified, then sort will
+      be applied based on it, if not sort will be based on the PivotField
+      itself.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -288,18 +316,20 @@ methods:
       parameters:
         - id: sortBy
           description: Specifies if the sorting is done in ascending or descending order.
-          type: '<xref uid="ExcelScript!ExcelScript.SortBy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortBy:enum" />
       return:
         type: void
         description: ''
-  - name: 'sortByValues(sortBy, valuesHierarchy, pivotItemScope)'
-    uid: 'ExcelScript!ExcelScript.PivotField#sortByValues:member(1)'
+  - name: sortByValues(sortBy, valuesHierarchy, pivotItemScope)
+    uid: ExcelScript!ExcelScript.PivotField#sortByValues:member(1)
     package: ExcelScript!
-    fullName: 'sortByValues(sortBy, valuesHierarchy, pivotItemScope)'
+    fullName: sortByValues(sortBy, valuesHierarchy, pivotItemScope)
     summary: >-
-      Sorts the PivotField by specified values in a given scope. The scope defines which specific values will be used to
-      sort when there are multiple values from the same DataPivotHierarchy.
+      Sorts the PivotField by specified values in a given scope. The scope
+      defines which specific values will be used to sort when there are multiple
+      values from the same DataPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -312,17 +342,22 @@ methods:
       parameters:
         - id: sortBy
           description: Specifies if the sorting is done in ascending or descending order.
-          type: '<xref uid="ExcelScript!ExcelScript.SortBy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortBy:enum" />
         - id: valuesHierarchy
-          description: Specifies the values hierarchy on the data axis to be used for sorting.
-          type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />'
+          description: >-
+            Specifies the values hierarchy on the data axis to be used for
+            sorting.
+          type: <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />
         - id: pivotItemScope
           description: >-
-            The items that should be used for the scope of the sorting. These will be the items that make up the row or
-            column that you want to sort on. If a string is used instead of a PivotItem, the string represents the ID of
-            the PivotItem. If there are no items other than data hierarchy on the axis you want to sort on, this can be
-            empty.
-          type: 'Array&lt;<xref uid="ExcelScript!ExcelScript.PivotItem:interface" /> | string&gt;'
+            The items that should be used for the scope of the sorting. These
+            will be the items that make up the row or column that you want to
+            sort on. If a string is used instead of a PivotItem, the string
+            represents the ID of the PivotItem. If there are no items other than
+            data hierarchy on the axis you want to sort on, this can be empty.
+          type: >-
+            Array&lt;<xref uid="ExcelScript!ExcelScript.PivotItem:interface" />
+            | string&gt;
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfilters.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfilters.yml
@@ -1,26 +1,32 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotFilters
-uid: 'ExcelScript!ExcelScript.PivotFilters:interface'
+uid: ExcelScript!ExcelScript.PivotFilters:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotFilters
-summary: An interface representing all PivotFilters currently applied to a given PivotField.
+summary: >-
+  An interface representing all PivotFilters currently applied to a given
+  PivotField.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: dateFilter
-    uid: 'ExcelScript!ExcelScript.PivotFilters#dateFilter:member'
+    uid: ExcelScript!ExcelScript.PivotFilters#dateFilter:member
     package: ExcelScript!
     fullName: dateFilter
-    summary: The PivotField's currently applied date filter. This property is `null` if no value filter is applied.
+    summary: >-
+      The PivotField's currently applied date filter. This property is `null` if
+      no value filter is applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'dateFilter?: PivotDateFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotDateFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotDateFilter:interface" />
         description: |-
 
 
@@ -49,17 +55,20 @@ properties:
           }
           ```
   - name: labelFilter
-    uid: 'ExcelScript!ExcelScript.PivotFilters#labelFilter:member'
+    uid: ExcelScript!ExcelScript.PivotFilters#labelFilter:member
     package: ExcelScript!
     fullName: labelFilter
-    summary: The PivotField's currently applied label filter. This property is `null` if no value filter is applied.
+    summary: >-
+      The PivotField's currently applied label filter. This property is `null`
+      if no value filter is applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'labelFilter?: PivotLabelFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotLabelFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotLabelFilter:interface" />
         description: |-
 
 
@@ -89,17 +98,20 @@ properties:
           }
           ```
   - name: manualFilter
-    uid: 'ExcelScript!ExcelScript.PivotFilters#manualFilter:member'
+    uid: ExcelScript!ExcelScript.PivotFilters#manualFilter:member
     package: ExcelScript!
     fullName: manualFilter
-    summary: The PivotField's currently applied manual filter. This property is `null` if no value filter is applied.
+    summary: >-
+      The PivotField's currently applied manual filter. This property is `null`
+      if no value filter is applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'manualFilter?: PivotManualFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotManualFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotManualFilter:interface" />
         description: |-
 
 
@@ -131,17 +143,20 @@ properties:
           }
           ```
   - name: valueFilter
-    uid: 'ExcelScript!ExcelScript.PivotFilters#valueFilter:member'
+    uid: ExcelScript!ExcelScript.PivotFilters#valueFilter:member
     package: ExcelScript!
     fullName: valueFilter
-    summary: The PivotField's currently applied value filter. This property is `null` if no value filter is applied.
+    summary: >-
+      The PivotField's currently applied value filter. This property is `null`
+      if no value filter is applied.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'valueFilter?: PivotValueFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotValueFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotValueFilter:interface" />
         description: |-
 
 

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfiltertopbottomcriterion.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfiltertopbottomcriterion.yml
@@ -1,38 +1,39 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PivotFilterTopBottomCriterion
-uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion:enum'
+uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotFilterTopBottomCriterion
 summary: Represents the criteria for the top/bottom values filter.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottomItems
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomItems:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomItems:member
     package: ExcelScript!
     summary: ''
   - name: bottomPercent
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomPercent:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomPercent:member
     package: ExcelScript!
     summary: ''
   - name: bottomSum
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomSum:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.bottomSum:member
     package: ExcelScript!
     summary: ''
   - name: invalid
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.invalid:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.invalid:member
     package: ExcelScript!
     summary: ''
   - name: topItems
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topItems:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topItems:member
     package: ExcelScript!
     summary: ''
   - name: topPercent
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topPercent:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topPercent:member
     package: ExcelScript!
     summary: ''
   - name: topSum
-    uid: 'ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topSum:member'
+    uid: ExcelScript!ExcelScript.PivotFilterTopBottomCriterion.topSum:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfiltertype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotfiltertype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PivotFilterType
-uid: 'ExcelScript!ExcelScript.PivotFilterType:enum'
+uid: ExcelScript!ExcelScript.PivotFilterType:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotFilterType
 summary: A simple enum that represents a type of filter for a PivotField.
@@ -25,30 +25,33 @@ remarks: |-
     typeField.clearFilter(ExcelScript.PivotFilterType.value);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: date
-    uid: 'ExcelScript!ExcelScript.PivotFilterType.date:member'
+    uid: ExcelScript!ExcelScript.PivotFilterType.date:member
     package: ExcelScript!
     summary: >-
-      Filters PivotItems with a date in place of a label. Note: A PivotField cannot simultaneously have a label filter
-      and a date filter applied.
+      Filters PivotItems with a date in place of a label. Note: A PivotField
+      cannot simultaneously have a label filter and a date filter applied.
   - name: label
-    uid: 'ExcelScript!ExcelScript.PivotFilterType.label:member'
+    uid: ExcelScript!ExcelScript.PivotFilterType.label:member
     package: ExcelScript!
     summary: >-
-      Filters PivotItems based on their labels. Note: A PivotField cannot simultaneously have a label filter and a date
-      filter applied.
+      Filters PivotItems based on their labels. Note: A PivotField cannot
+      simultaneously have a label filter and a date filter applied.
   - name: manual
-    uid: 'ExcelScript!ExcelScript.PivotFilterType.manual:member'
+    uid: ExcelScript!ExcelScript.PivotFilterType.manual:member
     package: ExcelScript!
     summary: Filters specific manually selected PivotItems from the PivotTable.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.PivotFilterType.unknown:member'
+    uid: ExcelScript!ExcelScript.PivotFilterType.unknown:member
     package: ExcelScript!
     summary: '`PivotFilterType` is unknown or unsupported.'
   - name: value
-    uid: 'ExcelScript!ExcelScript.PivotFilterType.value:member'
+    uid: ExcelScript!ExcelScript.PivotFilterType.value:member
     package: ExcelScript!
-    summary: Filters based on the value of a PivotItem with respect to a `DataPivotHierarchy`<!-- -->.
+    summary: >-
+      Filters based on the value of a PivotItem with respect to a
+      `DataPivotHierarchy`<!-- -->.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivothierarchy.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotHierarchy
-uid: 'ExcelScript!ExcelScript.PivotHierarchy:interface'
+uid: ExcelScript!ExcelScript.PivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotHierarchy
 summary: Represents the Excel PivotHierarchy.
@@ -28,29 +28,32 @@ remarks: |-
     pivotTable.addDataHierarchy(pivotTable.getHierarchy("Sales"));
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFields()
-    uid: 'ExcelScript!ExcelScript.PivotHierarchy#getFields:member(1)'
+    uid: ExcelScript!ExcelScript.PivotHierarchy#getFields:member(1)
     package: ExcelScript!
     fullName: getFields()
     summary: Returns the PivotFields associated with the PivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFields(): PivotField[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.PivotHierarchy#getId:member(1)'
+    uid: ExcelScript!ExcelScript.PivotHierarchy#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the PivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -59,11 +62,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PivotHierarchy#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotHierarchy#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the PivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,11 +76,14 @@ methods:
         type: string
         description: ''
   - name: getPivotField(name)
-    uid: 'ExcelScript!ExcelScript.PivotHierarchy#getPivotField:member(1)'
+    uid: ExcelScript!ExcelScript.PivotHierarchy#getPivotField:member(1)
     package: ExcelScript!
     fullName: getPivotField(name)
-    summary: 'Gets a PivotField by name. If the PivotField does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotField by name. If the PivotField does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -86,14 +93,17 @@ methods:
           description: Name of the PivotField to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotField:interface" /> |
+          undefined
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.PivotHierarchy#setName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotHierarchy#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the PivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotitem.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotitem.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotItem
-uid: 'ExcelScript!ExcelScript.PivotItem:interface'
+uid: ExcelScript!ExcelScript.PivotItem:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotItem
 summary: Represents the Excel PivotItem.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.PivotItem#getId:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the PivotItem.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,14 @@ methods:
         type: string
         description: ''
   - name: getIsExpanded()
-    uid: 'ExcelScript!ExcelScript.PivotItem#getIsExpanded:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#getIsExpanded:member(1)
     package: ExcelScript!
     fullName: getIsExpanded()
-    summary: Determines whether the item is expanded to show child items or if it's collapsed and child items are hidden.
+    summary: >-
+      Determines whether the item is expanded to show child items or if it's
+      collapsed and child items are hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +41,12 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PivotItem#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the PivotItem.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +55,12 @@ methods:
         type: string
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.PivotItem#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the PivotItem is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +69,14 @@ methods:
         type: boolean
         description: ''
   - name: setIsExpanded(isExpanded)
-    uid: 'ExcelScript!ExcelScript.PivotItem#setIsExpanded:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#setIsExpanded:member(1)
     package: ExcelScript!
     fullName: setIsExpanded(isExpanded)
-    summary: Determines whether the item is expanded to show child items or if it's collapsed and child items are hidden.
+    summary: >-
+      Determines whether the item is expanded to show child items or if it's
+      collapsed and child items are hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,11 +89,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.PivotItem#setName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the PivotItem.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -96,11 +107,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.PivotItem#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.PivotItem#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the PivotItem is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlabelfilter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlabelfilter.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotLabelFilter
-uid: 'ExcelScript!ExcelScript.PivotLabelFilter:interface'
+uid: ExcelScript!ExcelScript.PivotLabelFilter:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotLabelFilter
 summary: >-
-  Configurable template for a label filter to apply to a PivotField. The `condition` defines what criteria need to be
-  set in order for the filter to operate.
+  Configurable template for a label filter to apply to a PivotField. The
+  `condition` defines what criteria need to be set in order for the filter to
+  operate.
 remarks: |-
 
 
@@ -34,18 +35,21 @@ remarks: |-
     field.applyFilter({ labelFilter: filter });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: comparator
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#comparator:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#comparator:member
     package: ExcelScript!
     fullName: comparator
     summary: >-
-      The comparator is the static value to which other values are compared. The type of comparison is defined by the
-      condition. Note: A numeric string is treated as a number when being compared against other numeric strings.
+      The comparator is the static value to which other values are compared. The
+      type of comparison is defined by the condition. Note: A numeric string is
+      treated as a number when being compared against other numeric strings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -53,25 +57,29 @@ properties:
       return:
         type: string
   - name: condition
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#condition:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#condition:member
     package: ExcelScript!
     fullName: condition
-    summary: 'Specifies the condition for the filter, which defines the necessary filtering criteria.'
+    summary: >-
+      Specifies the condition for the filter, which defines the necessary
+      filtering criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'condition: LabelFilterCondition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LabelFilterCondition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.LabelFilterCondition:enum" />
   - name: exclusive
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#exclusive:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#exclusive:member
     package: ExcelScript!
     fullName: exclusive
     summary: >-
-      If `true`<!-- -->, filter *excludes* items that meet criteria. The default is `false` (filter to include items
-      that meet criteria).
+      If `true`<!-- -->, filter *excludes* items that meet criteria. The
+      default is `false` (filter to include items that meet criteria).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,13 +87,15 @@ properties:
       return:
         type: boolean
   - name: lowerBound
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#lowerBound:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#lowerBound:member
     package: ExcelScript!
     fullName: lowerBound
     summary: >-
-      The lower-bound of the range for the `between` filter condition. Note: A numeric string is treated as a number
-      when being compared against other numeric strings.
+      The lower-bound of the range for the `between` filter condition. Note: A
+      numeric string is treated as a number when being compared against other
+      numeric strings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,11 +103,14 @@ properties:
       return:
         type: string
   - name: substring
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#substring:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#substring:member
     package: ExcelScript!
     fullName: substring
-    summary: 'The substring used for the `beginsWith`<!-- -->, `endsWith`<!-- -->, and `contains` filter conditions.'
+    summary: >-
+      The substring used for the `beginsWith`<!-- -->, `endsWith`<!-- -->, and
+      `contains` filter conditions.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -105,13 +118,15 @@ properties:
       return:
         type: string
   - name: upperBound
-    uid: 'ExcelScript!ExcelScript.PivotLabelFilter#upperBound:member'
+    uid: ExcelScript!ExcelScript.PivotLabelFilter#upperBound:member
     package: ExcelScript!
     fullName: upperBound
     summary: >-
-      The upper-bound of the range for the `between` filter condition. Note: A numeric string is treated as a number
-      when being compared against other numeric strings.
+      The upper-bound of the range for the `between` filter condition. Note: A
+      numeric string is treated as a number when being compared against other
+      numeric strings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayout.yml
@@ -1,23 +1,27 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotLayout
-uid: 'ExcelScript!ExcelScript.PivotLayout:interface'
+uid: ExcelScript!ExcelScript.PivotLayout:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotLayout
 summary: Represents the visual layout of the PivotTable.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: displayBlankLineAfterEachItem(display)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#displayBlankLineAfterEachItem:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PivotLayout#displayBlankLineAfterEachItem:member(1)
     package: ExcelScript!
     fullName: displayBlankLineAfterEachItem(display)
     summary: >-
-      Sets whether or not to display a blank line after each item. This is set at the global level for the PivotTable
-      and applied to individual PivotFields. This function overwrites the setting for all fields in the PivotTable to
-      the value of `display` parameter.
+      Sets whether or not to display a blank line after each item. This is set
+      at the global level for the PivotTable and applied to individual
+      PivotFields. This function overwrites the setting for all fields in the
+      PivotTable to the value of `display` parameter.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -30,18 +34,21 @@ methods:
         type: void
         description: ''
   - name: getAltTextDescription()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getAltTextDescription:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getAltTextDescription:member(1)
     package: ExcelScript!
     fullName: getAltTextDescription()
     summary: >-
       The alt text description of the PivotTable.
 
 
-      Alt text provides alternative, text-based representations of the information contained in the PivotTable. This
-      information is useful for people with vision or cognitive impairments who may not be able to see or understand the
-      table. A title can be read to a person with a disability and is used to determine whether they wish to hear the
-      description of the content.
+      Alt text provides alternative, text-based representations of the
+      information contained in the PivotTable. This information is useful for
+      people with vision or cognitive impairments who may not be able to see or
+      understand the table. A title can be read to a person with a disability
+      and is used to determine whether they wish to hear the description of the
+      content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,18 +57,21 @@ methods:
         type: string
         description: ''
   - name: getAltTextTitle()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getAltTextTitle:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getAltTextTitle:member(1)
     package: ExcelScript!
     fullName: getAltTextTitle()
     summary: >-
       The alt text title of the PivotTable.
 
 
-      Alt text provides alternative, text-based representations of the information contained in the PivotTable. This
-      information is useful for people with vision or cognitive impairments who may not be able to see or understand the
-      table. A title can be read to a person with a disability and is used to determine whether they wish to hear the
-      description of the content.
+      Alt text provides alternative, text-based representations of the
+      information contained in the PivotTable. This information is useful for
+      people with vision or cognitive impairments who may not be able to see or
+      understand the table. A title can be read to a person with a disability
+      and is used to determine whether they wish to hear the description of the
+      content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -70,11 +80,14 @@ methods:
         type: string
         description: ''
   - name: getAutoFormat()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getAutoFormat:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getAutoFormat:member(1)
     package: ExcelScript!
     fullName: getAutoFormat()
-    summary: Specifies if formatting will be automatically formatted when it's refreshed or when fields are moved.
+    summary: >-
+      Specifies if formatting will be automatically formatted when it's
+      refreshed or when fields are moved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -83,17 +96,18 @@ methods:
         type: boolean
         description: ''
   - name: getBodyAndTotalRange()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getBodyAndTotalRange:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getBodyAndTotalRange:member(1)
     package: ExcelScript!
     fullName: getBodyAndTotalRange()
     summary: Returns the range where the PivotTable's data values reside.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBodyAndTotalRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -124,24 +138,28 @@ methods:
           }
           ```
   - name: getColumnLabelRange()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getColumnLabelRange:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getColumnLabelRange:member(1)
     package: ExcelScript!
     fullName: getColumnLabelRange()
     summary: Returns the range where the PivotTable's column labels reside.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getColumnLabelRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getDataHierarchy(cell)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getDataHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getDataHierarchy:member(1)
     package: ExcelScript!
     fullName: getDataHierarchy(cell)
-    summary: Gets the DataHierarchy that is used to calculate the value in a specified range within the PivotTable.
+    summary: >-
+      Gets the DataHierarchy that is used to calculate the value in a specified
+      range within the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -149,19 +167,22 @@ methods:
       parameters:
         - id: cell
           description: A single cell within the PivotTable data body.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />
         description: ''
   - name: getEmptyCellText()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getEmptyCellText:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getEmptyCellText:member(1)
     package: ExcelScript!
     fullName: getEmptyCellText()
     summary: >-
-      The text that is automatically filled into any empty cell in the PivotTable if `fillEmptyCells == true`<!-- -->.
-      Note that this value persists if `fillEmptyCells` is set to `false`<!-- -->, and that setting this value does not
-      set that property to `true`<!-- -->. By default, this is an empty string.
+      The text that is automatically filled into any empty cell in the
+      PivotTable if `fillEmptyCells == true`<!-- -->. Note that this value
+      persists if `fillEmptyCells` is set to `false`<!-- -->, and that setting
+      this value does not set that property to `true`<!-- -->. By default, this
+      is an empty string.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -170,11 +191,12 @@ methods:
         type: string
         description: ''
   - name: getEnableFieldList()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getEnableFieldList:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getEnableFieldList:member(1)
     package: ExcelScript!
     fullName: getEnableFieldList()
     summary: Specifies if the field list can be shown in the UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -183,13 +205,16 @@ methods:
         type: boolean
         description: ''
   - name: getFillEmptyCells()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getFillEmptyCells:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getFillEmptyCells:member(1)
     package: ExcelScript!
     fullName: getFillEmptyCells()
     summary: >-
-      Specifies whether empty cells in the PivotTable should be populated with the `emptyCellText`<!-- -->. Default is
-      `false`<!-- -->. Note that the value of `emptyCellText` persists when this property is set to `false`<!-- -->.
+      Specifies whether empty cells in the PivotTable should be populated with
+      the `emptyCellText`<!-- -->. Default is `false`<!-- -->. Note that the
+      value of `emptyCellText` persists when this property is set to `false`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -198,41 +223,45 @@ methods:
         type: boolean
         description: ''
   - name: getFilterAxisRange()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getFilterAxisRange:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getFilterAxisRange:member(1)
     package: ExcelScript!
     fullName: getFilterAxisRange()
     summary: Returns the range of the PivotTable's filter area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFilterAxisRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getLayoutType()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getLayoutType:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getLayoutType:member(1)
     package: ExcelScript!
     fullName: getLayoutType()
     summary: >-
-      This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this
-      will be null.
+      This property indicates the PivotLayoutType of all fields on the
+      PivotTable. If fields have different states, this will be null.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLayoutType(): PivotLayoutType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotLayoutType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotLayoutType:enum" />
         description: ''
   - name: getPreserveFormatting()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getPreserveFormatting:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getPreserveFormatting:member(1)
     package: ExcelScript!
     fullName: getPreserveFormatting()
     summary: >-
-      Specifies if formatting is preserved when the report is refreshed or recalculated by operations such as pivoting,
-      sorting, or changing page field items.
+      Specifies if formatting is preserved when the report is refreshed or
+      recalculated by operations such as pivoting, sorting, or changing page
+      field items.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -241,37 +270,40 @@ methods:
         type: boolean
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
-    summary: 'Returns the range the PivotTable exists on, excluding the filter area.'
+    summary: Returns the range the PivotTable exists on, excluding the filter area.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRowLabelRange()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getRowLabelRange:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getRowLabelRange:member(1)
     package: ExcelScript!
     fullName: getRowLabelRange()
     summary: Returns the range where the PivotTable's row labels reside.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRowLabelRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getShowColumnGrandTotals()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getShowColumnGrandTotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getShowColumnGrandTotals:member(1)
     package: ExcelScript!
     fullName: getShowColumnGrandTotals()
     summary: Specifies if the PivotTable report shows grand totals for columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -280,11 +312,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowFieldHeaders()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getShowFieldHeaders:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getShowFieldHeaders:member(1)
     package: ExcelScript!
     fullName: getShowFieldHeaders()
-    summary: Specifies whether the PivotTable displays field headers (field captions and filter drop-downs).
+    summary: >-
+      Specifies whether the PivotTable displays field headers (field captions
+      and filter drop-downs).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -293,11 +328,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowRowGrandTotals()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getShowRowGrandTotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getShowRowGrandTotals:member(1)
     package: ExcelScript!
     fullName: getShowRowGrandTotals()
     summary: Specifies if the PivotTable report shows grand totals for rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -306,50 +342,59 @@ methods:
         type: boolean
         description: ''
   - name: getSubtotalLocation()
-    uid: 'ExcelScript!ExcelScript.PivotLayout#getSubtotalLocation:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#getSubtotalLocation:member(1)
     package: ExcelScript!
     fullName: getSubtotalLocation()
     summary: >-
-      This property indicates the `SubtotalLocationType` of all fields on the PivotTable. If fields have different
-      states, this will be `null`<!-- -->.
+      This property indicates the `SubtotalLocationType` of all fields on the
+      PivotTable. If fields have different states, this will be `null`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSubtotalLocation(): SubtotalLocationType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SubtotalLocationType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SubtotalLocationType:enum" />
         description: ''
   - name: repeatAllItemLabels(repeatLabels)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#repeatAllItemLabels:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#repeatAllItemLabels:member(1)
     package: ExcelScript!
     fullName: repeatAllItemLabels(repeatLabels)
-    summary: Sets the "repeat all item labels" setting across all fields in the PivotTable.
+    summary: >-
+      Sets the "repeat all item labels" setting across all fields in the
+      PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'repeatAllItemLabels(repeatLabels: boolean): void;'
       parameters:
         - id: repeatLabels
-          description: True turns on the label-repetition display setting. False turns it off.
+          description: >-
+            True turns on the label-repetition display setting. False turns it
+            off.
           type: boolean
       return:
         type: void
         description: ''
   - name: setAltTextDescription(altTextDescription)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setAltTextDescription:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setAltTextDescription:member(1)
     package: ExcelScript!
     fullName: setAltTextDescription(altTextDescription)
     summary: >-
       The alt text description of the PivotTable.
 
 
-      Alt text provides alternative, text-based representations of the information contained in the PivotTable. This
-      information is useful for people with vision or cognitive impairments who may not be able to see or understand the
-      table. A title can be read to a person with a disability and is used to determine whether they wish to hear the
-      description of the content.
+      Alt text provides alternative, text-based representations of the
+      information contained in the PivotTable. This information is useful for
+      people with vision or cognitive impairments who may not be able to see or
+      understand the table. A title can be read to a person with a disability
+      and is used to determine whether they wish to hear the description of the
+      content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -362,18 +407,21 @@ methods:
         type: void
         description: ''
   - name: setAltTextTitle(altTextTitle)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setAltTextTitle:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setAltTextTitle:member(1)
     package: ExcelScript!
     fullName: setAltTextTitle(altTextTitle)
     summary: >-
       The alt text title of the PivotTable.
 
 
-      Alt text provides alternative, text-based representations of the information contained in the PivotTable. This
-      information is useful for people with vision or cognitive impairments who may not be able to see or understand the
-      table. A title can be read to a person with a disability and is used to determine whether they wish to hear the
-      description of the content.
+      Alt text provides alternative, text-based representations of the
+      information contained in the PivotTable. This information is useful for
+      people with vision or cognitive impairments who may not be able to see or
+      understand the table. A title can be read to a person with a disability
+      and is used to determine whether they wish to hear the description of the
+      content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -386,11 +434,14 @@ methods:
         type: void
         description: ''
   - name: setAutoFormat(autoFormat)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setAutoFormat:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setAutoFormat:member(1)
     package: ExcelScript!
     fullName: setAutoFormat(autoFormat)
-    summary: Specifies if formatting will be automatically formatted when it's refreshed or when fields are moved.
+    summary: >-
+      Specifies if formatting will be automatically formatted when it's
+      refreshed or when fields are moved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -402,37 +453,44 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'setAutoSortOnCell(cell, sortBy)'
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setAutoSortOnCell:member(1)'
+  - name: setAutoSortOnCell(cell, sortBy)
+    uid: ExcelScript!ExcelScript.PivotLayout#setAutoSortOnCell:member(1)
     package: ExcelScript!
-    fullName: 'setAutoSortOnCell(cell, sortBy)'
+    fullName: setAutoSortOnCell(cell, sortBy)
     summary: >-
-      Sets the PivotTable to automatically sort using the specified cell to automatically select all necessary criteria
-      and context. This behaves identically to applying an autosort from the UI.
+      Sets the PivotTable to automatically sort using the specified cell to
+      automatically select all necessary criteria and context. This behaves
+      identically to applying an autosort from the UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setAutoSortOnCell(cell: Range | string, sortBy: SortBy): void;'
       parameters:
         - id: cell
-          description: A single cell to use get the criteria from for applying the autosort.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            A single cell to use get the criteria from for applying the
+            autosort.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: sortBy
           description: The direction of the sort.
-          type: '<xref uid="ExcelScript!ExcelScript.SortBy:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortBy:enum" />
       return:
         type: void
         description: ''
   - name: setEmptyCellText(emptyCellText)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setEmptyCellText:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setEmptyCellText:member(1)
     package: ExcelScript!
     fullName: setEmptyCellText(emptyCellText)
     summary: >-
-      The text that is automatically filled into any empty cell in the PivotTable if `fillEmptyCells == true`<!-- -->.
-      Note that this value persists if `fillEmptyCells` is set to `false`<!-- -->, and that setting this value does not
-      set that property to `true`<!-- -->. By default, this is an empty string.
+      The text that is automatically filled into any empty cell in the
+      PivotTable if `fillEmptyCells == true`<!-- -->. Note that this value
+      persists if `fillEmptyCells` is set to `false`<!-- -->, and that setting
+      this value does not set that property to `true`<!-- -->. By default, this
+      is an empty string.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -445,11 +503,12 @@ methods:
         type: void
         description: ''
   - name: setEnableFieldList(enableFieldList)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setEnableFieldList:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setEnableFieldList:member(1)
     package: ExcelScript!
     fullName: setEnableFieldList(enableFieldList)
     summary: Specifies if the field list can be shown in the UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -462,13 +521,16 @@ methods:
         type: void
         description: ''
   - name: setFillEmptyCells(fillEmptyCells)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setFillEmptyCells:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setFillEmptyCells:member(1)
     package: ExcelScript!
     fullName: setFillEmptyCells(fillEmptyCells)
     summary: >-
-      Specifies whether empty cells in the PivotTable should be populated with the `emptyCellText`<!-- -->. Default is
-      `false`<!-- -->. Note that the value of `emptyCellText` persists when this property is set to `false`<!-- -->.
+      Specifies whether empty cells in the PivotTable should be populated with
+      the `emptyCellText`<!-- -->. Default is `false`<!-- -->. Note that the
+      value of `emptyCellText` persists when this property is set to `false`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -481,13 +543,14 @@ methods:
         type: void
         description: ''
   - name: setLayoutType(layoutType)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setLayoutType:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setLayoutType:member(1)
     package: ExcelScript!
     fullName: setLayoutType(layoutType)
     summary: >-
-      This property indicates the PivotLayoutType of all fields on the PivotTable. If fields have different states, this
-      will be null.
+      This property indicates the PivotLayoutType of all fields on the
+      PivotTable. If fields have different states, this will be null.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -495,7 +558,7 @@ methods:
       parameters:
         - id: layoutType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PivotLayoutType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotLayoutType:enum" />
       return:
         type: void
         description: |-
@@ -520,13 +583,15 @@ methods:
           }
           ```
   - name: setPreserveFormatting(preserveFormatting)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setPreserveFormatting:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setPreserveFormatting:member(1)
     package: ExcelScript!
     fullName: setPreserveFormatting(preserveFormatting)
     summary: >-
-      Specifies if formatting is preserved when the report is refreshed or recalculated by operations such as pivoting,
-      sorting, or changing page field items.
+      Specifies if formatting is preserved when the report is refreshed or
+      recalculated by operations such as pivoting, sorting, or changing page
+      field items.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -539,11 +604,12 @@ methods:
         type: void
         description: ''
   - name: setShowColumnGrandTotals(showColumnGrandTotals)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setShowColumnGrandTotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setShowColumnGrandTotals:member(1)
     package: ExcelScript!
     fullName: setShowColumnGrandTotals(showColumnGrandTotals)
     summary: Specifies if the PivotTable report shows grand totals for columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -556,11 +622,14 @@ methods:
         type: void
         description: ''
   - name: setShowFieldHeaders(showFieldHeaders)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setShowFieldHeaders:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setShowFieldHeaders:member(1)
     package: ExcelScript!
     fullName: setShowFieldHeaders(showFieldHeaders)
-    summary: Specifies whether the PivotTable displays field headers (field captions and filter drop-downs).
+    summary: >-
+      Specifies whether the PivotTable displays field headers (field captions
+      and filter drop-downs).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -573,11 +642,12 @@ methods:
         type: void
         description: ''
   - name: setShowRowGrandTotals(showRowGrandTotals)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setShowRowGrandTotals:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setShowRowGrandTotals:member(1)
     package: ExcelScript!
     fullName: setShowRowGrandTotals(showRowGrandTotals)
     summary: Specifies if the PivotTable report shows grand totals for rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -590,13 +660,14 @@ methods:
         type: void
         description: ''
   - name: setSubtotalLocation(subtotalLocation)
-    uid: 'ExcelScript!ExcelScript.PivotLayout#setSubtotalLocation:member(1)'
+    uid: ExcelScript!ExcelScript.PivotLayout#setSubtotalLocation:member(1)
     package: ExcelScript!
     fullName: setSubtotalLocation(subtotalLocation)
     summary: >-
-      This property indicates the `SubtotalLocationType` of all fields on the PivotTable. If fields have different
-      states, this will be `null`<!-- -->.
+      This property indicates the `SubtotalLocationType` of all fields on the
+      PivotTable. If fields have different states, this will be `null`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -604,7 +675,7 @@ methods:
       parameters:
         - id: subtotalLocation
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.SubtotalLocationType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SubtotalLocationType:enum" />
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayouttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotlayouttype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PivotLayoutType
-uid: 'ExcelScript!ExcelScript.PivotLayoutType:enum'
+uid: ExcelScript!ExcelScript.PivotLayoutType:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotLayoutType
 summary: ''
@@ -25,18 +25,25 @@ remarks: |-
     layout.setLayoutType(ExcelScript.PivotLayoutType.tabular);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: compact
-    uid: 'ExcelScript!ExcelScript.PivotLayoutType.compact:member'
+    uid: ExcelScript!ExcelScript.PivotLayoutType.compact:member
     package: ExcelScript!
-    summary: A horizontally compressed form with labels from the next field in the same column.
+    summary: >-
+      A horizontally compressed form with labels from the next field in the same
+      column.
   - name: outline
-    uid: 'ExcelScript!ExcelScript.PivotLayoutType.outline:member'
+    uid: ExcelScript!ExcelScript.PivotLayoutType.outline:member
     package: ExcelScript!
-    summary: Inner fields' items are on same row as outer fields' items and subtotals are always on the bottom.
+    summary: >-
+      Inner fields' items are on same row as outer fields' items and subtotals
+      are always on the bottom.
   - name: tabular
-    uid: 'ExcelScript!ExcelScript.PivotLayoutType.tabular:member'
+    uid: ExcelScript!ExcelScript.PivotLayoutType.tabular:member
     package: ExcelScript!
-    summary: Inner fields' items are always on a new line relative to the outer fields' items.
+    summary: >-
+      Inner fields' items are always on a new line relative to the outer fields'
+      items.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotmanualfilter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotmanualfilter.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotManualFilter
-uid: 'ExcelScript!ExcelScript.PivotManualFilter:interface'
+uid: ExcelScript!ExcelScript.PivotManualFilter:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotManualFilter
 summary: >-
-  Configurable template for a manual filter to apply to a PivotField. The `condition` defines what criteria need to be
-  set in order for the filter to operate.
+  Configurable template for a manual filter to apply to a PivotField. The
+  `condition` defines what criteria need to be set in order for the filter to
+  operate.
 remarks: |-
 
 
@@ -38,19 +39,25 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: selectedItems
-    uid: 'ExcelScript!ExcelScript.PivotManualFilter#selectedItems:member'
+    uid: ExcelScript!ExcelScript.PivotManualFilter#selectedItems:member
     package: ExcelScript!
     fullName: selectedItems
-    summary: A list of selected items to manually filter. These must be existing and valid items from the chosen field.
+    summary: >-
+      A list of selected items to manually filter. These must be existing and
+      valid items from the chosen field.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'selectedItems?: (string | PivotItem)[];'
       return:
-        type: '(string | <xref uid="ExcelScript!ExcelScript.PivotItem:interface" />)[]'
+        type: >-
+          (string | <xref uid="ExcelScript!ExcelScript.PivotItem:interface"
+          />)[]

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivottable.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivottable.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotTable
-uid: 'ExcelScript!ExcelScript.PivotTable:interface'
+uid: ExcelScript!ExcelScript.PivotTable:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotTable
 summary: Represents an Excel PivotTable.
@@ -28,18 +28,21 @@ remarks: |-
     pivotTable.addDataHierarchy(pivotTable.getHierarchy("Sales"));
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: addColumnHierarchy(pivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#addColumnHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#addColumnHierarchy:member(1)
     package: ExcelScript!
     fullName: addColumnHierarchy(pivotHierarchy)
     summary: >-
-      Adds the PivotHierarchy to the current axis. If the hierarchy is present elsewhere on the row, column, or filter
-      axis, it will be removed from that location.
+      Adds the PivotHierarchy to the current axis. If the hierarchy is present
+      elsewhere on the row, column, or filter axis, it will be removed from that
+      location.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,9 +53,11 @@ methods:
       parameters:
         - id: pivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          />
         description: |-
 
 
@@ -81,11 +86,12 @@ methods:
           }
           ```
   - name: addDataHierarchy(pivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#addDataHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#addDataHierarchy:member(1)
     package: ExcelScript!
     fullName: addDataHierarchy(pivotHierarchy)
     summary: Adds the PivotHierarchy to the current axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,9 +99,9 @@ methods:
       parameters:
         - id: pivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />
         description: |-
 
 
@@ -121,13 +127,15 @@ methods:
           }
           ```
   - name: addFilterHierarchy(pivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#addFilterHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#addFilterHierarchy:member(1)
     package: ExcelScript!
     fullName: addFilterHierarchy(pivotHierarchy)
     summary: >-
-      Adds the PivotHierarchy to the current axis. If the hierarchy is present elsewhere on the row, column, or filter
-      axis, it will be removed from that location.
+      Adds the PivotHierarchy to the current axis. If the hierarchy is present
+      elsewhere on the row, column, or filter axis, it will be removed from that
+      location.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -138,9 +146,9 @@ methods:
       parameters:
         - id: pivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" />
         description: |-
 
 
@@ -172,13 +180,15 @@ methods:
           }
           ```
   - name: addRowHierarchy(pivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#addRowHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#addRowHierarchy:member(1)
     package: ExcelScript!
     fullName: addRowHierarchy(pivotHierarchy)
     summary: >-
-      Adds the PivotHierarchy to the current axis. If the hierarchy is present elsewhere on the row, column, or filter
-      axis, it will be removed from that location.
+      Adds the PivotHierarchy to the current axis. If the hierarchy is present
+      elsewhere on the row, column, or filter axis, it will be removed from that
+      location.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -189,9 +199,11 @@ methods:
       parameters:
         - id: pivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          />
         description: |-
 
 
@@ -217,11 +229,12 @@ methods:
           }
           ```
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.PivotTable#delete:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -230,11 +243,15 @@ methods:
         type: void
         description: ''
   - name: getAllowMultipleFiltersPerField()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getAllowMultipleFiltersPerField:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PivotTable#getAllowMultipleFiltersPerField:member(1)
     package: ExcelScript!
     fullName: getAllowMultipleFiltersPerField()
-    summary: Specifies if the PivotTable allows the application of multiple PivotFilters on a given PivotField in the table.
+    summary: >-
+      Specifies if the PivotTable allows the application of multiple
+      PivotFilters on a given PivotField in the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -243,26 +260,30 @@ methods:
         type: boolean
         description: ''
   - name: getColumnHierarchies()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getColumnHierarchies:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getColumnHierarchies:member(1)
     package: ExcelScript!
     fullName: getColumnHierarchies()
     summary: The Column Pivot Hierarchies of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getColumnHierarchies(): RowColumnPivotHierarchy[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          />[]
         description: ''
   - name: getColumnHierarchy(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#getColumnHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getColumnHierarchy:member(1)
     package: ExcelScript!
     fullName: getColumnHierarchy(name)
     summary: >-
-      Gets a RowColumnPivotHierarchy by name. If the RowColumnPivotHierarchy does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a RowColumnPivotHierarchy by name. If the RowColumnPivotHierarchy
+      does not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -272,29 +293,33 @@ methods:
           description: Name of the RowColumnPivotHierarchy to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          /> | undefined
         description: ''
   - name: getDataHierarchies()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getDataHierarchies:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getDataHierarchies:member(1)
     package: ExcelScript!
     fullName: getDataHierarchies()
     summary: The Data Pivot Hierarchies of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataHierarchies(): DataPivotHierarchy[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />[]
         description: ''
   - name: getDataHierarchy(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#getDataHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getDataHierarchy:member(1)
     package: ExcelScript!
     fullName: getDataHierarchy(name)
     summary: >-
-      Gets a DataPivotHierarchy by name. If the DataPivotHierarchy does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a DataPivotHierarchy by name. If the DataPivotHierarchy does not
+      exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -304,16 +329,20 @@ methods:
           description: Name of the DataPivotHierarchy to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" /> |
+          undefined
         description: ''
   - name: getDataSourceString()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getDataSourceString:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getDataSourceString:member(1)
     package: ExcelScript!
     fullName: getDataSourceString()
     summary: >-
-      Returns the string representation of the data source for the PivotTable. This method currently supports string
-      representations for table and range objects. Otherwise, it returns an empty string.
+      Returns the string representation of the data source for the PivotTable.
+      This method currently supports string representations for table and range
+      objects. Otherwise, it returns an empty string.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -322,24 +351,28 @@ methods:
         type: string
         description: ''
   - name: getDataSourceType()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getDataSourceType:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getDataSourceType:member(1)
     package: ExcelScript!
     fullName: getDataSourceType()
     summary: Gets the type of the data source for the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataSourceType(): DataSourceType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataSourceType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataSourceType:enum" />
         description: ''
   - name: getEnableDataValueEditing()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getEnableDataValueEditing:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getEnableDataValueEditing:member(1)
     package: ExcelScript!
     fullName: getEnableDataValueEditing()
-    summary: Specifies if the PivotTable allows values in the data body to be edited by the user.
+    summary: >-
+      Specifies if the PivotTable allows values in the data body to be edited by
+      the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -348,26 +381,30 @@ methods:
         type: boolean
         description: ''
   - name: getFilterHierarchies()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getFilterHierarchies:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getFilterHierarchies:member(1)
     package: ExcelScript!
     fullName: getFilterHierarchies()
     summary: The Filter Pivot Hierarchies of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFilterHierarchies(): FilterPivotHierarchy[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface"
+          />[]
         description: ''
   - name: getFilterHierarchy(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#getFilterHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getFilterHierarchy:member(1)
     package: ExcelScript!
     fullName: getFilterHierarchy(name)
     summary: >-
-      Gets a FilterPivotHierarchy by name. If the FilterPivotHierarchy does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a FilterPivotHierarchy by name. If the FilterPivotHierarchy does not
+      exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -377,27 +414,33 @@ methods:
           description: Name of the FilterPivotHierarchy to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" />
+          | undefined
         description: ''
   - name: getHierarchies()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getHierarchies:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getHierarchies:member(1)
     package: ExcelScript!
     fullName: getHierarchies()
     summary: The Pivot Hierarchies of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHierarchies(): PivotHierarchy[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" />[]
         description: ''
   - name: getHierarchy(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#getHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getHierarchy:member(1)
     package: ExcelScript!
     fullName: getHierarchy(name)
-    summary: 'Gets a PivotHierarchy by name. If the PivotHierarchy does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotHierarchy by name. If the PivotHierarchy does not exist, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -407,14 +450,17 @@ methods:
           description: Name of the PivotHierarchy to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotHierarchy:interface" /> |
+          undefined
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getId:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -423,17 +469,20 @@ methods:
         type: string
         description: ''
   - name: getLayout()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getLayout:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getLayout:member(1)
     package: ExcelScript!
     fullName: getLayout()
-    summary: The PivotLayout describing the layout and visual structure of the PivotTable.
+    summary: >-
+      The PivotLayout describing the layout and visual structure of the
+      PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLayout(): PivotLayout;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotLayout:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotLayout:interface" />
         description: |-
 
 
@@ -456,11 +505,12 @@ methods:
           }
           ```
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -469,26 +519,30 @@ methods:
         type: string
         description: ''
   - name: getRowHierarchies()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getRowHierarchies:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getRowHierarchies:member(1)
     package: ExcelScript!
     fullName: getRowHierarchies()
     summary: The Row Pivot Hierarchies of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRowHierarchies(): RowColumnPivotHierarchy[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          />[]
         description: ''
   - name: getRowHierarchy(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#getRowHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getRowHierarchy:member(1)
     package: ExcelScript!
     fullName: getRowHierarchy(name)
     summary: >-
-      Gets a RowColumnPivotHierarchy by name. If the RowColumnPivotHierarchy does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a RowColumnPivotHierarchy by name. If the RowColumnPivotHierarchy
+      does not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -498,7 +552,9 @@ methods:
           description: Name of the RowColumnPivotHierarchy to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface"
+          /> | undefined
         description: |-
 
 
@@ -523,11 +579,12 @@ methods:
           }
           ```
   - name: getUseCustomSortLists()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getUseCustomSortLists:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getUseCustomSortLists:member(1)
     package: ExcelScript!
     fullName: getUseCustomSortLists()
     summary: Specifies if the PivotTable uses custom lists when sorting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -536,24 +593,26 @@ methods:
         type: boolean
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.PivotTable#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: The worksheet containing the current PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: refresh()
-    uid: 'ExcelScript!ExcelScript.PivotTable#refresh:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#refresh:member(1)
     package: ExcelScript!
     fullName: refresh()
     summary: Refreshes the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -562,11 +621,12 @@ methods:
         type: void
         description: ''
   - name: removeColumnHierarchy(rowColumnPivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#removeColumnHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#removeColumnHierarchy:member(1)
     package: ExcelScript!
     fullName: removeColumnHierarchy(rowColumnPivotHierarchy)
     summary: Removes the PivotHierarchy from the current axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -577,16 +637,19 @@ methods:
       parameters:
         - id: rowColumnPivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />
       return:
         type: void
         description: ''
   - name: removeDataHierarchy(DataPivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#removeDataHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#removeDataHierarchy:member(1)
     package: ExcelScript!
     fullName: removeDataHierarchy(DataPivotHierarchy)
     summary: Removes the PivotHierarchy from the current axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -594,16 +657,17 @@ methods:
       parameters:
         - id: DataPivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.DataPivotHierarchy:interface" />
       return:
         type: void
         description: ''
   - name: removeFilterHierarchy(filterPivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#removeFilterHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#removeFilterHierarchy:member(1)
     package: ExcelScript!
     fullName: removeFilterHierarchy(filterPivotHierarchy)
     summary: Removes the PivotHierarchy from the current axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -611,16 +675,19 @@ methods:
       parameters:
         - id: filterPivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.FilterPivotHierarchy:interface"
+            />
       return:
         type: void
         description: ''
   - name: removeRowHierarchy(rowColumnPivotHierarchy)
-    uid: 'ExcelScript!ExcelScript.PivotTable#removeRowHierarchy:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#removeRowHierarchy:member(1)
     package: ExcelScript!
     fullName: removeRowHierarchy(rowColumnPivotHierarchy)
     summary: Removes the PivotHierarchy from the current axis.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -631,16 +698,22 @@ methods:
       parameters:
         - id: rowColumnPivotHierarchy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface" />
       return:
         type: void
         description: ''
   - name: setAllowMultipleFiltersPerField(allowMultipleFiltersPerField)
-    uid: 'ExcelScript!ExcelScript.PivotTable#setAllowMultipleFiltersPerField:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PivotTable#setAllowMultipleFiltersPerField:member(1)
     package: ExcelScript!
     fullName: setAllowMultipleFiltersPerField(allowMultipleFiltersPerField)
-    summary: Specifies if the PivotTable allows the application of multiple PivotFilters on a given PivotField in the table.
+    summary: >-
+      Specifies if the PivotTable allows the application of multiple
+      PivotFilters on a given PivotField in the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -656,11 +729,14 @@ methods:
         type: void
         description: ''
   - name: setEnableDataValueEditing(enableDataValueEditing)
-    uid: 'ExcelScript!ExcelScript.PivotTable#setEnableDataValueEditing:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#setEnableDataValueEditing:member(1)
     package: ExcelScript!
     fullName: setEnableDataValueEditing(enableDataValueEditing)
-    summary: Specifies if the PivotTable allows values in the data body to be edited by the user.
+    summary: >-
+      Specifies if the PivotTable allows values in the data body to be edited by
+      the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -673,11 +749,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.PivotTable#setName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the PivotTable.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -690,11 +767,12 @@ methods:
         type: void
         description: ''
   - name: setUseCustomSortLists(useCustomSortLists)
-    uid: 'ExcelScript!ExcelScript.PivotTable#setUseCustomSortLists:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTable#setUseCustomSortLists:member(1)
     package: ExcelScript!
     fullName: setUseCustomSortLists(useCustomSortLists)
     summary: Specifies if the PivotTable uses custom lists when sorting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivottablestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivottablestyle.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotTableStyle
-uid: 'ExcelScript!ExcelScript.PivotTableStyle:interface'
+uid: ExcelScript!ExcelScript.PivotTableStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotTableStyle
-summary: 'Represents a PivotTable style, which defines style elements by PivotTable region.'
+summary: >-
+  Represents a PivotTable style, which defines style elements by PivotTable
+  region.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.PivotTableStyle#delete:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTableStyle#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the PivotTable style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,28 @@ methods:
         type: void
         description: ''
   - name: duplicate()
-    uid: 'ExcelScript!ExcelScript.PivotTableStyle#duplicate:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTableStyle#duplicate:member(1)
     package: ExcelScript!
     fullName: duplicate()
-    summary: Creates a duplicate of this PivotTable style with copies of all the style elements.
+    summary: >-
+      Creates a duplicate of this PivotTable style with copies of all the style
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'duplicate(): PivotTableStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PivotTableStyle#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTableStyle#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the PivotTable style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: string
         description: ''
   - name: getReadOnly()
-    uid: 'ExcelScript!ExcelScript.PivotTableStyle#getReadOnly:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTableStyle#getReadOnly:member(1)
     package: ExcelScript!
     fullName: getReadOnly()
     summary: Specifies if this `PivotTableStyle` object is read-only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,12 @@ methods:
         type: boolean
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.PivotTableStyle#setName:member(1)'
+    uid: ExcelScript!ExcelScript.PivotTableStyle#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the PivotTable style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotvaluefilter.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.pivotvaluefilter.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSType
 name: ExcelScript.PivotValueFilter
-uid: 'ExcelScript!ExcelScript.PivotValueFilter:interface'
+uid: ExcelScript!ExcelScript.PivotValueFilter:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotValueFilter
 summary: >-
-  Configurable template for a value filter to apply to a PivotField. The `condition` defines what criteria need to be
-  set in order for the filter to operate.
+  Configurable template for a value filter to apply to a PivotField. The
+  `condition` defines what criteria need to be set in order for the filter to
+  operate.
 remarks: |-
 
 
@@ -39,19 +40,22 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: comparator
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#comparator:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#comparator:member
     package: ExcelScript!
     fullName: comparator
     summary: >-
-      The comparator is the static value to which other values are compared. The type of comparison is defined by the
-      condition. For example, if comparator is "50" and condition is "greaterThan", all item values that are not greater
-      than 50 will be removed by the filter.
+      The comparator is the static value to which other values are compared. The
+      type of comparison is defined by the condition. For example, if comparator
+      is "50" and condition is "greaterThan", all item values that are not
+      greater than 50 will be removed by the filter.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -59,25 +63,29 @@ properties:
       return:
         type: number
   - name: condition
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#condition:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#condition:member
     package: ExcelScript!
     fullName: condition
-    summary: 'Specifies the condition for the filter, which defines the necessary filtering criteria.'
+    summary: >-
+      Specifies the condition for the filter, which defines the necessary
+      filtering criteria.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'condition: ValueFilterCondition;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ValueFilterCondition:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ValueFilterCondition:enum" />
   - name: exclusive
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#exclusive:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#exclusive:member
     package: ExcelScript!
     fullName: exclusive
     summary: >-
-      If `true`<!-- -->, filter *excludes* items that meet criteria. The default is `false` (filter to include items
-      that meet criteria).
+      If `true`<!-- -->, filter *excludes* items that meet criteria. The
+      default is `false` (filter to include items that meet criteria).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -85,11 +93,12 @@ properties:
       return:
         type: boolean
   - name: lowerBound
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#lowerBound:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#lowerBound:member
     package: ExcelScript!
     fullName: lowerBound
     summary: The lower-bound of the range for the `between` filter condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -97,23 +106,29 @@ properties:
       return:
         type: number
   - name: selectionType
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#selectionType:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#selectionType:member
     package: ExcelScript!
     fullName: selectionType
-    summary: 'Specifies if the filter is for the top/bottom N items, top/bottom N percent, or top/bottom N sum.'
+    summary: >-
+      Specifies if the filter is for the top/bottom N items, top/bottom N
+      percent, or top/bottom N sum.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'selectionType?: TopBottomSelectionType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TopBottomSelectionType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.TopBottomSelectionType:enum" />
   - name: threshold
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#threshold:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#threshold:member
     package: ExcelScript!
     fullName: threshold
-    summary: 'The "N" threshold number of items, percent, or sum to be filtered for a top/bottom filter condition.'
+    summary: >-
+      The "N" threshold number of items, percent, or sum to be filtered for a
+      top/bottom filter condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -121,11 +136,12 @@ properties:
       return:
         type: number
   - name: upperBound
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#upperBound:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#upperBound:member
     package: ExcelScript!
     fullName: upperBound
     summary: The upper-bound of the range for the `between` filter condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -133,11 +149,12 @@ properties:
       return:
         type: number
   - name: value
-    uid: 'ExcelScript!ExcelScript.PivotValueFilter#value:member'
+    uid: ExcelScript!ExcelScript.PivotValueFilter#value:member
     package: ExcelScript!
     fullName: value
     summary: Name of the chosen "value" in the field by which to filter.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.placement.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.placement.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.Placement
-uid: 'ExcelScript!ExcelScript.Placement:enum'
+uid: ExcelScript!ExcelScript.Placement:enum
 package: ExcelScript!
 fullName: ExcelScript.Placement
 summary: Specifies the way that an object is attached to its underlying cells.
@@ -31,18 +31,19 @@ remarks: |-
     diamond.setPlacement(ExcelScript.Placement.twoCell);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: absolute
-    uid: 'ExcelScript!ExcelScript.Placement.absolute:member'
+    uid: ExcelScript!ExcelScript.Placement.absolute:member
     package: ExcelScript!
     summary: The object is free floating.
   - name: oneCell
-    uid: 'ExcelScript!ExcelScript.Placement.oneCell:member'
+    uid: ExcelScript!ExcelScript.Placement.oneCell:member
     package: ExcelScript!
     summary: The object is moved with the cells.
   - name: twoCell
-    uid: 'ExcelScript!ExcelScript.Placement.twoCell:member'
+    uid: ExcelScript!ExcelScript.Placement.twoCell:member
     package: ExcelScript!
     summary: The object is moved and sized with the cells.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.predefinedcellstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.predefinedcellstyle.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.PredefinedCellStyle
-uid: 'ExcelScript!ExcelScript.PredefinedCellStyle:interface'
+uid: ExcelScript!ExcelScript.PredefinedCellStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.PredefinedCellStyle
 summary: An object encapsulating a style's format and other properties.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#delete:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes this style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,11 +25,14 @@ methods:
         type: void
         description: ''
   - name: getAutoIndent()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getAutoIndent:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getAutoIndent:member(1)
     package: ExcelScript!
     fullName: getAutoIndent()
-    summary: Specifies if text is automatically indented when the text alignment in a cell is set to equal distribution.
+    summary: >-
+      Specifies if text is automatically indented when the text alignment in a
+      cell is set to equal distribution.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,24 +41,28 @@ methods:
         type: boolean
         description: ''
   - name: getBorders()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getBorders:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getBorders:member(1)
     package: ExcelScript!
     fullName: getBorders()
-    summary: A collection of four border objects that represent the style of the four borders.
+    summary: >-
+      A collection of four border objects that represent the style of the four
+      borders.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorders(): RangeBorder[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />[]
         description: ''
   - name: getBuiltIn()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getBuiltIn:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getBuiltIn:member(1)
     package: ExcelScript!
     fullName: getBuiltIn()
     summary: Specifies if the style is a built-in style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,37 +71,40 @@ methods:
         type: boolean
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: The fill of the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): RangeFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFill:interface" />
         description: ''
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
     summary: A `Font` object that represents the font of the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): RangeFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFont:interface" />
         description: ''
   - name: getFormulaHidden()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getFormulaHidden:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getFormulaHidden:member(1)
     package: ExcelScript!
     fullName: getFormulaHidden()
     summary: Specifies if the formula will be hidden when the worksheet is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,26 +113,32 @@ methods:
         type: boolean
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getHorizontalAlignment:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PredefinedCellStyle#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
-    summary: Represents the horizontal alignment for the style. See `ExcelScript.HorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment for the style. See
+      `ExcelScript.HorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): HorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />
         description: ''
   - name: getIncludeAlignment()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeAlignment:member(1)
     package: ExcelScript!
     fullName: getIncludeAlignment()
     summary: >-
-      Specifies if the style includes the auto indent, horizontal alignment, vertical alignment, wrap text, indent
-      level, and text orientation properties.
+      Specifies if the style includes the auto indent, horizontal alignment,
+      vertical alignment, wrap text, indent level, and text orientation
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -129,11 +147,14 @@ methods:
         type: boolean
         description: ''
   - name: getIncludeBorder()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeBorder:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeBorder:member(1)
     package: ExcelScript!
     fullName: getIncludeBorder()
-    summary: 'Specifies if the style includes the color, color index, line style, and weight border properties.'
+    summary: >-
+      Specifies if the style includes the color, color index, line style, and
+      weight border properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -142,13 +163,15 @@ methods:
         type: boolean
         description: ''
   - name: getIncludeFont()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeFont:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeFont:member(1)
     package: ExcelScript!
     fullName: getIncludeFont()
     summary: >-
-      Specifies if the style includes the background, bold, color, color index, font style, italic, name, size,
-      strikethrough, subscript, superscript, and underline font properties.
+      Specifies if the style includes the background, bold, color, color index,
+      font style, italic, name, size, strikethrough, subscript, superscript, and
+      underline font properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -157,11 +180,12 @@ methods:
         type: boolean
         description: ''
   - name: getIncludeNumber()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeNumber:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeNumber:member(1)
     package: ExcelScript!
     fullName: getIncludeNumber()
     summary: Specifies if the style includes the number format property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -170,13 +194,15 @@ methods:
         type: boolean
         description: ''
   - name: getIncludePatterns()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludePatterns:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludePatterns:member(1)
     package: ExcelScript!
     fullName: getIncludePatterns()
     summary: >-
-      Specifies if the style includes the color, color index, invert if negative, pattern, pattern color, and pattern
-      color index interior properties.
+      Specifies if the style includes the color, color index, invert if
+      negative, pattern, pattern color, and pattern color index interior
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -185,11 +211,14 @@ methods:
         type: boolean
         description: ''
   - name: getIncludeProtection()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeProtection:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIncludeProtection:member(1)
     package: ExcelScript!
     fullName: getIncludeProtection()
-    summary: Specifies if the style includes the formula hidden and locked protection properties.
+    summary: >-
+      Specifies if the style includes the formula hidden and locked protection
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -198,11 +227,12 @@ methods:
         type: boolean
         description: ''
   - name: getIndentLevel()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getIndentLevel:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getIndentLevel:member(1)
     package: ExcelScript!
     fullName: getIndentLevel()
     summary: An integer from 0 to 250 that indicates the indent level for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -211,11 +241,12 @@ methods:
         type: number
         description: ''
   - name: getLocked()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getLocked:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getLocked:member(1)
     package: ExcelScript!
     fullName: getLocked()
     summary: Specifies if the object is locked when the worksheet is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -224,11 +255,12 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getName:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: The name of the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -237,11 +269,12 @@ methods:
         type: string
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: The format code of the number format for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -250,11 +283,12 @@ methods:
         type: string
         description: ''
   - name: getNumberFormatLocal()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getNumberFormatLocal:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getNumberFormatLocal:member(1)
     package: ExcelScript!
     fullName: getNumberFormatLocal()
     summary: The localized format code of the number format for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -263,31 +297,37 @@ methods:
         type: string
         description: ''
   - name: getRangeBorder(index)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getRangeBorder:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getRangeBorder:member(1)
     package: ExcelScript!
     fullName: getRangeBorder(index)
     summary: Gets a border object using its name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRangeBorder(index: BorderIndex): RangeBorder;'
       parameters:
         - id: index
-          description: Index value of the border object to be retrieved. See `ExcelScript.BorderIndex` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />'
+          description: >-
+            Index value of the border object to be retrieved. See
+            `ExcelScript.BorderIndex` for details.
+          type: <xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />
         description: ''
   - name: getRangeBorderTintAndShade()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getRangeBorderTintAndShade:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PredefinedCellStyle#getRangeBorderTintAndShade:member(1)
     package: ExcelScript!
     fullName: getRangeBorderTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a color for range borders. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire border collection doesn't
+      Specifies a double that lightens or darkens a color for range borders. The
+      value is between -1 (darkest) and 1 (brightest), with 0 for the original
+      color. A `null` value indicates that the entire border collection doesn't
       have a uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -296,24 +336,28 @@ methods:
         type: number
         description: ''
   - name: getReadingOrder()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getReadingOrder:member(1)
     package: ExcelScript!
     fullName: getReadingOrder()
     summary: The reading order for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getReadingOrder(): ReadingOrder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />
         description: ''
   - name: getShrinkToFit()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getShrinkToFit:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getShrinkToFit:member(1)
     package: ExcelScript!
     fullName: getShrinkToFit()
-    summary: Specifies if text automatically shrinks to fit in the available column width.
+    summary: >-
+      Specifies if text automatically shrinks to fit in the available column
+      width.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -322,11 +366,12 @@ methods:
         type: boolean
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: The text orientation for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -335,24 +380,28 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
-    summary: Specifies the vertical alignment for the style. See `ExcelScript.VerticalAlignment` for details.
+    summary: >-
+      Specifies the vertical alignment for the style. See
+      `ExcelScript.VerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): VerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />
         description: ''
   - name: getWrapText()
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#getWrapText:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#getWrapText:member(1)
     package: ExcelScript!
     fullName: getWrapText()
     summary: Specifies if Excel wraps the text in the object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -361,11 +410,14 @@ methods:
         type: boolean
         description: ''
   - name: setAutoIndent(autoIndent)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setAutoIndent:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setAutoIndent:member(1)
     package: ExcelScript!
     fullName: setAutoIndent(autoIndent)
-    summary: Specifies if text is automatically indented when the text alignment in a cell is set to equal distribution.
+    summary: >-
+      Specifies if text is automatically indented when the text alignment in a
+      cell is set to equal distribution.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -378,11 +430,12 @@ methods:
         type: void
         description: ''
   - name: setFormulaHidden(formulaHidden)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setFormulaHidden:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setFormulaHidden:member(1)
     package: ExcelScript!
     fullName: setFormulaHidden(formulaHidden)
     summary: Specifies if the formula will be hidden when the worksheet is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -395,11 +448,15 @@ methods:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setHorizontalAlignment:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PredefinedCellStyle#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
-    summary: Represents the horizontal alignment for the style. See `ExcelScript.HorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment for the style. See
+      `ExcelScript.HorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -407,18 +464,20 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setIncludeAlignment(includeAlignment)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeAlignment:member(1)
     package: ExcelScript!
     fullName: setIncludeAlignment(includeAlignment)
     summary: >-
-      Specifies if the style includes the auto indent, horizontal alignment, vertical alignment, wrap text, indent
-      level, and text orientation properties.
+      Specifies if the style includes the auto indent, horizontal alignment,
+      vertical alignment, wrap text, indent level, and text orientation
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -431,11 +490,14 @@ methods:
         type: void
         description: ''
   - name: setIncludeBorder(includeBorder)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeBorder:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeBorder:member(1)
     package: ExcelScript!
     fullName: setIncludeBorder(includeBorder)
-    summary: 'Specifies if the style includes the color, color index, line style, and weight border properties.'
+    summary: >-
+      Specifies if the style includes the color, color index, line style, and
+      weight border properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -448,13 +510,15 @@ methods:
         type: void
         description: ''
   - name: setIncludeFont(includeFont)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeFont:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeFont:member(1)
     package: ExcelScript!
     fullName: setIncludeFont(includeFont)
     summary: >-
-      Specifies if the style includes the background, bold, color, color index, font style, italic, name, size,
-      strikethrough, subscript, superscript, and underline font properties.
+      Specifies if the style includes the background, bold, color, color index,
+      font style, italic, name, size, strikethrough, subscript, superscript, and
+      underline font properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -467,11 +531,12 @@ methods:
         type: void
         description: ''
   - name: setIncludeNumber(includeNumber)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeNumber:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeNumber:member(1)
     package: ExcelScript!
     fullName: setIncludeNumber(includeNumber)
     summary: Specifies if the style includes the number format property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -484,13 +549,15 @@ methods:
         type: void
         description: ''
   - name: setIncludePatterns(includePatterns)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludePatterns:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludePatterns:member(1)
     package: ExcelScript!
     fullName: setIncludePatterns(includePatterns)
     summary: >-
-      Specifies if the style includes the color, color index, invert if negative, pattern, pattern color, and pattern
-      color index interior properties.
+      Specifies if the style includes the color, color index, invert if
+      negative, pattern, pattern color, and pattern color index interior
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -503,11 +570,14 @@ methods:
         type: void
         description: ''
   - name: setIncludeProtection(includeProtection)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeProtection:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIncludeProtection:member(1)
     package: ExcelScript!
     fullName: setIncludeProtection(includeProtection)
-    summary: Specifies if the style includes the formula hidden and locked protection properties.
+    summary: >-
+      Specifies if the style includes the formula hidden and locked protection
+      properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -520,11 +590,12 @@ methods:
         type: void
         description: ''
   - name: setIndentLevel(indentLevel)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setIndentLevel:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setIndentLevel:member(1)
     package: ExcelScript!
     fullName: setIndentLevel(indentLevel)
     summary: An integer from 0 to 250 that indicates the indent level for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -537,11 +608,12 @@ methods:
         type: void
         description: ''
   - name: setLocked(locked)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setLocked:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setLocked:member(1)
     package: ExcelScript!
     fullName: setLocked(locked)
     summary: Specifies if the object is locked when the worksheet is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -554,11 +626,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: The format code of the number format for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -571,11 +644,12 @@ methods:
         type: void
         description: ''
   - name: setNumberFormatLocal(numberFormatLocal)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setNumberFormatLocal:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setNumberFormatLocal:member(1)
     package: ExcelScript!
     fullName: setNumberFormatLocal(numberFormatLocal)
     summary: The localized format code of the number format for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -588,14 +662,17 @@ methods:
         type: void
         description: ''
   - name: setRangeBorderTintAndShade(rangeBorderTintAndShade)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setRangeBorderTintAndShade:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PredefinedCellStyle#setRangeBorderTintAndShade:member(1)
     package: ExcelScript!
     fullName: setRangeBorderTintAndShade(rangeBorderTintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a color for range borders. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire border collection doesn't
+      Specifies a double that lightens or darkens a color for range borders. The
+      value is between -1 (darkest) and 1 (brightest), with 0 for the original
+      color. A `null` value indicates that the entire border collection doesn't
       have a uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -608,11 +685,12 @@ methods:
         type: void
         description: ''
   - name: setReadingOrder(readingOrder)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setReadingOrder:member(1)
     package: ExcelScript!
     fullName: setReadingOrder(readingOrder)
     summary: The reading order for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -620,16 +698,19 @@ methods:
       parameters:
         - id: readingOrder
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />
       return:
         type: void
         description: ''
   - name: setShrinkToFit(shrinkToFit)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setShrinkToFit:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setShrinkToFit:member(1)
     package: ExcelScript!
     fullName: setShrinkToFit(shrinkToFit)
-    summary: Specifies if text automatically shrinks to fit in the available column width.
+    summary: >-
+      Specifies if text automatically shrinks to fit in the available column
+      width.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -642,11 +723,12 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: The text orientation for the style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -659,11 +741,14 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
-    summary: Specifies the vertical alignment for the style. See `ExcelScript.VerticalAlignment` for details.
+    summary: >-
+      Specifies the vertical alignment for the style. See
+      `ExcelScript.VerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -671,16 +756,17 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setWrapText(wrapText)
-    uid: 'ExcelScript!ExcelScript.PredefinedCellStyle#setWrapText:member(1)'
+    uid: ExcelScript!ExcelScript.PredefinedCellStyle#setWrapText:member(1)
     package: ExcelScript!
     fullName: setWrapText(wrapText)
     summary: Specifies if Excel wraps the text in the object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.presetcriteriaconditionalformat.yml
@@ -1,11 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.PresetCriteriaConditionalFormat
-uid: 'ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.PresetCriteriaConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.PresetCriteriaConditionalFormat
 summary: >-
-  Represents the preset criteria conditional format such as above average, below average, unique values, contains blank,
-  nonblank, error, and noerror.
+  Represents the preset criteria conditional format such as above average, below
+  average, unique values, contains blank, nonblank, error, and noerror.
 remarks: |-
 
 
@@ -37,42 +37,54 @@ remarks: |-
     presetFormat.setRule(duplicateRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#getFormat:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the conditional formats font, fill, borders, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the conditional formats font, fill,
+      borders, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ConditionalRangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface"
+          />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
     summary: The rule of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): ConditionalPresetCriteriaRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface"
+          />
         description: ''
   - name: setRule(rule)
-    uid: 'ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#setRule:member(1)'
+    uid: ExcelScript!ExcelScript.PresetCriteriaConditionalFormat#setRule:member(1)
     package: ExcelScript!
     fullName: setRule(rule)
     summary: The rule of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,7 +92,10 @@ methods:
       parameters:
         - id: rule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.printcomments.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.printcomments.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PrintComments
-uid: 'ExcelScript!ExcelScript.PrintComments:enum'
+uid: ExcelScript!ExcelScript.PrintComments:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintComments
 summary: ''
@@ -25,18 +25,19 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: endSheet
-    uid: 'ExcelScript!ExcelScript.PrintComments.endSheet:member'
+    uid: ExcelScript!ExcelScript.PrintComments.endSheet:member
     package: ExcelScript!
     summary: Comments will be printed as end notes at the end of the worksheet.
   - name: inPlace
-    uid: 'ExcelScript!ExcelScript.PrintComments.inPlace:member'
+    uid: ExcelScript!ExcelScript.PrintComments.inPlace:member
     package: ExcelScript!
     summary: Comments will be printed where they were inserted in the worksheet.
   - name: noComments
-    uid: 'ExcelScript!ExcelScript.PrintComments.noComments:member'
+    uid: ExcelScript!ExcelScript.PrintComments.noComments:member
     package: ExcelScript!
     summary: Comments will not be printed.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.printerrortype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.printerrortype.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PrintErrorType
-uid: 'ExcelScript!ExcelScript.PrintErrorType:enum'
+uid: ExcelScript!ExcelScript.PrintErrorType:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintErrorType
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: asDisplayed
-    uid: 'ExcelScript!ExcelScript.PrintErrorType.asDisplayed:member'
+    uid: ExcelScript!ExcelScript.PrintErrorType.asDisplayed:member
     package: ExcelScript!
     summary: ''
   - name: blank
-    uid: 'ExcelScript!ExcelScript.PrintErrorType.blank:member'
+    uid: ExcelScript!ExcelScript.PrintErrorType.blank:member
     package: ExcelScript!
     summary: ''
   - name: dash
-    uid: 'ExcelScript!ExcelScript.PrintErrorType.dash:member'
+    uid: ExcelScript!ExcelScript.PrintErrorType.dash:member
     package: ExcelScript!
     summary: ''
   - name: notAvailable
-    uid: 'ExcelScript!ExcelScript.PrintErrorType.notAvailable:member'
+    uid: ExcelScript!ExcelScript.PrintErrorType.notAvailable:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.printmarginunit.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.printmarginunit.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PrintMarginUnit
-uid: 'ExcelScript!ExcelScript.PrintMarginUnit:enum'
+uid: ExcelScript!ExcelScript.PrintMarginUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintMarginUnit
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: centimeters
-    uid: 'ExcelScript!ExcelScript.PrintMarginUnit.centimeters:member'
+    uid: ExcelScript!ExcelScript.PrintMarginUnit.centimeters:member
     package: ExcelScript!
     summary: Assign the page margins in centimeters.
   - name: inches
-    uid: 'ExcelScript!ExcelScript.PrintMarginUnit.inches:member'
+    uid: ExcelScript!ExcelScript.PrintMarginUnit.inches:member
     package: ExcelScript!
     summary: Assign the page margins in inches.
   - name: points
-    uid: 'ExcelScript!ExcelScript.PrintMarginUnit.points:member'
+    uid: ExcelScript!ExcelScript.PrintMarginUnit.points:member
     package: ExcelScript!
     summary: Assign the page margins in points. A point is 1/72 of an inch.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.printorder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.printorder.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.PrintOrder
-uid: 'ExcelScript!ExcelScript.PrintOrder:enum'
+uid: ExcelScript!ExcelScript.PrintOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintOrder
 summary: ''
@@ -26,14 +26,19 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: downThenOver
-    uid: 'ExcelScript!ExcelScript.PrintOrder.downThenOver:member'
+    uid: ExcelScript!ExcelScript.PrintOrder.downThenOver:member
     package: ExcelScript!
-    summary: Process down the rows before processing across pages or page fields to the right.
+    summary: >-
+      Process down the rows before processing across pages or page fields to the
+      right.
   - name: overThenDown
-    uid: 'ExcelScript!ExcelScript.PrintOrder.overThenDown:member'
+    uid: ExcelScript!ExcelScript.PrintOrder.overThenDown:member
     package: ExcelScript!
-    summary: Process across pages or page fields to the right before moving down the rows.
+    summary: >-
+      Process across pages or page fields to the right before moving down the
+      rows.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.protectionselectionmode.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.protectionselectionmode.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ProtectionSelectionMode
-uid: 'ExcelScript!ExcelScript.ProtectionSelectionMode:enum'
+uid: ExcelScript!ExcelScript.ProtectionSelectionMode:enum
 package: ExcelScript!
 fullName: ExcelScript.ProtectionSelectionMode
 summary: ''
@@ -27,18 +27,19 @@ remarks: |-
     sheetProtection.protect(protectionOptions);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: none
-    uid: 'ExcelScript!ExcelScript.ProtectionSelectionMode.none:member'
+    uid: ExcelScript!ExcelScript.ProtectionSelectionMode.none:member
     package: ExcelScript!
     summary: Selection is not allowed for any cells.
   - name: normal
-    uid: 'ExcelScript!ExcelScript.ProtectionSelectionMode.normal:member'
+    uid: ExcelScript!ExcelScript.ProtectionSelectionMode.normal:member
     package: ExcelScript!
     summary: Selection is allowed for all cells.
   - name: unlocked
-    uid: 'ExcelScript!ExcelScript.ProtectionSelectionMode.unlocked:member'
+    uid: ExcelScript!ExcelScript.ProtectionSelectionMode.unlocked:member
     package: ExcelScript!
     summary: Selection is allowed only for cells that are not locked.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.query.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.query.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.Query
-uid: 'ExcelScript!ExcelScript.Query:interface'
+uid: ExcelScript!ExcelScript.Query:interface
 package: ExcelScript!
 fullName: ExcelScript.Query
 summary: Represents a Power Query query.
@@ -23,42 +23,46 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getError()
-    uid: 'ExcelScript!ExcelScript.Query#getError:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getError:member(1)
     package: ExcelScript!
     fullName: getError()
     summary: Gets the query error message from when the query was last refreshed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getError(): QueryError;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.QueryError:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.QueryError:enum" />
         description: ''
   - name: getLoadedTo()
-    uid: 'ExcelScript!ExcelScript.Query#getLoadedTo:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getLoadedTo:member(1)
     package: ExcelScript!
     fullName: getLoadedTo()
     summary: Gets the query loaded to object type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLoadedTo(): LoadToType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LoadToType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.LoadToType:enum" />
         description: ''
   - name: getLoadedToDataModel()
-    uid: 'ExcelScript!ExcelScript.Query#getLoadedToDataModel:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getLoadedToDataModel:member(1)
     package: ExcelScript!
     fullName: getLoadedToDataModel()
     summary: Specifies if the query loaded to the data model.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -67,11 +71,14 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Query#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getName:member(1)
     package: ExcelScript!
     fullName: getName()
-    summary: Gets the name of the query. Query names cannot contain periods or quotation marks.
+    summary: >-
+      Gets the name of the query. Query names cannot contain periods or
+      quotation marks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,11 +87,12 @@ methods:
         type: string
         description: ''
   - name: getRefreshDate()
-    uid: 'ExcelScript!ExcelScript.Query#getRefreshDate:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getRefreshDate:member(1)
     package: ExcelScript!
     fullName: getRefreshDate()
     summary: Gets the date and time when the query was last refreshed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,13 +101,14 @@ methods:
         type: Date
         description: ''
   - name: getRowsLoadedCount()
-    uid: 'ExcelScript!ExcelScript.Query#getRowsLoadedCount:member(1)'
+    uid: ExcelScript!ExcelScript.Query#getRowsLoadedCount:member(1)
     package: ExcelScript!
     fullName: getRowsLoadedCount()
     summary: >-
-      Gets the number of rows that were loaded when the query was last refreshed. If last refresh has errors the value
-      will be -1.
+      Gets the number of rows that were loaded when the query was last
+      refreshed. If last refresh has errors the value will be -1.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.queryerror.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.queryerror.yml
@@ -1,34 +1,35 @@
 ### YamlMime:TSEnum
 name: ExcelScript.QueryError
-uid: 'ExcelScript!ExcelScript.QueryError:enum'
+uid: ExcelScript!ExcelScript.QueryError:enum
 package: ExcelScript!
 fullName: ExcelScript.QueryError
 summary: An enum that specifies the query load error message.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: failedDownload
-    uid: 'ExcelScript!ExcelScript.QueryError.failedDownload:member'
+    uid: ExcelScript!ExcelScript.QueryError.failedDownload:member
     package: ExcelScript!
     summary: Download failed.
   - name: failedLoadToDataModel
-    uid: 'ExcelScript!ExcelScript.QueryError.failedLoadToDataModel:member'
+    uid: ExcelScript!ExcelScript.QueryError.failedLoadToDataModel:member
     package: ExcelScript!
     summary: Load to the data model failed.
   - name: failedLoadToWorksheet
-    uid: 'ExcelScript!ExcelScript.QueryError.failedLoadToWorksheet:member'
+    uid: ExcelScript!ExcelScript.QueryError.failedLoadToWorksheet:member
     package: ExcelScript!
     summary: Load to the worksheet failed.
   - name: failedToCompleteDownload
-    uid: 'ExcelScript!ExcelScript.QueryError.failedToCompleteDownload:member'
+    uid: ExcelScript!ExcelScript.QueryError.failedToCompleteDownload:member
     package: ExcelScript!
     summary: Download did not complete.
   - name: none
-    uid: 'ExcelScript!ExcelScript.QueryError.none:member'
+    uid: ExcelScript!ExcelScript.QueryError.none:member
     package: ExcelScript!
     summary: No error.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.QueryError.unknown:member'
+    uid: ExcelScript!ExcelScript.QueryError.unknown:member
     package: ExcelScript!
     summary: Unknown error.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.range.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.Range
-uid: 'ExcelScript!ExcelScript.Range:interface'
+uid: ExcelScript!ExcelScript.Range:interface
 package: ExcelScript!
 fullName: ExcelScript.Range
-summary: 'Range represents a set of one or more contiguous cells such as a cell, a row, a column, or a block of cells.'
+summary: >-
+  Range represents a set of one or more contiguous cells such as a cell, a row,
+  a column, or a block of cells.
 remarks: |-
 
 
@@ -24,26 +26,30 @@ remarks: |-
     console.log(usedRange.getAddress());
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: addConditionalFormat(type)
-    uid: 'ExcelScript!ExcelScript.Range#addConditionalFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Range#addConditionalFormat:member(1)
     package: ExcelScript!
     fullName: addConditionalFormat(type)
     summary: Adds a new conditional format to the collection at the first/top priority.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'addConditionalFormat(type: ConditionalFormatType): ConditionalFormat;'
       parameters:
         - id: type
-          description: The type of conditional format being added. See `ExcelScript.ConditionalFormatType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />'
+          description: >-
+            The type of conditional format being added. See
+            `ExcelScript.ConditionalFormatType` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />
         description: |-
 
 
@@ -70,15 +76,17 @@ methods:
             });
           }
           ```
-  - name: 'autoFill(destinationRange, autoFillType)'
-    uid: 'ExcelScript!ExcelScript.Range#autoFill:member(1)'
+  - name: autoFill(destinationRange, autoFillType)
+    uid: ExcelScript!ExcelScript.Range#autoFill:member(1)
     package: ExcelScript!
-    fullName: 'autoFill(destinationRange, autoFillType)'
+    fullName: autoFill(destinationRange, autoFillType)
     summary: >-
-      Fills a range from the current range to the destination range using the specified AutoFill logic. The destination
-      range can be `null` or can extend the source range either horizontally or vertically. Discontiguous ranges are not
-      supported.
+      Fills a range from the current range to the destination range using the
+      specified AutoFill logic. The destination range can be `null` or can
+      extend the source range either horizontally or vertically. Discontiguous
+      ranges are not supported.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,14 +98,17 @@ methods:
       parameters:
         - id: destinationRange
           description: >-
-            The destination range to AutoFill. If the destination range is `null`<!-- -->, data is filled out based on
-            the surrounding cells (which is the behavior when double-clicking the UI's range fill handle).
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The destination range to AutoFill. If the destination range is
+            `null`<!-- -->, data is filled out based on the surrounding cells
+            (which is the behavior when double-clicking the UI's range fill
+            handle).
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: autoFillType
           description: >-
-            The type of AutoFill. Specifies how the destination range is to be filled, based on the contents of the
-            current range. Default is "FillDefault".
-          type: '<xref uid="ExcelScript!ExcelScript.AutoFillType:enum" />'
+            The type of AutoFill. Specifies how the destination range is to be
+            filled, based on the contents of the current range. Default is
+            "FillDefault".
+          type: <xref uid="ExcelScript!ExcelScript.AutoFillType:enum" />
       return:
         type: void
         description: |-
@@ -124,11 +135,12 @@ methods:
           }
           ```
   - name: calculate()
-    uid: 'ExcelScript!ExcelScript.Range#calculate:member(1)'
+    uid: ExcelScript!ExcelScript.Range#calculate:member(1)
     package: ExcelScript!
     fullName: calculate()
     summary: Calculates a range of cells on a worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -158,19 +170,22 @@ methods:
           }
           ```
   - name: clear(applyTo)
-    uid: 'ExcelScript!ExcelScript.Range#clear:member(1)'
+    uid: ExcelScript!ExcelScript.Range#clear:member(1)
     package: ExcelScript!
     fullName: clear(applyTo)
-    summary: 'Clear range values and formatting, such as fill and border.'
+    summary: Clear range values and formatting, such as fill and border.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'clear(applyTo?: ClearApplyTo): void;'
       parameters:
         - id: applyTo
-          description: Optional. Determines the type of clear action. See `ExcelScript.ClearApplyTo` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ClearApplyTo:enum" />'
+          description: >-
+            Optional. Determines the type of clear action. See
+            `ExcelScript.ClearApplyTo` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ClearApplyTo:enum" />
       return:
         type: void
         description: |-
@@ -191,11 +206,12 @@ methods:
           }
           ```
   - name: clearAllConditionalFormats()
-    uid: 'ExcelScript!ExcelScript.Range#clearAllConditionalFormats:member(1)'
+    uid: ExcelScript!ExcelScript.Range#clearAllConditionalFormats:member(1)
     package: ExcelScript!
     fullName: clearAllConditionalFormats()
     summary: Clears all conditional formats active on the current specified range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -204,15 +220,18 @@ methods:
         type: void
         description: ''
   - name: clearOrResetContents()
-    uid: 'ExcelScript!ExcelScript.Range#clearOrResetContents:member(1)'
+    uid: ExcelScript!ExcelScript.Range#clearOrResetContents:member(1)
     package: ExcelScript!
     fullName: clearOrResetContents()
     summary: >-
-      Clears the values of the cells in the range, with special consideration given to cells containing controls. If the
-      range contains only blank values and controls set to their default value, then the values and control formatting
-      are removed. Otherwise, this sets the cells with controls to their default value and clears the values of the
-      other cells in the range.
+      Clears the values of the cells in the range, with special consideration
+      given to cells containing controls. If the range contains only blank
+      values and controls set to their default value, then the values and
+      control formatting are removed. Otherwise, this sets the cells with
+      controls to their default value and clears the values of the other cells
+      in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -221,11 +240,12 @@ methods:
         type: void
         description: ''
   - name: convertDataTypeToText()
-    uid: 'ExcelScript!ExcelScript.Range#convertDataTypeToText:member(1)'
+    uid: ExcelScript!ExcelScript.Range#convertDataTypeToText:member(1)
     package: ExcelScript!
     fullName: convertDataTypeToText()
     summary: Converts the range cells with data types into text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -233,17 +253,21 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'copyFrom(sourceRange, copyType, skipBlanks, transpose)'
-    uid: 'ExcelScript!ExcelScript.Range#copyFrom:member(1)'
+  - name: copyFrom(sourceRange, copyType, skipBlanks, transpose)
+    uid: ExcelScript!ExcelScript.Range#copyFrom:member(1)
     package: ExcelScript!
-    fullName: 'copyFrom(sourceRange, copyType, skipBlanks, transpose)'
+    fullName: copyFrom(sourceRange, copyType, skipBlanks, transpose)
     summary: >-
-      Copies cell data or formatting from the source range or `RangeAreas` to the current range. The destination range
-      can be a different size than the source range or `RangeAreas`<!-- -->. The destination is expanded automatically
-      if it's smaller than the source. Note: Like the copy functionality in the Excel UI, if the destination range is an
-      exact multiple greater than the source range in either rows or columns, then the source content is replicated
-      multiple times. For example, a 2x2 range copy into a 2x6 range will result in 3 copies of the original 2x2 range.
+      Copies cell data or formatting from the source range or `RangeAreas` to
+      the current range. The destination range can be a different size than the
+      source range or `RangeAreas`<!-- -->. The destination is expanded
+      automatically if it's smaller than the source. Note: Like the copy
+      functionality in the Excel UI, if the destination range is an exact
+      multiple greater than the source range in either rows or columns, then the
+      source content is replicated multiple times. For example, a 2x2 range copy
+      into a 2x6 range will result in 3 copies of the original 2x2 range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -257,19 +281,22 @@ methods:
       parameters:
         - id: sourceRange
           description: >-
-            The source range or `RangeAreas` to copy from. When the source `RangeAreas` has multiple ranges, their form
-            must be able to be created by removing full rows or columns from a rectangular range.
+            The source range or `RangeAreas` to copy from. When the source
+            `RangeAreas` has multiple ranges, their form must be able to be
+            created by removing full rows or columns from a rectangular range.
           type: >-
             <xref uid="ExcelScript!ExcelScript.Range:interface" /> | <xref
             uid="ExcelScript!ExcelScript.RangeAreas:interface" /> | string
         - id: copyType
           description: The type of cell data or formatting to copy over. Default is "All".
-          type: '<xref uid="ExcelScript!ExcelScript.RangeCopyType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.RangeCopyType:enum" />
         - id: skipBlanks
           description: True if to skip blank cells in the source range. Default is false.
           type: boolean
         - id: transpose
-          description: True if to transpose the cells in the destination range. Default is false.
+          description: >-
+            True if to transpose the cells in the destination range. Default is
+            false.
           type: boolean
       return:
         type: void
@@ -298,19 +325,22 @@ methods:
           }
           ```
   - name: delete(shift)
-    uid: 'ExcelScript!ExcelScript.Range#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Range#delete:member(1)
     package: ExcelScript!
     fullName: delete(shift)
     summary: Deletes the cells associated with the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'delete(shift: DeleteShiftDirection): void;'
       parameters:
         - id: shift
-          description: Specifies which way to shift the cells. See `ExcelScript.DeleteShiftDirection` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.DeleteShiftDirection:enum" />'
+          description: >-
+            Specifies which way to shift the cells. See
+            `ExcelScript.DeleteShiftDirection` for details.
+          type: <xref uid="ExcelScript!ExcelScript.DeleteShiftDirection:enum" />
       return:
         type: void
         description: |-
@@ -350,15 +380,18 @@ methods:
             console.log(currentSheet.getRange("A1:D4").getValues()); 
           }
           ```
-  - name: 'find(text, criteria)'
-    uid: 'ExcelScript!ExcelScript.Range#find:member(1)'
+  - name: find(text, criteria)
+    uid: ExcelScript!ExcelScript.Range#find:member(1)
     package: ExcelScript!
-    fullName: 'find(text, criteria)'
+    fullName: find(text, criteria)
     summary: >-
-      Finds the given string based on the criteria specified. If the current range is larger than a single cell, then
-      the search will be limited to that range, else the search will cover the entire sheet starting after that cell. If
-      there are no matches, then this method returns `undefined`<!-- -->.
+      Finds the given string based on the criteria specified. If the current
+      range is larger than a single cell, then the search will be limited to
+      that range, else the search will cover the entire sheet starting after
+      that cell. If there are no matches, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -369,11 +402,12 @@ methods:
           type: string
         - id: criteria
           description: >-
-            Additional search criteria, including the search direction and whether the search needs to match the entire
-            cell or be case-sensitive.
-          type: '<xref uid="ExcelScript!ExcelScript.SearchCriteria:interface" />'
+            Additional search criteria, including the search direction and
+            whether the search needs to match the entire cell or be
+            case-sensitive.
+          type: <xref uid="ExcelScript!ExcelScript.SearchCriteria:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -401,13 +435,15 @@ methods:
           }
           ```
   - name: flashFill()
-    uid: 'ExcelScript!ExcelScript.Range#flashFill:member(1)'
+    uid: ExcelScript!ExcelScript.Range#flashFill:member(1)
     package: ExcelScript!
     fullName: flashFill()
     summary: >-
-      Does a Flash Fill to the current range. Flash Fill automatically fills data when it senses a pattern, so the range
-      must be a single column range and have data around it in order to find a pattern.
+      Does a Flash Fill to the current range. Flash Fill automatically fills
+      data when it senses a pattern, so the range must be a single column range
+      and have data around it in order to find a pattern.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -436,14 +472,15 @@ methods:
             dataRange.flashFill();
           }
           ```
-  - name: 'getAbsoluteResizedRange(numRows, numColumns)'
-    uid: 'ExcelScript!ExcelScript.Range#getAbsoluteResizedRange:member(1)'
+  - name: getAbsoluteResizedRange(numRows, numColumns)
+    uid: ExcelScript!ExcelScript.Range#getAbsoluteResizedRange:member(1)
     package: ExcelScript!
-    fullName: 'getAbsoluteResizedRange(numRows, numColumns)'
+    fullName: getAbsoluteResizedRange(numRows, numColumns)
     summary: >-
-      Gets a `Range` object with the same top-left cell as the current `Range` object, but with the specified numbers of
-      rows and columns.
+      Gets a `Range` object with the same top-left cell as the current `Range`
+      object, but with the specified numbers of rows and columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -456,14 +493,17 @@ methods:
           description: The number of columns of the new range size.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getAddress()
-    uid: 'ExcelScript!ExcelScript.Range#getAddress:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getAddress:member(1)
     package: ExcelScript!
     fullName: getAddress()
-    summary: 'Specifies the range reference in A1-style. Address value contains the sheet reference (e.g., "Sheet1!A1:B4").'
+    summary: >-
+      Specifies the range reference in A1-style. Address value contains the
+      sheet reference (e.g., "Sheet1!A1:B4").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -491,11 +531,14 @@ methods:
           }
           ```
   - name: getAddressLocal()
-    uid: 'ExcelScript!ExcelScript.Range#getAddressLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getAddressLocal:member(1)
     package: ExcelScript!
     fullName: getAddressLocal()
-    summary: Represents the range reference for the specified range in the language of the user.
+    summary: >-
+      Represents the range reference for the specified range in the language of
+      the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -504,23 +547,24 @@ methods:
         type: string
         description: ''
   - name: getBoundingRect(anotherRange)
-    uid: 'ExcelScript!ExcelScript.Range#getBoundingRect:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getBoundingRect:member(1)
     package: ExcelScript!
     fullName: getBoundingRect(anotherRange)
     summary: >-
-      Gets the smallest range object that encompasses the given ranges. For example, the `GetBoundingRect` of "B2:C5"
-      and "D10:E15" is "B2:E15".
+      Gets the smallest range object that encompasses the given ranges. For
+      example, the `GetBoundingRect` of "B2:C5" and "D10:E15" is "B2:E15".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBoundingRect(anotherRange: Range | string): Range;'
       parameters:
         - id: anotherRange
-          description: 'The range object, address, or range name.'
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: The range object, address, or range name.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -549,15 +593,17 @@ methods:
             format.getRangeBorder(ExcelScript.BorderIndex.edgeRight).setStyle(ExcelScript.BorderLineStyle.continuous); // Right border
           }
           ```
-  - name: 'getCell(row, column)'
-    uid: 'ExcelScript!ExcelScript.Range#getCell:member(1)'
+  - name: getCell(row, column)
+    uid: ExcelScript!ExcelScript.Range#getCell:member(1)
     package: ExcelScript!
-    fullName: 'getCell(row, column)'
+    fullName: getCell(row, column)
     summary: >-
-      Gets the range object containing the single cell based on row and column numbers. The cell can be outside the
-      bounds of its parent range, so long as it stays within the worksheet grid. The returned cell is located relative
-      to the top left cell of the range.
+      Gets the range object containing the single cell based on row and column
+      numbers. The cell can be outside the bounds of its parent range, so long
+      as it stays within the worksheet grid. The returned cell is located
+      relative to the top left cell of the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -570,16 +616,17 @@ methods:
           description: Column number of the cell to be retrieved. Zero-indexed.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getCellCount()
-    uid: 'ExcelScript!ExcelScript.Range#getCellCount:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getCellCount:member(1)
     package: ExcelScript!
     fullName: getCellCount()
     summary: >-
-      Specifies the number of cells in the range. This API will return -1 if the cell count exceeds 2^31-1
-      (2,147,483,647).
+      Specifies the number of cells in the range. This API will return -1 if the
+      cell count exceeds 2^31-1 (2,147,483,647).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -588,11 +635,12 @@ methods:
         type: number
         description: ''
   - name: getColumn(column)
-    uid: 'ExcelScript!ExcelScript.Range#getColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumn:member(1)
     package: ExcelScript!
     fullName: getColumn(column)
     summary: Gets a column contained in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -602,14 +650,15 @@ methods:
           description: Column number of the range to be retrieved. Zero-indexed.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getColumnCount()
-    uid: 'ExcelScript!ExcelScript.Range#getColumnCount:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumnCount:member(1)
     package: ExcelScript!
     fullName: getColumnCount()
     summary: Specifies the total number of columns in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -652,14 +701,16 @@ methods:
           }
           ```
   - name: getColumnHidden()
-    uid: 'ExcelScript!ExcelScript.Range#getColumnHidden:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumnHidden:member(1)
     package: ExcelScript!
     fullName: getColumnHidden()
     summary: >-
-      Represents if all columns in the current range are hidden. Value is `true` when all columns in a range are hidden.
-      Value is `false` when no columns in the range are hidden. Value is `null` when some columns in a range are hidden
-      and other columns in the same range are not hidden.
+      Represents if all columns in the current range are hidden. Value is `true`
+      when all columns in a range are hidden. Value is `false` when no columns
+      in the range are hidden. Value is `null` when some columns in a range are
+      hidden and other columns in the same range are not hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -668,11 +719,12 @@ methods:
         type: boolean
         description: ''
   - name: getColumnIndex()
-    uid: 'ExcelScript!ExcelScript.Range#getColumnIndex:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumnIndex:member(1)
     package: ExcelScript!
     fullName: getColumnIndex()
     summary: Specifies the column number of the first cell in the range. Zero-indexed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -681,11 +733,14 @@ methods:
         type: number
         description: ''
   - name: getColumnsAfter(count)
-    uid: 'ExcelScript!ExcelScript.Range#getColumnsAfter:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumnsAfter:member(1)
     package: ExcelScript!
     fullName: getColumnsAfter(count)
-    summary: Gets a certain number of columns to the right of the current `Range` object.
+    summary: >-
+      Gets a certain number of columns to the right of the current `Range`
+      object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -693,19 +748,23 @@ methods:
       parameters:
         - id: count
           description: >-
-            Optional. The number of columns to include in the resulting range. In general, use a positive number to
-            create a range outside the current range. You can also use a negative number to create a range within the
-            current range. The default value is 1.
+            Optional. The number of columns to include in the resulting range.
+            In general, use a positive number to create a range outside the
+            current range. You can also use a negative number to create a range
+            within the current range. The default value is 1.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getColumnsBefore(count)
-    uid: 'ExcelScript!ExcelScript.Range#getColumnsBefore:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getColumnsBefore:member(1)
     package: ExcelScript!
     fullName: getColumnsBefore(count)
-    summary: Gets a certain number of columns to the left of the current `Range` object.
+    summary: >-
+      Gets a certain number of columns to the left of the current `Range`
+      object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -713,21 +772,24 @@ methods:
       parameters:
         - id: count
           description: >-
-            Optional. The number of columns to include in the resulting range. In general, use a positive number to
-            create a range outside the current range. You can also use a negative number to create a range within the
-            current range. The default value is 1.
+            Optional. The number of columns to include in the resulting range.
+            In general, use a positive number to create a range outside the
+            current range. You can also use a negative number to create a range
+            within the current range. The default value is 1.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getConditionalFormat(id)
-    uid: 'ExcelScript!ExcelScript.Range#getConditionalFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getConditionalFormat:member(1)
     package: ExcelScript!
     fullName: getConditionalFormat(id)
     summary: >-
-      Returns a conditional format identified by its ID. If the conditional format object does not exist, then this
-      method returns `undefined`<!-- -->.
+      Returns a conditional format identified by its ID. If the conditional
+      format object does not exist, then this method returns `undefined`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -737,48 +799,53 @@ methods:
           description: The ID of the conditional format.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" /> |
+          undefined
         description: ''
   - name: getConditionalFormats()
-    uid: 'ExcelScript!ExcelScript.Range#getConditionalFormats:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getConditionalFormats:member(1)
     package: ExcelScript!
     fullName: getConditionalFormats()
     summary: The collection of `ConditionalFormats` that intersect the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalFormats(): ConditionalFormat[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />[]
         description: ''
   - name: getControl()
-    uid: 'ExcelScript!ExcelScript.Range#getControl:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getControl:member(1)
     package: ExcelScript!
     fullName: getControl()
     summary: >-
-      Accesses the cell control applied to this range. If the range has multiple cell controls, this returns
-      `EmptyCellControl`<!-- -->.
+      Accesses the cell control applied to this range. If the range has multiple
+      cell controls, this returns `EmptyCellControl`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getControl(): CellControl;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellControl:type" />'
+        type: <xref uid="ExcelScript!ExcelScript.CellControl:type" />
         description: ''
   - name: getDataValidation()
-    uid: 'ExcelScript!ExcelScript.Range#getDataValidation:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getDataValidation:member(1)
     package: ExcelScript!
     fullName: getDataValidation()
     summary: Returns a data validation object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataValidation(): DataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidation:interface" />
         description: |-
 
 
@@ -818,52 +885,58 @@ methods:
           }
           ```
   - name: getDependents()
-    uid: 'ExcelScript!ExcelScript.Range#getDependents:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getDependents:member(1)
     package: ExcelScript!
     fullName: getDependents()
     summary: >-
-      Returns a `WorkbookRangeAreas` object that represents the range containing all the dependent cells of a specified
-      range in the same worksheet or across multiple worksheets. Note: This API returns an `ItemNotFound` error if no
-      dependents are found.
+      Returns a `WorkbookRangeAreas` object that represents the range containing
+      all the dependent cells of a specified range in the same worksheet or
+      across multiple worksheets. Note: This API returns an `ItemNotFound` error
+      if no dependents are found.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDependents(): WorkbookRangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />
         description: ''
   - name: getDirectDependents()
-    uid: 'ExcelScript!ExcelScript.Range#getDirectDependents:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getDirectDependents:member(1)
     package: ExcelScript!
     fullName: getDirectDependents()
     summary: >-
-      Returns a `WorkbookRangeAreas` object that represents the range containing all the direct dependent cells of a
-      specified range in the same worksheet or across multiple worksheets. Note: This API returns an `ItemNotFound`
+      Returns a `WorkbookRangeAreas` object that represents the range containing
+      all the direct dependent cells of a specified range in the same worksheet
+      or across multiple worksheets. Note: This API returns an `ItemNotFound`
       error if no dependents are found.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDirectDependents(): WorkbookRangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />
         description: ''
   - name: getDirectPrecedents()
-    uid: 'ExcelScript!ExcelScript.Range#getDirectPrecedents:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getDirectPrecedents:member(1)
     package: ExcelScript!
     fullName: getDirectPrecedents()
     summary: >-
-      Returns a `WorkbookRangeAreas` object that represents the range containing all the direct precedent cells of a
-      specified range in the same worksheet or across multiple worksheets. Note: This API returns an `ItemNotFound`
+      Returns a `WorkbookRangeAreas` object that represents the range containing
+      all the direct precedent cells of a specified range in the same worksheet
+      or across multiple worksheets. Note: This API returns an `ItemNotFound`
       error if no precedents are found.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDirectPrecedents(): WorkbookRangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />
         description: |-
 
 
@@ -889,44 +962,50 @@ methods:
           }
           ```
   - name: getEntireColumn()
-    uid: 'ExcelScript!ExcelScript.Range#getEntireColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getEntireColumn:member(1)
     package: ExcelScript!
     fullName: getEntireColumn()
     summary: >-
-      Gets an object that represents the entire column of the range (for example, if the current range represents cells
-      "B4:E11", its `getEntireColumn` is a range that represents columns "B:E").
+      Gets an object that represents the entire column of the range (for
+      example, if the current range represents cells "B4:E11", its
+      `getEntireColumn` is a range that represents columns "B:E").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEntireColumn(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getEntireRow()
-    uid: 'ExcelScript!ExcelScript.Range#getEntireRow:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getEntireRow:member(1)
     package: ExcelScript!
     fullName: getEntireRow()
     summary: >-
-      Gets an object that represents the entire row of the range (for example, if the current range represents cells
-      "B4:E11", its `GetEntireRow` is a range that represents rows "4:11").
+      Gets an object that represents the entire row of the range (for example,
+      if the current range represents cells "B4:E11", its `GetEntireRow` is a
+      range that represents rows "4:11").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEntireRow(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
-  - name: 'getExtendedRange(direction, activeCell)'
-    uid: 'ExcelScript!ExcelScript.Range#getExtendedRange:member(1)'
+  - name: getExtendedRange(direction, activeCell)
+    uid: ExcelScript!ExcelScript.Range#getExtendedRange:member(1)
     package: ExcelScript!
-    fullName: 'getExtendedRange(direction, activeCell)'
+    fullName: getExtendedRange(direction, activeCell)
     summary: >-
-      Returns a range object that includes the current range and up to the edge of the range, based on the provided
-      direction. This matches the <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Arrow key</kbd> behavior in the Excel on Windows
-      UI.
+      Returns a range object that includes the current range and up to the edge
+      of the range, based on the provided direction. This matches the
+      <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>Arrow key</kbd> behavior in the
+      Excel on Windows UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -938,14 +1017,15 @@ methods:
       parameters:
         - id: direction
           description: The direction from the active cell.
-          type: '<xref uid="ExcelScript!ExcelScript.KeyboardDirection:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.KeyboardDirection:enum" />
         - id: activeCell
           description: >-
-            The active cell in this range. By default, the active cell is the top-left cell of the range. An error is
-            thrown if the active cell is not in this range.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The active cell in this range. By default, the active cell is the
+            top-left cell of the range. An error is thrown if the active cell is
+            not in this range.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -971,17 +1051,20 @@ methods:
           }
           ```
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.Range#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the range''s font, fill, borders, alignment, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the range's font, fill, borders,
+      alignment, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): RangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFormat:interface" />
         description: |-
 
 
@@ -1003,13 +1086,15 @@ methods:
           }
           ```
   - name: getFormula()
-    uid: 'ExcelScript!ExcelScript.Range#getFormula:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormula:member(1)
     package: ExcelScript!
     fullName: getFormula()
     summary: >-
-      Represents the cell formula in A1-style notation. If the range contains multiple cells, the data from first cell
-      (represented by row index of 0 and column index of 0) will be returned.
+      Represents the cell formula in A1-style notation. If the range contains
+      multiple cells, the data from first cell (represented by row index of 0
+      and column index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1042,14 +1127,17 @@ methods:
           }
           ```
   - name: getFormulaLocal()
-    uid: 'ExcelScript!ExcelScript.Range#getFormulaLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormulaLocal:member(1)
     package: ExcelScript!
     fullName: getFormulaLocal()
     summary: >-
-      Represents the cell formula in A1-style notation, in the user's language and number-formatting locale. For
-      example, the English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If the range contains
-      multiple cells, the data from first cell (represented by row index of 0 and column index of 0) will be returned.
+      Represents the cell formula in A1-style notation, in the user's language
+      and number-formatting locale. For example, the English "=SUM(A1, 1.5)"
+      formula would become "=SUMME(A1; 1,5)" in German. If the range contains
+      multiple cells, the data from first cell (represented by row index of 0
+      and column index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1058,13 +1146,15 @@ methods:
         type: string
         description: ''
   - name: getFormulaR1C1()
-    uid: 'ExcelScript!ExcelScript.Range#getFormulaR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormulaR1C1:member(1)
     package: ExcelScript!
     fullName: getFormulaR1C1()
     summary: >-
-      Represents the cell formula in R1C1-style notation. If the range contains multiple cells, the data from first cell
-      (represented by row index of 0 and column index of 0) will be returned.
+      Represents the cell formula in R1C1-style notation. If the range contains
+      multiple cells, the data from first cell (represented by row index of 0
+      and column index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1073,56 +1163,66 @@ methods:
         type: string
         description: ''
   - name: getFormulas()
-    uid: 'ExcelScript!ExcelScript.Range#getFormulas:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormulas:member(1)
     package: ExcelScript!
     fullName: getFormulas()
-    summary: 'Represents the formula in A1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in A1-style notation. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulas(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getFormulasLocal()
-    uid: 'ExcelScript!ExcelScript.Range#getFormulasLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormulasLocal:member(1)
     package: ExcelScript!
     fullName: getFormulasLocal()
     summary: >-
-      Represents the formula in A1-style notation, in the user's language and number-formatting locale. For example, the
-      English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its value is
-      returned instead.
+      Represents the formula in A1-style notation, in the user's language and
+      number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula
+      would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulasLocal(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getFormulasR1C1()
-    uid: 'ExcelScript!ExcelScript.Range#getFormulasR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getFormulasR1C1:member(1)
     package: ExcelScript!
     fullName: getFormulasR1C1()
-    summary: 'Represents the formula in R1C1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in R1C1-style notation. If a cell has no formula,
+      its value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulasR1C1(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getHasSpill()
-    uid: 'ExcelScript!ExcelScript.Range#getHasSpill:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getHasSpill:member(1)
     package: ExcelScript!
     fullName: getHasSpill()
     summary: >-
-      Represents if all cells have a spill border. Returns `true` if all cells have a spill border, or `false` if all
-      cells do not have a spill border. Returns `null` if there are cells both with and without spill borders within the
-      range.
+      Represents if all cells have a spill border. Returns `true` if all cells
+      have a spill border, or `false` if all cells do not have a spill border.
+      Returns `null` if there are cells both with and without spill borders
+      within the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1131,11 +1231,14 @@ methods:
         type: boolean
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.Range#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
-    summary: 'Returns the distance in points, for 100% zoom, from the top edge of the range to the bottom edge of the range.'
+    summary: >-
+      Returns the distance in points, for 100% zoom, from the top edge of the
+      range to the bottom edge of the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1144,14 +1247,16 @@ methods:
         type: number
         description: ''
   - name: getHidden()
-    uid: 'ExcelScript!ExcelScript.Range#getHidden:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getHidden:member(1)
     package: ExcelScript!
     fullName: getHidden()
     summary: >-
-      Represents if all cells in the current range are hidden. Value is `true` when all cells in a range are hidden.
-      Value is `false` when no cells in the range are hidden. Value is `null` when some cells in a range are hidden and
-      other cells in the same range are not hidden.
+      Represents if all cells in the current range are hidden. Value is `true`
+      when all cells in a range are hidden. Value is `false` when no cells in
+      the range are hidden. Value is `null` when some cells in a range are
+      hidden and other cells in the same range are not hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1160,28 +1265,32 @@ methods:
         type: boolean
         description: ''
   - name: getHyperlink()
-    uid: 'ExcelScript!ExcelScript.Range#getHyperlink:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getHyperlink:member(1)
     package: ExcelScript!
     fullName: getHyperlink()
     summary: Represents the hyperlink for the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHyperlink(): RangeHyperlink;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeHyperlink:interface" />'
-        description: |-
+        type: <xref uid="ExcelScript!ExcelScript.RangeHyperlink:interface" />
+        description: >-
 
 
           #### Examples
 
+
           ```TypeScript
+
           /**
            * This sample clears all of the hyperlinks from the current worksheet
            * and removes the usual hyperlink formatting.
            */
-          function main(workbook: ExcelScript.Workbook, sheetName: string = 'Sheet1') {
+          function main(workbook: ExcelScript.Workbook, sheetName: string =
+          'Sheet1') {
             // Get the active worksheet. 
             let sheet = workbook.getWorksheet(sheetName);
 
@@ -1212,13 +1321,15 @@ methods:
 
             console.log(`Done. Cleared hyperlinks from ${clearedCount} cells`);
           }
+
           ```
   - name: getImage()
-    uid: 'ExcelScript!ExcelScript.Range#getImage:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getImage:member(1)
     package: ExcelScript!
     fullName: getImage()
     summary: Renders the range as a Base64-encoded PNG image.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1227,30 +1338,35 @@ methods:
         type: string
         description: ''
   - name: getIntersection(anotherRange)
-    uid: 'ExcelScript!ExcelScript.Range#getIntersection:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getIntersection:member(1)
     package: ExcelScript!
     fullName: getIntersection(anotherRange)
     summary: >-
-      Gets the range object that represents the rectangular intersection of the given ranges. If no intersection is
-      found, then this method returns `undefined`<!-- -->.
+      Gets the range object that represents the rectangular intersection of the
+      given ranges. If no intersection is found, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getIntersection(anotherRange: Range | string): Range;'
       parameters:
         - id: anotherRange
-          description: The range object or range address that will be used to determine the intersection of ranges.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            The range object or range address that will be used to determine the
+            intersection of ranges.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getIsEntireColumn()
-    uid: 'ExcelScript!ExcelScript.Range#getIsEntireColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getIsEntireColumn:member(1)
     package: ExcelScript!
     fullName: getIsEntireColumn()
     summary: Represents if the current range is an entire column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1259,11 +1375,12 @@ methods:
         type: boolean
         description: ''
   - name: getIsEntireRow()
-    uid: 'ExcelScript!ExcelScript.Range#getIsEntireRow:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getIsEntireRow:member(1)
     package: ExcelScript!
     fullName: getIsEntireRow()
     summary: Represents if the current range is an entire row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1272,50 +1389,62 @@ methods:
         type: boolean
         description: ''
   - name: getLastCell()
-    uid: 'ExcelScript!ExcelScript.Range#getLastCell:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLastCell:member(1)
     package: ExcelScript!
     fullName: getLastCell()
-    summary: 'Gets the last cell within the range. For example, the last cell of "B2:D5" is "D5".'
+    summary: >-
+      Gets the last cell within the range. For example, the last cell of "B2:D5"
+      is "D5".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLastCell(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getLastColumn()
-    uid: 'ExcelScript!ExcelScript.Range#getLastColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLastColumn:member(1)
     package: ExcelScript!
     fullName: getLastColumn()
-    summary: 'Gets the last column within the range. For example, the last column of "B2:D5" is "D2:D5".'
+    summary: >-
+      Gets the last column within the range. For example, the last column of
+      "B2:D5" is "D2:D5".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLastColumn(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getLastRow()
-    uid: 'ExcelScript!ExcelScript.Range#getLastRow:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLastRow:member(1)
     package: ExcelScript!
     fullName: getLastRow()
-    summary: 'Gets the last row within the range. For example, the last row of "B2:D5" is "B5:D5".'
+    summary: >-
+      Gets the last row within the range. For example, the last row of "B2:D5"
+      is "B5:D5".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLastRow(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.Range#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
-    summary: 'Returns the distance in points, for 100% zoom, from the left edge of the worksheet to the left edge of the range.'
+    summary: >-
+      Returns the distance in points, for 100% zoom, from the left edge of the
+      worksheet to the left edge of the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1324,55 +1453,61 @@ methods:
         type: number
         description: ''
   - name: getLinkedDataTypeState()
-    uid: 'ExcelScript!ExcelScript.Range#getLinkedDataTypeState:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLinkedDataTypeState:member(1)
     package: ExcelScript!
     fullName: getLinkedDataTypeState()
     summary: Represents the data type state of the cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLinkedDataTypeState(): LinkedDataTypeState;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LinkedDataTypeState:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.LinkedDataTypeState:enum" />
         description: ''
   - name: getLinkedDataTypeStates()
-    uid: 'ExcelScript!ExcelScript.Range#getLinkedDataTypeStates:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getLinkedDataTypeStates:member(1)
     package: ExcelScript!
     fullName: getLinkedDataTypeStates()
     summary: Represents the data type state of each cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLinkedDataTypeStates(): LinkedDataTypeState[][];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LinkedDataTypeState:enum" />[][]'
+        type: <xref uid="ExcelScript!ExcelScript.LinkedDataTypeState:enum" />[][]
         description: ''
   - name: getMergedAreas()
-    uid: 'ExcelScript!ExcelScript.Range#getMergedAreas:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getMergedAreas:member(1)
     package: ExcelScript!
     fullName: getMergedAreas()
     summary: >-
-      Returns a `RangeAreas` object that represents the merged areas in this range. Note that if the merged areas count
-      in this range is more than 512, then this method will fail to return the result. If the `RangeAreas` object
-      doesn't exist, then this function returns `undefined`<!-- -->.
+      Returns a `RangeAreas` object that represents the merged areas in this
+      range. Note that if the merged areas count in this range is more than 512,
+      then this method will fail to return the result. If the `RangeAreas`
+      object doesn't exist, then this function returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMergedAreas(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: >-
-      Represents cell Excel number format code for the given range. If the range contains multiple cells, the data from
-      first cell (represented by row index of 0 and column index of 0) will be returned.
+      Represents cell Excel number format code for the given range. If the range
+      contains multiple cells, the data from first cell (represented by row
+      index of 0 and column index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1381,17 +1516,18 @@ methods:
         type: string
         description: ''
   - name: getNumberFormatCategories()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormatCategories:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormatCategories:member(1)
     package: ExcelScript!
     fullName: getNumberFormatCategories()
     summary: Represents the category of number format of each cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormatCategories(): NumberFormatCategory[][];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NumberFormatCategory:enum" />[][]'
+        type: <xref uid="ExcelScript!ExcelScript.NumberFormatCategory:enum" />[][]
         description: |-
 
 
@@ -1420,31 +1556,35 @@ methods:
           }
           ```
   - name: getNumberFormatCategory()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormatCategory:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormatCategory:member(1)
     package: ExcelScript!
     fullName: getNumberFormatCategory()
     summary: >-
-      Specifies the number format category of first cell in the range (represented by row index of 0 and column index of
-      0).
+      Specifies the number format category of first cell in the range
+      (represented by row index of 0 and column index of 0).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormatCategory(): NumberFormatCategory;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NumberFormatCategory:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.NumberFormatCategory:enum" />
         description: ''
   - name: getNumberFormatLocal()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormatLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormatLocal:member(1)
     package: ExcelScript!
     fullName: getNumberFormatLocal()
     summary: >-
-      Represents cell Excel number format code for the given range, based on the language settings of the user.​ Excel
-      does not perform any language or format coercion when getting or setting the `numberFormatLocal` property. Any
-      returned text uses the locally-formatted strings based on the language specified in the system settings. If the
-      range contains multiple cells, the data from first cell (represented by row index of 0 and column index of 0) will
-      be returned.
+      Represents cell Excel number format code for the given range, based on the
+      language settings of the user.​ Excel does not perform any language or
+      format coercion when getting or setting the `numberFormatLocal` property.
+      Any returned text uses the locally-formatted strings based on the language
+      specified in the system settings. If the range contains multiple cells,
+      the data from first cell (represented by row index of 0 and column index
+      of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1453,43 +1593,49 @@ methods:
         type: string
         description: ''
   - name: getNumberFormats()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormats:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormats:member(1)
     package: ExcelScript!
     fullName: getNumberFormats()
     summary: Represents Excel's number format code for the given range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormats(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getNumberFormatsLocal()
-    uid: 'ExcelScript!ExcelScript.Range#getNumberFormatsLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getNumberFormatsLocal:member(1)
     package: ExcelScript!
     fullName: getNumberFormatsLocal()
     summary: >-
-      Represents Excel's number format code for the given range, based on the language settings of the user. Excel does
-      not perform any language or format coercion when getting or setting the `numberFormatLocal` property. Any returned
-      text uses the locally-formatted strings based on the language specified in the system settings.
+      Represents Excel's number format code for the given range, based on the
+      language settings of the user. Excel does not perform any language or
+      format coercion when getting or setting the `numberFormatLocal` property.
+      Any returned text uses the locally-formatted strings based on the language
+      specified in the system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormatsLocal(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
-  - name: 'getOffsetRange(rowOffset, columnOffset)'
-    uid: 'ExcelScript!ExcelScript.Range#getOffsetRange:member(1)'
+  - name: getOffsetRange(rowOffset, columnOffset)
+    uid: ExcelScript!ExcelScript.Range#getOffsetRange:member(1)
     package: ExcelScript!
-    fullName: 'getOffsetRange(rowOffset, columnOffset)'
+    fullName: getOffsetRange(rowOffset, columnOffset)
     summary: >-
-      Gets an object which represents a range that's offset from the specified range. The dimension of the returned
-      range will match this range. If the resulting range is forced outside the bounds of the worksheet grid, an error
-      will be thrown.
+      Gets an object which represents a range that's offset from the specified
+      range. The dimension of the returned range will match this range. If the
+      resulting range is forced outside the bounds of the worksheet grid, an
+      error will be thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1497,16 +1643,18 @@ methods:
       parameters:
         - id: rowOffset
           description: >-
-            The number of rows (positive, negative, or 0) by which the range is to be offset. Positive values are offset
-            downward, and negative values are offset upward.
+            The number of rows (positive, negative, or 0) by which the range is
+            to be offset. Positive values are offset downward, and negative
+            values are offset upward.
           type: number
         - id: columnOffset
           description: >-
-            The number of columns (positive, negative, or 0) by which the range is to be offset. Positive values are
-            offset to the right, and negative values are offset to the left.
+            The number of columns (positive, negative, or 0) by which the range
+            is to be offset. Positive values are offset to the right, and
+            negative values are offset to the left.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -1540,11 +1688,12 @@ methods:
           }
           ```
   - name: getPivotTables(fullyContained)
-    uid: 'ExcelScript!ExcelScript.Range#getPivotTables:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getPivotTables:member(1)
     package: ExcelScript!
     fullName: getPivotTables(fullyContained)
     summary: Gets a scoped collection of PivotTables that overlap with the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1552,37 +1701,41 @@ methods:
       parameters:
         - id: fullyContained
           description: >-
-            If `true`<!-- -->, returns only PivotTables that are fully contained within the range bounds. The default
-            value is `false`<!-- -->.
+            If `true`<!-- -->, returns only PivotTables that are fully contained
+            within the range bounds. The default value is `false`<!-- -->.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]
         description: ''
   - name: getPrecedents()
-    uid: 'ExcelScript!ExcelScript.Range#getPrecedents:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getPrecedents:member(1)
     package: ExcelScript!
     fullName: getPrecedents()
     summary: >-
-      Returns a `WorkbookRangeAreas` object that represents the range containing all the precedent cells of a specified
-      range in the same worksheet or across multiple worksheets. Note: This API returns an `ItemNotFound` error if no
-      precedents are found.
+      Returns a `WorkbookRangeAreas` object that represents the range containing
+      all the precedent cells of a specified range in the same worksheet or
+      across multiple worksheets. Note: This API returns an `ItemNotFound` error
+      if no precedents are found.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrecedents(): WorkbookRangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookRangeAreas:interface" />
         description: ''
   - name: getPredefinedCellStyle()
-    uid: 'ExcelScript!ExcelScript.Range#getPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: getPredefinedCellStyle()
     summary: >-
-      Represents the style of the current range. If the styles of the cells are inconsistent, `null` will be returned.
-      For custom styles, the style name will be returned. For built-in styles, a string representing a value in the
-      `BuiltInStyle` enum will be returned.
+      Represents the style of the current range. If the styles of the cells are
+      inconsistent, `null` will be returned. For custom styles, the style name
+      will be returned. For built-in styles, a string representing a value in
+      the `BuiltInStyle` enum will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1590,14 +1743,16 @@ methods:
       return:
         type: string
         description: ''
-  - name: 'getRangeEdge(direction, activeCell)'
-    uid: 'ExcelScript!ExcelScript.Range#getRangeEdge:member(1)'
+  - name: getRangeEdge(direction, activeCell)
+    uid: ExcelScript!ExcelScript.Range#getRangeEdge:member(1)
     package: ExcelScript!
-    fullName: 'getRangeEdge(direction, activeCell)'
+    fullName: getRangeEdge(direction, activeCell)
     summary: >-
-      Returns a range object that is the edge cell of the data region that corresponds to the provided direction. This
-      matches the <kbd>Ctrl</kbd>+<kbd>Arrow key</kbd> behavior in the Excel on Windows UI.
+      Returns a range object that is the edge cell of the data region that
+      corresponds to the provided direction. This matches the
+      <kbd>Ctrl</kbd>+<kbd>Arrow key</kbd> behavior in the Excel on Windows UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1609,14 +1764,15 @@ methods:
       parameters:
         - id: direction
           description: The direction from the active cell.
-          type: '<xref uid="ExcelScript!ExcelScript.KeyboardDirection:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.KeyboardDirection:enum" />
         - id: activeCell
           description: >-
-            The active cell in this range. By default, the active cell is the top-left cell of the range. An error is
-            thrown if the active cell is not in this range.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The active cell in this range. By default, the active cell is the
+            top-left cell of the range. An error is thrown if the active cell is
+            not in this range.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -1641,14 +1797,16 @@ methods:
             cellAfter.setValue("Total");
           }
           ```
-  - name: 'getResizedRange(deltaRows, deltaColumns)'
-    uid: 'ExcelScript!ExcelScript.Range#getResizedRange:member(1)'
+  - name: getResizedRange(deltaRows, deltaColumns)
+    uid: ExcelScript!ExcelScript.Range#getResizedRange:member(1)
     package: ExcelScript!
-    fullName: 'getResizedRange(deltaRows, deltaColumns)'
+    fullName: getResizedRange(deltaRows, deltaColumns)
     summary: >-
-      Gets a `Range` object similar to the current `Range` object, but with its bottom-right corner expanded (or
-      contracted) by some number of rows and columns.
+      Gets a `Range` object similar to the current `Range` object, but with its
+      bottom-right corner expanded (or contracted) by some number of rows and
+      columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1656,16 +1814,18 @@ methods:
       parameters:
         - id: deltaRows
           description: >-
-            The number of rows by which to expand the bottom-right corner, relative to the current range. Use a positive
-            number to expand the range, or a negative number to decrease it.
+            The number of rows by which to expand the bottom-right corner,
+            relative to the current range. Use a positive number to expand the
+            range, or a negative number to decrease it.
           type: number
         - id: deltaColumns
           description: >-
-            The number of columns by which to expand the bottom-right corner, relative to the current range. Use a
-            positive number to expand the range, or a negative number to decrease it.
+            The number of columns by which to expand the bottom-right corner,
+            relative to the current range. Use a positive number to expand the
+            range, or a negative number to decrease it.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -1694,11 +1854,12 @@ methods:
           }
           ```
   - name: getRow(row)
-    uid: 'ExcelScript!ExcelScript.Range#getRow:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRow:member(1)
     package: ExcelScript!
     fullName: getRow(row)
     summary: Gets a row contained in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1708,14 +1869,15 @@ methods:
           description: Row number of the range to be retrieved. Zero-indexed.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRowCount()
-    uid: 'ExcelScript!ExcelScript.Range#getRowCount:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRowCount:member(1)
     package: ExcelScript!
     fullName: getRowCount()
     summary: Returns the total number of rows in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1758,14 +1920,16 @@ methods:
           }
           ```
   - name: getRowHidden()
-    uid: 'ExcelScript!ExcelScript.Range#getRowHidden:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRowHidden:member(1)
     package: ExcelScript!
     fullName: getRowHidden()
     summary: >-
-      Represents if all rows in the current range are hidden. Value is `true` when all rows in a range are hidden. Value
-      is `false` when no rows in the range are hidden. Value is `null` when some rows in a range are hidden and other
-      rows in the same range are not hidden.
+      Represents if all rows in the current range are hidden. Value is `true`
+      when all rows in a range are hidden. Value is `false` when no rows in the
+      range are hidden. Value is `null` when some rows in a range are hidden and
+      other rows in the same range are not hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1774,11 +1938,12 @@ methods:
         type: boolean
         description: ''
   - name: getRowIndex()
-    uid: 'ExcelScript!ExcelScript.Range#getRowIndex:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRowIndex:member(1)
     package: ExcelScript!
     fullName: getRowIndex()
     summary: Returns the row number of the first cell in the range. Zero-indexed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1787,11 +1952,12 @@ methods:
         type: number
         description: ''
   - name: getRowsAbove(count)
-    uid: 'ExcelScript!ExcelScript.Range#getRowsAbove:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRowsAbove:member(1)
     package: ExcelScript!
     fullName: getRowsAbove(count)
     summary: Gets a certain number of rows above the current `Range` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1799,19 +1965,21 @@ methods:
       parameters:
         - id: count
           description: >-
-            Optional. The number of rows to include in the resulting range. In general, use a positive number to create
-            a range outside the current range. You can also use a negative number to create a range within the current
-            range. The default value is 1.
+            Optional. The number of rows to include in the resulting range. In
+            general, use a positive number to create a range outside the current
+            range. You can also use a negative number to create a range within
+            the current range. The default value is 1.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRowsBelow(count)
-    uid: 'ExcelScript!ExcelScript.Range#getRowsBelow:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getRowsBelow:member(1)
     package: ExcelScript!
     fullName: getRowsBelow(count)
     summary: Gets a certain number of rows below the current `Range` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1819,22 +1987,25 @@ methods:
       parameters:
         - id: count
           description: >-
-            Optional. The number of rows to include in the resulting range. In general, use a positive number to create
-            a range outside the current range. You can also use a negative number to create a range within the current
-            range. The default value is 1.
+            Optional. The number of rows to include in the resulting range. In
+            general, use a positive number to create a range outside the current
+            range. You can also use a negative number to create a range within
+            the current range. The default value is 1.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getSavedAsArray()
-    uid: 'ExcelScript!ExcelScript.Range#getSavedAsArray:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getSavedAsArray:member(1)
     package: ExcelScript!
     fullName: getSavedAsArray()
     summary: >-
-      Represents if all the cells would be saved as an array formula. Returns `true` if all cells would be saved as an
-      array formula, or `false` if all cells would not be saved as an array formula. Returns `null` if some cells would
-      be saved as an array formula and some would not be.
+      Represents if all the cells would be saved as an array formula. Returns
+      `true` if all cells would be saved as an array formula, or `false` if all
+      cells would not be saved as an array formula. Returns `null` if some cells
+      would be saved as an array formula and some would not be.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1843,26 +2014,29 @@ methods:
         type: boolean
         description: ''
   - name: getSort()
-    uid: 'ExcelScript!ExcelScript.Range#getSort:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getSort:member(1)
     package: ExcelScript!
     fullName: getSort()
     summary: Represents the range sort of the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSort(): RangeSort;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeSort:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeSort:interface" />
         description: ''
-  - name: 'getSpecialCells(cellType, cellValueType)'
-    uid: 'ExcelScript!ExcelScript.Range#getSpecialCells:member(1)'
+  - name: getSpecialCells(cellType, cellValueType)
+    uid: ExcelScript!ExcelScript.Range#getSpecialCells:member(1)
     package: ExcelScript!
-    fullName: 'getSpecialCells(cellType, cellValueType)'
+    fullName: getSpecialCells(cellType, cellValueType)
     summary: >-
-      Gets the `RangeAreas` object, comprising one or more ranges, that represents all the cells that match the
-      specified type and value. If no special cells are found, then this method returns `undefined`<!-- -->.
+      Gets the `RangeAreas` object, comprising one or more ranges, that
+      represents all the cells that match the specified type and value. If no
+      special cells are found, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1874,15 +2048,17 @@ methods:
       parameters:
         - id: cellType
           description: The type of cells to include.
-          type: '<xref uid="ExcelScript!ExcelScript.SpecialCellType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SpecialCellType:enum" />
         - id: cellValueType
           description: >-
-            If `cellType` is either `constants` or `formulas`<!-- -->, this argument is used to determine which types of
-            cells to include in the result. These values can be combined together to return more than one type. The
-            default is to select all constants or formulas, no matter what the type.
-          type: '<xref uid="ExcelScript!ExcelScript.SpecialCellValueType:enum" />'
+            If `cellType` is either `constants` or `formulas`<!-- -->, this
+            argument is used to determine which types of cells to include in the
+            result. These values can be combined together to return more than
+            one type. The default is to select all constants or formulas, no
+            matter what the type.
+          type: <xref uid="ExcelScript!ExcelScript.SpecialCellValueType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: |-
 
 
@@ -1903,56 +2079,63 @@ methods:
           }
           ```
   - name: getSpillingToRange()
-    uid: 'ExcelScript!ExcelScript.Range#getSpillingToRange:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getSpillingToRange:member(1)
     package: ExcelScript!
     fullName: getSpillingToRange()
     summary: >-
-      Gets the range object containing the spill range when called on an anchor cell. If the range isn't an anchor cell
-      or the spill range can't be found, then this method returns `undefined`<!-- -->.
+      Gets the range object containing the spill range when called on an anchor
+      cell. If the range isn't an anchor cell or the spill range can't be found,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSpillingToRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getSpillParent()
-    uid: 'ExcelScript!ExcelScript.Range#getSpillParent:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getSpillParent:member(1)
     package: ExcelScript!
     fullName: getSpillParent()
     summary: >-
-      Gets the range object containing the anchor cell for the cell getting spilled into. If it's not a spilled cell, or
-      more than one cell is given, then this method returns `undefined`<!-- -->.
+      Gets the range object containing the anchor cell for the cell getting
+      spilled into. If it's not a spilled cell, or more than one cell is given,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSpillParent(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getSurroundingRegion()
-    uid: 'ExcelScript!ExcelScript.Range#getSurroundingRegion:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getSurroundingRegion:member(1)
     package: ExcelScript!
     fullName: getSurroundingRegion()
     summary: >-
-      Returns a `Range` object that represents the surrounding region for the top-left cell in this range. A surrounding
-      region is a range bounded by any combination of blank rows and blank columns relative to this range.
+      Returns a `Range` object that represents the surrounding region for the
+      top-left cell in this range. A surrounding region is a range bounded by
+      any combination of blank rows and blank columns relative to this range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSurroundingRegion(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getTables(fullyContained)
-    uid: 'ExcelScript!ExcelScript.Range#getTables:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getTables:member(1)
     package: ExcelScript!
     fullName: getTables(fullyContained)
     summary: Gets a scoped collection of tables that overlap with the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1960,21 +2143,24 @@ methods:
       parameters:
         - id: fullyContained
           description: >-
-            If `true`<!-- -->, returns only tables that are fully contained within the range bounds. The default value
-            is `false`<!-- -->.
+            If `true`<!-- -->, returns only tables that are fully contained
+            within the range bounds. The default value is `false`<!-- -->.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />[]
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.Range#getText:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: >-
-      Represents Text value of the specified range. The Text value will not depend on the cell width. The \# sign
-      substitution that happens in Excel UI will not affect the text value returned by the API. If the range contains
-      multiple cells, the data from first cell (represented by row index of 0 and column index of 0) will be returned.
+      Represents Text value of the specified range. The Text value will not
+      depend on the cell width. The \# sign substitution that happens in Excel
+      UI will not affect the text value returned by the API. If the range
+      contains multiple cells, the data from first cell (represented by row
+      index of 0 and column index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1983,26 +2169,31 @@ methods:
         type: string
         description: ''
   - name: getTexts()
-    uid: 'ExcelScript!ExcelScript.Range#getTexts:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getTexts:member(1)
     package: ExcelScript!
     fullName: getTexts()
     summary: >-
-      Text values of the specified range. The text value will not depend on the cell width. The number sign (\#)
-      substitution that happens in the Excel UI will not affect the text value returned by the API.
+      Text values of the specified range. The text value will not depend on the
+      cell width. The number sign (\#) substitution that happens in the Excel UI
+      will not affect the text value returned by the API.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTexts(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.Range#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
-    summary: 'Returns the distance in points, for 100% zoom, from the top edge of the worksheet to the top edge of the range.'
+    summary: >-
+      Returns the distance in points, for 100% zoom, from the top edge of the
+      worksheet to the top edge of the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2011,13 +2202,14 @@ methods:
         type: number
         description: ''
   - name: getUsedRange(valuesOnly)
-    uid: 'ExcelScript!ExcelScript.Range#getUsedRange:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getUsedRange:member(1)
     package: ExcelScript!
     fullName: getUsedRange(valuesOnly)
     summary: >-
-      Returns the used range of the given range object. If there are no used cells within the range, then this method
-      returns `undefined`<!-- -->.
+      Returns the used range of the given range object. If there are no used
+      cells within the range, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2027,17 +2219,20 @@ methods:
           description: Considers only cells with values as used cells.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getValue()
-    uid: 'ExcelScript!ExcelScript.Range#getValue:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getValue:member(1)
     package: ExcelScript!
     fullName: getValue()
     summary: >-
-      Represents the raw value of the specified range. The data returned could be of type string, number, or a boolean.
-      Cell that contain an error will return the error string. If the range contains multiple cells, the data from first
-      cell (represented by row index of 0 and column index of 0) will be returned.
+      Represents the raw value of the specified range. The data returned could
+      be of type string, number, or a boolean. Cell that contain an error will
+      return the error string. If the range contains multiple cells, the data
+      from first cell (represented by row index of 0 and column index of 0) will
+      be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2065,35 +2260,39 @@ methods:
           }
           ```
   - name: getValues()
-    uid: 'ExcelScript!ExcelScript.Range#getValues:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getValues:member(1)
     package: ExcelScript!
     fullName: getValues()
     summary: >-
-      Represents the raw values of the specified range. The data returned could be a string, number, or boolean. Cells
-      that contain an error will return the error string. If the returned value starts with a plus ("+"), minus ("-"),
-      or equal sign ("="), Excel interprets this value as a formula.
+      Represents the raw values of the specified range. The data returned could
+      be a string, number, or boolean. Cells that contain an error will return
+      the error string. If the returned value starts with a plus ("+"), minus
+      ("-"), or equal sign ("="), Excel interprets this value as a formula.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValues(): (string | number | boolean)[][];'
       return:
-        type: '(string | number | boolean)[][]'
+        type: (string | number | boolean)[][]
         description: ''
   - name: getValueType()
-    uid: 'ExcelScript!ExcelScript.Range#getValueType:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getValueType:member(1)
     package: ExcelScript!
     fullName: getValueType()
     summary: >-
-      Represents the type of data in the cell. If the range contains multiple cells, the data from first cell
-      (represented by row index of 0 and column index of 0) will be returned.
+      Represents the type of data in the cell. If the range contains multiple
+      cells, the data from first cell (represented by row index of 0 and column
+      index of 0) will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValueType(): RangeValueType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />
         description: |-
 
 
@@ -2134,30 +2333,32 @@ methods:
           }
           ```
   - name: getValueTypes()
-    uid: 'ExcelScript!ExcelScript.Range#getValueTypes:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getValueTypes:member(1)
     package: ExcelScript!
     fullName: getValueTypes()
     summary: Specifies the type of data in each cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValueTypes(): RangeValueType[][];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]
         description: ''
   - name: getVisibleView()
-    uid: 'ExcelScript!ExcelScript.Range#getVisibleView:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getVisibleView:member(1)
     package: ExcelScript!
     fullName: getVisibleView()
     summary: Represents the visible rows of the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVisibleView(): RangeView;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeView:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeView:interface" />
         description: |-
 
 
@@ -2182,11 +2383,14 @@ methods:
           }
           ```
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.Range#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
-    summary: 'Returns the distance in points, for 100% zoom, from the left edge of the range to the right edge of the range.'
+    summary: >-
+      Returns the distance in points, for 100% zoom, from the left edge of the
+      range to the right edge of the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2195,24 +2399,26 @@ methods:
         type: number
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.Range#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Range#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: The worksheet containing the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: group(groupOption)
-    uid: 'ExcelScript!ExcelScript.Range#group:member(1)'
+    uid: ExcelScript!ExcelScript.Range#group:member(1)
     package: ExcelScript!
     fullName: group(groupOption)
     summary: Groups columns and rows for an outline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2220,10 +2426,12 @@ methods:
       parameters:
         - id: groupOption
           description: >-
-            Specifies how the range can be grouped by rows or columns. An `InvalidArgument` error is thrown when the
-            group option differs from the range's `isEntireRow` or `isEntireColumn` property (i.e., `range.isEntireRow`
-            is true and `groupOption` is "ByColumns" or `range.isEntireColumn` is true and `groupOption` is "ByRows").
-          type: '<xref uid="ExcelScript!ExcelScript.GroupOption:enum" />'
+            Specifies how the range can be grouped by rows or columns. An
+            `InvalidArgument` error is thrown when the group option differs from
+            the range's `isEntireRow` or `isEntireColumn` property (i.e.,
+            `range.isEntireRow` is true and `groupOption` is "ByColumns" or
+            `range.isEntireColumn` is true and `groupOption` is "ByRows").
+          type: <xref uid="ExcelScript!ExcelScript.GroupOption:enum" />
       return:
         type: void
         description: |-
@@ -2247,40 +2455,47 @@ methods:
           }
           ```
   - name: hideGroupDetails(groupOption)
-    uid: 'ExcelScript!ExcelScript.Range#hideGroupDetails:member(1)'
+    uid: ExcelScript!ExcelScript.Range#hideGroupDetails:member(1)
     package: ExcelScript!
     fullName: hideGroupDetails(groupOption)
     summary: Hides the details of the row or column group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'hideGroupDetails(groupOption: GroupOption): void;'
       parameters:
         - id: groupOption
-          description: Specifies whether to hide the details of grouped rows or grouped columns.
-          type: '<xref uid="ExcelScript!ExcelScript.GroupOption:enum" />'
+          description: >-
+            Specifies whether to hide the details of grouped rows or grouped
+            columns.
+          type: <xref uid="ExcelScript!ExcelScript.GroupOption:enum" />
       return:
         type: void
         description: ''
   - name: insert(shift)
-    uid: 'ExcelScript!ExcelScript.Range#insert:member(1)'
+    uid: ExcelScript!ExcelScript.Range#insert:member(1)
     package: ExcelScript!
     fullName: insert(shift)
     summary: >-
-      Inserts a cell or a range of cells into the worksheet in place of this range, and shifts the other cells to make
-      space. Returns a new `Range` object at the now blank space.
+      Inserts a cell or a range of cells into the worksheet in place of this
+      range, and shifts the other cells to make space. Returns a new `Range`
+      object at the now blank space.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'insert(shift: InsertShiftDirection): Range;'
       parameters:
         - id: shift
-          description: Specifies which way to shift the cells. See `ExcelScript.InsertShiftDirection` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.InsertShiftDirection:enum" />'
+          description: >-
+            Specifies which way to shift the cells. See
+            `ExcelScript.InsertShiftDirection` for details.
+          type: <xref uid="ExcelScript!ExcelScript.InsertShiftDirection:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -2306,11 +2521,12 @@ methods:
           }
           ```
   - name: merge(across)
-    uid: 'ExcelScript!ExcelScript.Range#merge:member(1)'
+    uid: ExcelScript!ExcelScript.Range#merge:member(1)
     package: ExcelScript!
     fullName: merge(across)
     summary: Merge the range cells into one region in the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2318,8 +2534,9 @@ methods:
       parameters:
         - id: across
           description: >-
-            Optional. Set `true` to merge cells in each row of the specified range as separate merged cells. The default
-            value is `false`<!-- -->.
+            Optional. Set `true` to merge cells in each row of the specified
+            range as separate merged cells. The default value is `false`<!--
+            -->.
           type: boolean
       return:
         type: void
@@ -2342,31 +2559,37 @@ methods:
           }
           ```
   - name: moveTo(destinationRange)
-    uid: 'ExcelScript!ExcelScript.Range#moveTo:member(1)'
+    uid: ExcelScript!ExcelScript.Range#moveTo:member(1)
     package: ExcelScript!
     fullName: moveTo(destinationRange)
     summary: >-
-      Moves cell values, formatting, and formulas from current range to the destination range, replacing the old
-      information in those cells. The destination range will be expanded automatically if it is smaller than the current
-      range. Any cells in the destination range that are outside of the original range's area are not changed.
+      Moves cell values, formatting, and formulas from current range to the
+      destination range, replacing the old information in those cells. The
+      destination range will be expanded automatically if it is smaller than the
+      current range. Any cells in the destination range that are outside of the
+      original range's area are not changed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'moveTo(destinationRange: Range | string): void;'
       parameters:
         - id: destinationRange
-          description: destinationRange Specifies the range to where the information in this range will be moved.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            destinationRange Specifies the range to where the information in
+            this range will be moved.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: ''
-  - name: 'removeDuplicates(columns, includesHeader)'
-    uid: 'ExcelScript!ExcelScript.Range#removeDuplicates:member(1)'
+  - name: removeDuplicates(columns, includesHeader)
+    uid: ExcelScript!ExcelScript.Range#removeDuplicates:member(1)
     package: ExcelScript!
-    fullName: 'removeDuplicates(columns, includesHeader)'
+    fullName: removeDuplicates(columns, includesHeader)
     summary: Removes duplicate values from the range specified by the columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2378,14 +2601,16 @@ methods:
       parameters:
         - id: columns
           description: >-
-            The columns inside the range that may contain duplicates. At least one column needs to be specified.
-            Zero-indexed.
-          type: 'number[]'
+            The columns inside the range that may contain duplicates. At least
+            one column needs to be specified. Zero-indexed.
+          type: number[]
         - id: includesHeader
           description: True if the input data contains header. Default is false.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RemoveDuplicatesResult:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.RemoveDuplicatesResult:interface"
+          />
         description: |-
 
 
@@ -2406,12 +2631,15 @@ methods:
             console.log(`Rows removed: ${removedResults.getRemoved()}.`);
           }
           ```
-  - name: 'replaceAll(text, replacement, criteria)'
-    uid: 'ExcelScript!ExcelScript.Range#replaceAll:member(1)'
+  - name: replaceAll(text, replacement, criteria)
+    uid: ExcelScript!ExcelScript.Range#replaceAll:member(1)
     package: ExcelScript!
-    fullName: 'replaceAll(text, replacement, criteria)'
-    summary: Finds and replaces the given string based on the criteria specified within the current range.
+    fullName: replaceAll(text, replacement, criteria)
+    summary: >-
+      Finds and replaces the given string based on the criteria specified within
+      the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2430,7 +2658,7 @@ methods:
           type: string
         - id: criteria
           description: Additional replacement criteria.
-          type: '<xref uid="ExcelScript!ExcelScript.ReplaceCriteria:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.ReplaceCriteria:interface" />
       return:
         type: number
         description: |-
@@ -2455,11 +2683,12 @@ methods:
           }
           ```
   - name: select()
-    uid: 'ExcelScript!ExcelScript.Range#select:member(1)'
+    uid: ExcelScript!ExcelScript.Range#select:member(1)
     package: ExcelScript!
     fullName: select()
     summary: Selects the specified range in the Excel UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2488,14 +2717,16 @@ methods:
           }
           ```
   - name: setColumnHidden(columnHidden)
-    uid: 'ExcelScript!ExcelScript.Range#setColumnHidden:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setColumnHidden:member(1)
     package: ExcelScript!
     fullName: setColumnHidden(columnHidden)
     summary: >-
-      Represents if all columns in the current range are hidden. Value is `true` when all columns in a range are hidden.
-      Value is `false` when no columns in the range are hidden. Value is `null` when some columns in a range are hidden
-      and other columns in the same range are not hidden.
+      Represents if all columns in the current range are hidden. Value is `true`
+      when all columns in a range are hidden. Value is `false` when no columns
+      in the range are hidden. Value is `null` when some columns in a range are
+      hidden and other columns in the same range are not hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2508,13 +2739,14 @@ methods:
         type: void
         description: ''
   - name: setControl(control)
-    uid: 'ExcelScript!ExcelScript.Range#setControl:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setControl:member(1)
     package: ExcelScript!
     fullName: setControl(control)
     summary: >-
-      Accesses the cell control applied to this range. If the range has multiple cell controls, this returns
-      `EmptyCellControl`<!-- -->.
+      Accesses the cell control applied to this range. If the range has multiple
+      cell controls, this returns `EmptyCellControl`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2522,16 +2754,17 @@ methods:
       parameters:
         - id: control
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.CellControl:type" />'
+          type: <xref uid="ExcelScript!ExcelScript.CellControl:type" />
       return:
         type: void
         description: ''
   - name: setDirty()
-    uid: 'ExcelScript!ExcelScript.Range#setDirty:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setDirty:member(1)
     package: ExcelScript!
     fullName: setDirty()
     summary: Set a range to be recalculated when the next recalculation occurs.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2540,13 +2773,14 @@ methods:
         type: void
         description: ''
   - name: setFormula(formula)
-    uid: 'ExcelScript!ExcelScript.Range#setFormula:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormula:member(1)
     package: ExcelScript!
     fullName: setFormula(formula)
     summary: >-
-      Sets the cell formula in A1-style notation. If the range contains multiple cells, each cell in the given range
-      will be updated with the input data.
+      Sets the cell formula in A1-style notation. If the range contains multiple
+      cells, each cell in the given range will be updated with the input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2583,14 +2817,16 @@ methods:
           }
           ```
   - name: setFormulaLocal(formulaLocal)
-    uid: 'ExcelScript!ExcelScript.Range#setFormulaLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormulaLocal:member(1)
     package: ExcelScript!
     fullName: setFormulaLocal(formulaLocal)
     summary: >-
-      Set the cell formula in A1-style notation, in the user's language and number-formatting locale. For example, the
-      English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If the range contains multiple cells,
-      each cell in the given range will be updated with the input data.
+      Set the cell formula in A1-style notation, in the user's language and
+      number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula
+      would become "=SUMME(A1; 1,5)" in German. If the range contains multiple
+      cells, each cell in the given range will be updated with the input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2603,13 +2839,15 @@ methods:
         type: void
         description: ''
   - name: setFormulaR1C1(formulaR1C1)
-    uid: 'ExcelScript!ExcelScript.Range#setFormulaR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormulaR1C1:member(1)
     package: ExcelScript!
     fullName: setFormulaR1C1(formulaR1C1)
     summary: >-
-      Sets the cell formula in R1C1-style notation. If the range contains multiple cells, each cell in the given range
-      will be updated with the input data.
+      Sets the cell formula in R1C1-style notation. If the range contains
+      multiple cells, each cell in the given range will be updated with the
+      input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2622,11 +2860,14 @@ methods:
         type: void
         description: ''
   - name: setFormulas(formulas)
-    uid: 'ExcelScript!ExcelScript.Range#setFormulas:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormulas:member(1)
     package: ExcelScript!
     fullName: setFormulas(formulas)
-    summary: 'Represents the formula in A1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in A1-style notation. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2634,7 +2875,7 @@ methods:
       parameters:
         - id: formulas
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: |-
@@ -2663,14 +2904,16 @@ methods:
           }
           ```
   - name: setFormulasLocal(formulasLocal)
-    uid: 'ExcelScript!ExcelScript.Range#setFormulasLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormulasLocal:member(1)
     package: ExcelScript!
     fullName: setFormulasLocal(formulasLocal)
     summary: >-
-      Represents the formula in A1-style notation, in the user's language and number-formatting locale. For example, the
-      English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its value is
-      returned instead.
+      Represents the formula in A1-style notation, in the user's language and
+      number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula
+      would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2678,16 +2921,19 @@ methods:
       parameters:
         - id: formulasLocal
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setFormulasR1C1(formulasR1C1)
-    uid: 'ExcelScript!ExcelScript.Range#setFormulasR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setFormulasR1C1:member(1)
     package: ExcelScript!
     fullName: setFormulasR1C1(formulasR1C1)
-    summary: 'Represents the formula in R1C1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in R1C1-style notation. If a cell has no formula,
+      its value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2695,16 +2941,17 @@ methods:
       parameters:
         - id: formulasR1C1
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setHyperlink(hyperlink)
-    uid: 'ExcelScript!ExcelScript.Range#setHyperlink:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setHyperlink:member(1)
     package: ExcelScript!
     fullName: setHyperlink(hyperlink)
     summary: Represents the hyperlink for the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2712,7 +2959,7 @@ methods:
       parameters:
         - id: hyperlink
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.RangeHyperlink:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.RangeHyperlink:interface" />
       return:
         type: void
         description: |-
@@ -2748,13 +2995,15 @@ methods:
           }
           ```
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.Range#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: >-
-      Sets cell Excel number format code for the given range. If the range contains multiple cells, each cell in the
-      given range will be updated with the input data.
+      Sets cell Excel number format code for the given range. If the range
+      contains multiple cells, each cell in the given range will be updated with
+      the input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2782,15 +3031,18 @@ methods:
           }
           ```
   - name: setNumberFormatLocal(numberFormatLocal)
-    uid: 'ExcelScript!ExcelScript.Range#setNumberFormatLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setNumberFormatLocal:member(1)
     package: ExcelScript!
     fullName: setNumberFormatLocal(numberFormatLocal)
     summary: >-
-      Sets cell Excel number format code for the given range, based on the language settings of the user.​ Excel does
-      not perform any language or format coercion when getting or setting the `numberFormatLocal` property. Any returned
-      text uses the locally-formatted strings based on the language specified in the system settings. If the range
-      contains multiple cells, each cell in the given range will be updated with the input data.
+      Sets cell Excel number format code for the given range, based on the
+      language settings of the user.​ Excel does not perform any language or
+      format coercion when getting or setting the `numberFormatLocal` property.
+      Any returned text uses the locally-formatted strings based on the language
+      specified in the system settings. If the range contains multiple cells,
+      each cell in the given range will be updated with the input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2818,11 +3070,12 @@ methods:
           }
           ```
   - name: setNumberFormats(numberFormats)
-    uid: 'ExcelScript!ExcelScript.Range#setNumberFormats:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setNumberFormats:member(1)
     package: ExcelScript!
     fullName: setNumberFormats(numberFormats)
     summary: Represents Excel's number format code for the given range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2830,19 +3083,22 @@ methods:
       parameters:
         - id: numberFormats
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setNumberFormatsLocal(numberFormatsLocal)
-    uid: 'ExcelScript!ExcelScript.Range#setNumberFormatsLocal:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setNumberFormatsLocal:member(1)
     package: ExcelScript!
     fullName: setNumberFormatsLocal(numberFormatsLocal)
     summary: >-
-      Represents Excel's number format code for the given range, based on the language settings of the user. Excel does
-      not perform any language or format coercion when getting or setting the `numberFormatLocal` property. Any returned
-      text uses the locally-formatted strings based on the language specified in the system settings.
+      Represents Excel's number format code for the given range, based on the
+      language settings of the user. Excel does not perform any language or
+      format coercion when getting or setting the `numberFormatLocal` property.
+      Any returned text uses the locally-formatted strings based on the language
+      specified in the system settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2850,16 +3106,17 @@ methods:
       parameters:
         - id: numberFormatsLocal
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setPredefinedCellStyle(predefinedCellStyle)
-    uid: 'ExcelScript!ExcelScript.Range#setPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: setPredefinedCellStyle(predefinedCellStyle)
     summary: Represents the style of the current range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2872,14 +3129,16 @@ methods:
         type: void
         description: ''
   - name: setRowHidden(rowHidden)
-    uid: 'ExcelScript!ExcelScript.Range#setRowHidden:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setRowHidden:member(1)
     package: ExcelScript!
     fullName: setRowHidden(rowHidden)
     summary: >-
-      Represents if all rows in the current range are hidden. Value is `true` when all rows in a range are hidden. Value
-      is `false` when no rows in the range are hidden. Value is `null` when some rows in a range are hidden and other
-      rows in the same range are not hidden.
+      Represents if all rows in the current range are hidden. Value is `true`
+      when all rows in a range are hidden. Value is `false` when no rows in the
+      range are hidden. Value is `null` when some rows in a range are hidden and
+      other rows in the same range are not hidden.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2892,14 +3151,16 @@ methods:
         type: void
         description: ''
   - name: setValue(value)
-    uid: 'ExcelScript!ExcelScript.Range#setValue:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setValue:member(1)
     package: ExcelScript!
     fullName: setValue(value)
     summary: >-
-      Sets the raw value of the specified range. The data being set could be of type string, number, or a boolean.
-      `null` value will be ignored (not set or overwritten in Excel). If the range contains multiple cells, each cell in
-      the given range will be updated with the input data.
+      Sets the raw value of the specified range. The data being set could be of
+      type string, number, or a boolean. `null` value will be ignored (not set
+      or overwritten in Excel). If the range contains multiple cells, each cell
+      in the given range will be updated with the input data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2912,14 +3173,16 @@ methods:
         type: void
         description: ''
   - name: setValues(values)
-    uid: 'ExcelScript!ExcelScript.Range#setValues:member(1)'
+    uid: ExcelScript!ExcelScript.Range#setValues:member(1)
     package: ExcelScript!
     fullName: setValues(values)
     summary: >-
-      Sets the raw values of the specified range. The data provided could be a string, number, or boolean. If the
-      provided value starts with a plus ("+"), minus ("-"), or equal sign ("="), Excel interprets this value as a
+      Sets the raw values of the specified range. The data provided could be a
+      string, number, or boolean. If the provided value starts with a plus
+      ("+"), minus ("-"), or equal sign ("="), Excel interprets this value as a
       formula.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2927,7 +3190,7 @@ methods:
       parameters:
         - id: values
           description: ''
-          type: '(string | number | boolean)[][]'
+          type: (string | number | boolean)[][]
       return:
         type: void
         description: |-
@@ -2972,11 +3235,12 @@ methods:
            ];
           ```
   - name: showCard()
-    uid: 'ExcelScript!ExcelScript.Range#showCard:member(1)'
+    uid: ExcelScript!ExcelScript.Range#showCard:member(1)
     package: ExcelScript!
     fullName: showCard()
     summary: Displays the card for an active cell if it has rich value content.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -2985,28 +3249,32 @@ methods:
         type: void
         description: ''
   - name: showGroupDetails(groupOption)
-    uid: 'ExcelScript!ExcelScript.Range#showGroupDetails:member(1)'
+    uid: ExcelScript!ExcelScript.Range#showGroupDetails:member(1)
     package: ExcelScript!
     fullName: showGroupDetails(groupOption)
     summary: Shows the details of the row or column group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'showGroupDetails(groupOption: GroupOption): void;'
       parameters:
         - id: groupOption
-          description: Specifies whether to show the details of grouped rows or grouped columns.
-          type: '<xref uid="ExcelScript!ExcelScript.GroupOption:enum" />'
+          description: >-
+            Specifies whether to show the details of grouped rows or grouped
+            columns.
+          type: <xref uid="ExcelScript!ExcelScript.GroupOption:enum" />
       return:
         type: void
         description: ''
   - name: ungroup(groupOption)
-    uid: 'ExcelScript!ExcelScript.Range#ungroup:member(1)'
+    uid: ExcelScript!ExcelScript.Range#ungroup:member(1)
     package: ExcelScript!
     fullName: ungroup(groupOption)
     summary: Ungroups columns and rows for an outline.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -3014,16 +3282,17 @@ methods:
       parameters:
         - id: groupOption
           description: Specifies how the range can be ungrouped by rows or columns.
-          type: '<xref uid="ExcelScript!ExcelScript.GroupOption:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.GroupOption:enum" />
       return:
         type: void
         description: ''
   - name: unmerge()
-    uid: 'ExcelScript!ExcelScript.Range#unmerge:member(1)'
+    uid: ExcelScript!ExcelScript.Range#unmerge:member(1)
     package: ExcelScript!
     fullName: unmerge()
     summary: Unmerge the range cells into separate cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeareas.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeareas.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeAreas
-uid: 'ExcelScript!ExcelScript.RangeAreas:interface'
+uid: ExcelScript!ExcelScript.RangeAreas:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeAreas
-summary: '`RangeAreas` represents a collection of one or more rectangular ranges in the same worksheet.'
+summary: >-
+  `RangeAreas` represents a collection of one or more rectangular ranges in the
+  same worksheet.
 remarks: |-
 
 
@@ -27,33 +29,38 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: addConditionalFormat(type)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#addConditionalFormat:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#addConditionalFormat:member(1)
     package: ExcelScript!
     fullName: addConditionalFormat(type)
     summary: Adds a new conditional format to the collection at the first/top priority.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'addConditionalFormat(type: ConditionalFormatType): ConditionalFormat;'
       parameters:
         - id: type
-          description: The type of conditional format being added. See `ExcelScript.ConditionalFormatType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />'
+          description: >-
+            The type of conditional format being added. See
+            `ExcelScript.ConditionalFormatType` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ConditionalFormatType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />
         description: ''
   - name: calculate()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#calculate:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#calculate:member(1)
     package: ExcelScript!
     fullName: calculate()
     summary: Calculates all cells in the `RangeAreas`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,21 +69,24 @@ methods:
         type: void
         description: ''
   - name: clear(applyTo)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#clear:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#clear:member(1)
     package: ExcelScript!
     fullName: clear(applyTo)
     summary: >-
-      Clears values, format, fill, border, and other properties on each of the areas that comprise this `RangeAreas`
-      object.
+      Clears values, format, fill, border, and other properties on each of the
+      areas that comprise this `RangeAreas` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'clear(applyTo?: ClearApplyTo): void;'
       parameters:
         - id: applyTo
-          description: Optional. Determines the type of clear action. See `ExcelScript.ClearApplyTo` for details. Default is "All".
-          type: '<xref uid="ExcelScript!ExcelScript.ClearApplyTo:enum" />'
+          description: >-
+            Optional. Determines the type of clear action. See
+            `ExcelScript.ClearApplyTo` for details. Default is "All".
+          type: <xref uid="ExcelScript!ExcelScript.ClearApplyTo:enum" />
       return:
         type: void
         description: |-
@@ -103,11 +113,12 @@ methods:
           }
           ```
   - name: clearAllConditionalFormats()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#clearAllConditionalFormats:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#clearAllConditionalFormats:member(1)
     package: ExcelScript!
     fullName: clearAllConditionalFormats()
     summary: Clears all conditional formats active on the current specified range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,15 +127,18 @@ methods:
         type: void
         description: ''
   - name: clearOrResetContents()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#clearOrResetContents:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#clearOrResetContents:member(1)
     package: ExcelScript!
     fullName: clearOrResetContents()
     summary: >-
-      Clears the values of the cells in the ranges, with special consideration given to cells containing controls. If
-      the ranges contain only blank values and controls set to their default value, then the values and control
-      formatting are removed. Otherwise, this sets the cells with controls to their default value and clears the values
-      of the other cells in the ranges.
+      Clears the values of the cells in the ranges, with special consideration
+      given to cells containing controls. If the ranges contain only blank
+      values and controls set to their default value, then the values and
+      control formatting are removed. Otherwise, this sets the cells with
+      controls to their default value and clears the values of the other cells
+      in the ranges.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -133,11 +147,12 @@ methods:
         type: void
         description: ''
   - name: convertDataTypeToText()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#convertDataTypeToText:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#convertDataTypeToText:member(1)
     package: ExcelScript!
     fullName: convertDataTypeToText()
     summary: Converts all cells in the `RangeAreas` with data types into text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -145,15 +160,18 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'copyFrom(sourceRange, copyType, skipBlanks, transpose)'
-    uid: 'ExcelScript!ExcelScript.RangeAreas#copyFrom:member(1)'
+  - name: copyFrom(sourceRange, copyType, skipBlanks, transpose)
+    uid: ExcelScript!ExcelScript.RangeAreas#copyFrom:member(1)
     package: ExcelScript!
-    fullName: 'copyFrom(sourceRange, copyType, skipBlanks, transpose)'
+    fullName: copyFrom(sourceRange, copyType, skipBlanks, transpose)
     summary: >-
-      Copies cell data or formatting from the source range or `RangeAreas` to the current `RangeAreas`<!-- -->. The
-      destination `RangeAreas` can be a different size than the source range or `RangeAreas`<!-- -->. The destination
-      will be expanded automatically if it is smaller than the source.
+      Copies cell data or formatting from the source range or `RangeAreas` to
+      the current `RangeAreas`<!-- -->. The destination `RangeAreas` can be a
+      different size than the source range or `RangeAreas`<!-- -->. The
+      destination will be expanded automatically if it is smaller than the
+      source.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -167,31 +185,38 @@ methods:
       parameters:
         - id: sourceRange
           description: >-
-            The source range or `RangeAreas` to copy from. When the source `RangeAreas` has multiple ranges, their form
-            must able to be created by removing full rows or columns from a rectangular range.
+            The source range or `RangeAreas` to copy from. When the source
+            `RangeAreas` has multiple ranges, their form must able to be created
+            by removing full rows or columns from a rectangular range.
           type: >-
             <xref uid="ExcelScript!ExcelScript.Range:interface" /> | <xref
             uid="ExcelScript!ExcelScript.RangeAreas:interface" /> | string
         - id: copyType
           description: The type of cell data or formatting to copy over. Default is "All".
-          type: '<xref uid="ExcelScript!ExcelScript.RangeCopyType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.RangeCopyType:enum" />
         - id: skipBlanks
-          description: True if to skip blank cells in the source range or `RangeAreas`<!-- -->. Default is false.
+          description: >-
+            True if to skip blank cells in the source range or `RangeAreas`<!--
+            -->. Default is false.
           type: boolean
         - id: transpose
-          description: True if to transpose the cells in the destination `RangeAreas`<!-- -->. Default is false.
+          description: >-
+            True if to transpose the cells in the destination `RangeAreas`<!--
+            -->. Default is false.
           type: boolean
       return:
         type: void
         description: ''
   - name: getAddress()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getAddress:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getAddress:member(1)
     package: ExcelScript!
     fullName: getAddress()
     summary: >-
-      Returns the `RangeAreas` reference in A1-style. Address value will contain the worksheet name for each rectangular
-      block of cells (e.g., "Sheet1!A1:B4, Sheet1!D1:D4").
+      Returns the `RangeAreas` reference in A1-style. Address value will contain
+      the worksheet name for each rectangular block of cells (e.g.,
+      "Sheet1!A1:B4, Sheet1!D1:D4").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -200,11 +225,12 @@ methods:
         type: string
         description: ''
   - name: getAddressLocal()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getAddressLocal:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getAddressLocal:member(1)
     package: ExcelScript!
     fullName: getAddressLocal()
     summary: Returns the `RangeAreas` reference in the user locale.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -213,11 +239,14 @@ methods:
         type: string
         description: ''
   - name: getAreaCount()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getAreaCount:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getAreaCount:member(1)
     package: ExcelScript!
     fullName: getAreaCount()
-    summary: Returns the number of rectangular ranges that comprise this `RangeAreas` object.
+    summary: >-
+      Returns the number of rectangular ranges that comprise this `RangeAreas`
+      object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -226,26 +255,31 @@ methods:
         type: number
         description: ''
   - name: getAreas()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getAreas:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getAreas:member(1)
     package: ExcelScript!
     fullName: getAreas()
-    summary: Returns a collection of rectangular ranges that comprise this `RangeAreas` object.
+    summary: >-
+      Returns a collection of rectangular ranges that comprise this `RangeAreas`
+      object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAreas(): Range[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />[]
         description: ''
   - name: getCellCount()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getCellCount:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getCellCount:member(1)
     package: ExcelScript!
     fullName: getCellCount()
     summary: >-
-      Returns the number of cells in the `RangeAreas` object, summing up the cell counts of all of the individual
-      rectangular ranges. Returns -1 if the cell count exceeds 2^31-1 (2,147,483,647).
+      Returns the number of cells in the `RangeAreas` object, summing up the
+      cell counts of all of the individual rectangular ranges. Returns -1 if the
+      cell count exceeds 2^31-1 (2,147,483,647).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -254,13 +288,15 @@ methods:
         type: number
         description: ''
   - name: getConditionalFormat(id)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getConditionalFormat:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getConditionalFormat:member(1)
     package: ExcelScript!
     fullName: getConditionalFormat(id)
     summary: >-
-      Returns a conditional format identified by its ID. If the conditional format object does not exist, then this
-      method returns `undefined`<!-- -->.
+      Returns a conditional format identified by its ID. If the conditional
+      format object does not exist, then this method returns `undefined`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -270,78 +306,92 @@ methods:
           description: The ID of the conditional format.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" /> |
+          undefined
         description: ''
   - name: getConditionalFormats()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getConditionalFormats:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getConditionalFormats:member(1)
     package: ExcelScript!
     fullName: getConditionalFormats()
-    summary: Returns a collection of conditional formats that intersect with any cells in this `RangeAreas` object.
+    summary: >-
+      Returns a collection of conditional formats that intersect with any cells
+      in this `RangeAreas` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getConditionalFormats(): ConditionalFormat[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.ConditionalFormat:interface" />[]
         description: ''
   - name: getDataValidation()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getDataValidation:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getDataValidation:member(1)
     package: ExcelScript!
     fullName: getDataValidation()
-    summary: Returns a data validation object for all ranges in the `RangeAreas`<!-- -->.
+    summary: >-
+      Returns a data validation object for all ranges in the `RangeAreas`<!--
+      -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDataValidation(): DataValidation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DataValidation:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DataValidation:interface" />
         description: ''
   - name: getEntireColumn()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getEntireColumn:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getEntireColumn:member(1)
     package: ExcelScript!
     fullName: getEntireColumn()
     summary: >-
-      Returns a `RangeAreas` object that represents the entire columns of the `RangeAreas` (for example, if the current
-      `RangeAreas` represents cells "B4:E11, H2", it returns a `RangeAreas` that represents columns "B:E, H:H").
+      Returns a `RangeAreas` object that represents the entire columns of the
+      `RangeAreas` (for example, if the current `RangeAreas` represents cells
+      "B4:E11, H2", it returns a `RangeAreas` that represents columns "B:E,
+      H:H").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEntireColumn(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getEntireRow()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getEntireRow:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getEntireRow:member(1)
     package: ExcelScript!
     fullName: getEntireRow()
     summary: >-
-      Returns a `RangeAreas` object that represents the entire rows of the `RangeAreas` (for example, if the current
-      `RangeAreas` represents cells "B4:E11", it returns a `RangeAreas` that represents rows "4:11").
+      Returns a `RangeAreas` object that represents the entire rows of the
+      `RangeAreas` (for example, if the current `RangeAreas` represents cells
+      "B4:E11", it returns a `RangeAreas` that represents rows "4:11").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getEntireRow(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
     summary: >-
-      Returns a `RangeFormat` object, encapsulating the font, fill, borders, alignment, and other properties for all
-      ranges in the `RangeAreas` object.
+      Returns a `RangeFormat` object, encapsulating the font, fill, borders,
+      alignment, and other properties for all ranges in the `RangeAreas` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): RangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFormat:interface" />
         description: |-
 
 
@@ -364,32 +414,39 @@ methods:
           }
           ```
   - name: getIntersection(anotherRange)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getIntersection:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getIntersection:member(1)
     package: ExcelScript!
     fullName: getIntersection(anotherRange)
     summary: >-
-      Returns the `RangeAreas` object that represents the intersection of the given ranges or `RangeAreas`<!-- -->. If
-      no intersection is found, then this method returns `undefined`<!-- -->.
+      Returns the `RangeAreas` object that represents the intersection of the
+      given ranges or `RangeAreas`<!-- -->. If no intersection is found, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getIntersection(anotherRange: Range | RangeAreas | string): RangeAreas;'
       parameters:
         - id: anotherRange
-          description: 'The range, `RangeAreas` object, or address that will be used to determine the intersection.'
+          description: >-
+            The range, `RangeAreas` object, or address that will be used to
+            determine the intersection.
           type: >-
             <xref uid="ExcelScript!ExcelScript.Range:interface" /> | <xref
             uid="ExcelScript!ExcelScript.RangeAreas:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getIsEntireColumn()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getIsEntireColumn:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getIsEntireColumn:member(1)
     package: ExcelScript!
     fullName: getIsEntireColumn()
-    summary: 'Specifies if all the ranges on this `RangeAreas` object represent entire columns (e.g., "A:C, Q:Z").'
+    summary: >-
+      Specifies if all the ranges on this `RangeAreas` object represent entire
+      columns (e.g., "A:C, Q:Z").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -398,11 +455,14 @@ methods:
         type: boolean
         description: ''
   - name: getIsEntireRow()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getIsEntireRow:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getIsEntireRow:member(1)
     package: ExcelScript!
     fullName: getIsEntireRow()
-    summary: 'Specifies if all the ranges on this `RangeAreas` object represent entire rows (e.g., "1:3, 5:7").'
+    summary: >-
+      Specifies if all the ranges on this `RangeAreas` object represent entire
+      rows (e.g., "1:3, 5:7").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -410,15 +470,17 @@ methods:
       return:
         type: boolean
         description: ''
-  - name: 'getOffsetRangeAreas(rowOffset, columnOffset)'
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getOffsetRangeAreas:member(1)'
+  - name: getOffsetRangeAreas(rowOffset, columnOffset)
+    uid: ExcelScript!ExcelScript.RangeAreas#getOffsetRangeAreas:member(1)
     package: ExcelScript!
-    fullName: 'getOffsetRangeAreas(rowOffset, columnOffset)'
+    fullName: getOffsetRangeAreas(rowOffset, columnOffset)
     summary: >-
-      Returns a `RangeAreas` object that is shifted by the specific row and column offset. The dimension of the returned
-      `RangeAreas` will match the original object. If the resulting `RangeAreas` is forced outside the bounds of the
-      worksheet grid, an error will be thrown.
+      Returns a `RangeAreas` object that is shifted by the specific row and
+      column offset. The dimension of the returned `RangeAreas` will match the
+      original object. If the resulting `RangeAreas` is forced outside the
+      bounds of the worksheet grid, an error will be thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -430,26 +492,30 @@ methods:
       parameters:
         - id: rowOffset
           description: >-
-            The number of rows (positive, negative, or 0) by which the `RangeAreas` is to be offset. Positive values are
-            offset downward, and negative values are offset upward.
+            The number of rows (positive, negative, or 0) by which the
+            `RangeAreas` is to be offset. Positive values are offset downward,
+            and negative values are offset upward.
           type: number
         - id: columnOffset
           description: >-
-            The number of columns (positive, negative, or 0) by which the `RangeAreas` is to be offset. Positive values
-            are offset to the right, and negative values are offset to the left.
+            The number of columns (positive, negative, or 0) by which the
+            `RangeAreas` is to be offset. Positive values are offset to the
+            right, and negative values are offset to the left.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getPredefinedCellStyle()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: getPredefinedCellStyle()
     summary: >-
-      Represents the style for all ranges in this `RangeAreas` object. If the styles of the cells are inconsistent,
-      `null` will be returned. For custom styles, the style name will be returned. For built-in styles, a string
+      Represents the style for all ranges in this `RangeAreas` object. If the
+      styles of the cells are inconsistent, `null` will be returned. For custom
+      styles, the style name will be returned. For built-in styles, a string
       representing a value in the `BuiltInStyle` enum will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -457,14 +523,16 @@ methods:
       return:
         type: string
         description: ''
-  - name: 'getSpecialCells(cellType, cellValueType)'
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getSpecialCells:member(1)'
+  - name: getSpecialCells(cellType, cellValueType)
+    uid: ExcelScript!ExcelScript.RangeAreas#getSpecialCells:member(1)
     package: ExcelScript!
-    fullName: 'getSpecialCells(cellType, cellValueType)'
+    fullName: getSpecialCells(cellType, cellValueType)
     summary: >-
-      Returns a `RangeAreas` object that represents all the cells that match the specified type and value. If no special
-      cells are found that match the criteria, then this method returns `undefined`<!-- -->.
+      Returns a `RangeAreas` object that represents all the cells that match the
+      specified type and value. If no special cells are found that match the
+      criteria, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -476,22 +544,27 @@ methods:
       parameters:
         - id: cellType
           description: The type of cells to include.
-          type: '<xref uid="ExcelScript!ExcelScript.SpecialCellType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SpecialCellType:enum" />
         - id: cellValueType
           description: >-
-            If `cellType` is either `constants` or `formulas`<!-- -->, this argument is used to determine which types of
-            cells to include in the result. These values can be combined together to return more than one type. The
-            default is to select all constants or formulas, no matter what the type.
-          type: '<xref uid="ExcelScript!ExcelScript.SpecialCellValueType:enum" />'
+            If `cellType` is either `constants` or `formulas`<!-- -->, this
+            argument is used to determine which types of cells to include in the
+            result. These values can be combined together to return more than
+            one type. The default is to select all constants or formulas, no
+            matter what the type.
+          type: <xref uid="ExcelScript!ExcelScript.SpecialCellValueType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getTables(fullyContained)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getTables:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getTables:member(1)
     package: ExcelScript!
     fullName: getTables(fullyContained)
-    summary: Returns a scoped collection of tables that overlap with any range in this `RangeAreas` object.
+    summary: >-
+      Returns a scoped collection of tables that overlap with any range in this
+      `RangeAreas` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -499,21 +572,23 @@ methods:
       parameters:
         - id: fullyContained
           description: >-
-            If `true`<!-- -->, returns only tables that are fully contained within the range bounds. Default is
-            `false`<!-- -->.
+            If `true`<!-- -->, returns only tables that are fully contained
+            within the range bounds. Default is `false`<!-- -->.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />[]
         description: ''
   - name: getUsedRangeAreas(valuesOnly)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getUsedRangeAreas:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getUsedRangeAreas:member(1)
     package: ExcelScript!
     fullName: getUsedRangeAreas(valuesOnly)
     summary: >-
-      Returns the used `RangeAreas` that comprises all the used areas of individual rectangular ranges in the
-      `RangeAreas` object. If there are no used cells within the `RangeAreas`<!-- -->, then this method returns
+      Returns the used `RangeAreas` that comprises all the used areas of
+      individual rectangular ranges in the `RangeAreas` object. If there are no
+      used cells within the `RangeAreas`<!-- -->, then this method returns
       `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -523,27 +598,31 @@ methods:
           description: Whether to only consider cells with values as used cells.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: Returns the worksheet for the current `RangeAreas`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: setDirty()
-    uid: 'ExcelScript!ExcelScript.RangeAreas#setDirty:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#setDirty:member(1)
     package: ExcelScript!
     fullName: setDirty()
-    summary: Sets the `RangeAreas` to be recalculated when the next recalculation occurs.
+    summary: >-
+      Sets the `RangeAreas` to be recalculated when the next recalculation
+      occurs.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -552,14 +631,16 @@ methods:
         type: void
         description: ''
   - name: setPredefinedCellStyle(predefinedCellStyle)
-    uid: 'ExcelScript!ExcelScript.RangeAreas#setPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.RangeAreas#setPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: setPredefinedCellStyle(predefinedCellStyle)
     summary: >-
-      Represents the style for all ranges in this `RangeAreas` object. If the styles of the cells are inconsistent,
-      `null` will be returned. For custom styles, the style name will be returned. For built-in styles, a string
+      Represents the style for all ranges in this `RangeAreas` object. If the
+      styles of the cells are inconsistent, `null` will be returned. For custom
+      styles, the style name will be returned. For built-in styles, a string
       representing a value in the `BuiltInStyle` enum will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeborder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeborder.yml
@@ -1,22 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeBorder
-uid: 'ExcelScript!ExcelScript.RangeBorder:interface'
+uid: ExcelScript!ExcelScript.RangeBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeBorder
 summary: Represents the border of an object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.RangeBorder#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500"), or as a named
-      HTML color (e.g., "orange").
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -25,42 +27,48 @@ methods:
         type: string
         description: ''
   - name: getSideIndex()
-    uid: 'ExcelScript!ExcelScript.RangeBorder#getSideIndex:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#getSideIndex:member(1)
     package: ExcelScript!
     fullName: getSideIndex()
-    summary: Constant value that indicates the specific side of the border. See `ExcelScript.BorderIndex` for details.
+    summary: >-
+      Constant value that indicates the specific side of the border. See
+      `ExcelScript.BorderIndex` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSideIndex(): BorderIndex;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.RangeBorder#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
     summary: >-
-      One of the constants of line style specifying the line style for the border. See `ExcelScript.BorderLineStyle` for
-      details.
+      One of the constants of line style specifying the line style for the
+      border. See `ExcelScript.BorderLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getStyle(): BorderLineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BorderLineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.BorderLineStyle:enum" />
         description: ''
   - name: getTintAndShade()
-    uid: 'ExcelScript!ExcelScript.RangeBorder#getTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#getTintAndShade:member(1)
     package: ExcelScript!
     fullName: getTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a color for the range border, the value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the border doesn't have a uniform
-      `tintAndShade` setting.
+      Specifies a double that lightens or darkens a color for the range border,
+      the value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the border doesn't have a
+      uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -69,26 +77,30 @@ methods:
         type: number
         description: ''
   - name: getWeight()
-    uid: 'ExcelScript!ExcelScript.RangeBorder#getWeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#getWeight:member(1)
     package: ExcelScript!
     fullName: getWeight()
-    summary: Specifies the weight of the border around a range. See `ExcelScript.BorderWeight` for details.
+    summary: >-
+      Specifies the weight of the border around a range. See
+      `ExcelScript.BorderWeight` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWeight(): BorderWeight;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.BorderWeight:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.BorderWeight:enum" />
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.RangeBorder#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      HTML color code representing the color of the border line, in the form \#RRGGBB (e.g., "FFA500"), or as a named
-      HTML color (e.g., "orange").
+      HTML color code representing the color of the border line, in the form
+      \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,13 +113,14 @@ methods:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.RangeBorder#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
     summary: >-
-      One of the constants of line style specifying the line style for the border. See `ExcelScript.BorderLineStyle` for
-      details.
+      One of the constants of line style specifying the line style for the
+      border. See `ExcelScript.BorderLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -115,7 +128,7 @@ methods:
       parameters:
         - id: style
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.BorderLineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.BorderLineStyle:enum" />
       return:
         type: void
         description: |-
@@ -140,14 +153,16 @@ methods:
           }
           ```
   - name: setTintAndShade(tintAndShade)
-    uid: 'ExcelScript!ExcelScript.RangeBorder#setTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#setTintAndShade:member(1)
     package: ExcelScript!
     fullName: setTintAndShade(tintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a color for the range border, the value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the border doesn't have a uniform
-      `tintAndShade` setting.
+      Specifies a double that lightens or darkens a color for the range border,
+      the value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the border doesn't have a
+      uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -160,11 +175,14 @@ methods:
         type: void
         description: ''
   - name: setWeight(weight)
-    uid: 'ExcelScript!ExcelScript.RangeBorder#setWeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeBorder#setWeight:member(1)
     package: ExcelScript!
     fullName: setWeight(weight)
-    summary: Specifies the weight of the border around a range. See `ExcelScript.BorderWeight` for details.
+    summary: >-
+      Specifies the weight of the border around a range. See
+      `ExcelScript.BorderWeight` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -172,7 +190,7 @@ methods:
       parameters:
         - id: weight
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.BorderWeight:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.BorderWeight:enum" />
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangecopytype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangecopytype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.RangeCopyType
-uid: 'ExcelScript!ExcelScript.RangeCopyType:enum'
+uid: ExcelScript!ExcelScript.RangeCopyType:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeCopyType
 summary: ''
@@ -33,26 +33,27 @@ remarks: |-
     newSheet.activate();
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: all
-    uid: 'ExcelScript!ExcelScript.RangeCopyType.all:member'
+    uid: ExcelScript!ExcelScript.RangeCopyType.all:member
     package: ExcelScript!
     summary: ''
   - name: formats
-    uid: 'ExcelScript!ExcelScript.RangeCopyType.formats:member'
+    uid: ExcelScript!ExcelScript.RangeCopyType.formats:member
     package: ExcelScript!
     summary: ''
   - name: formulas
-    uid: 'ExcelScript!ExcelScript.RangeCopyType.formulas:member'
+    uid: ExcelScript!ExcelScript.RangeCopyType.formulas:member
     package: ExcelScript!
     summary: ''
   - name: link
-    uid: 'ExcelScript!ExcelScript.RangeCopyType.link:member'
+    uid: ExcelScript!ExcelScript.RangeCopyType.link:member
     package: ExcelScript!
     summary: ''
   - name: values
-    uid: 'ExcelScript!ExcelScript.RangeCopyType.values:member'
+    uid: ExcelScript!ExcelScript.RangeCopyType.values:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangefill.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangefill.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeFill
-uid: 'ExcelScript!ExcelScript.RangeFill:interface'
+uid: ExcelScript!ExcelScript.RangeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeFill
 summary: Represents the background of a range object.
@@ -26,16 +26,18 @@ remarks: |-
     fill.setColor("green");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.RangeFill#clear:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Resets the range background.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,13 +64,14 @@ methods:
           }
           ```
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.RangeFill#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      HTML color code representing the color of the background, in the form \#RRGGBB (e.g., "FFA500"), or as a named
-      HTML color (e.g., "orange")
+      HTML color code representing the color of the background, in the form
+      \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,28 +80,31 @@ methods:
         type: string
         description: ''
   - name: getPattern()
-    uid: 'ExcelScript!ExcelScript.RangeFill#getPattern:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#getPattern:member(1)
     package: ExcelScript!
     fullName: getPattern()
     summary: >-
-      The pattern of a range. See `ExcelScript.FillPattern` for details. LinearGradient and RectangularGradient are not
-      supported. A `null` value indicates that the entire range doesn't have a uniform pattern setting.
+      The pattern of a range. See `ExcelScript.FillPattern` for details.
+      LinearGradient and RectangularGradient are not supported. A `null` value
+      indicates that the entire range doesn't have a uniform pattern setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPattern(): FillPattern;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FillPattern:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.FillPattern:enum" />
         description: ''
   - name: getPatternColor()
-    uid: 'ExcelScript!ExcelScript.RangeFill#getPatternColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#getPatternColor:member(1)
     package: ExcelScript!
     fullName: getPatternColor()
     summary: >-
-      The HTML color code representing the color of the range pattern, in the form \#RRGGBB (e.g., "FFA500"), or as a
-      named HTML color (e.g., "orange").
+      The HTML color code representing the color of the range pattern, in the
+      form \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -107,14 +113,16 @@ methods:
         type: string
         description: ''
   - name: getPatternTintAndShade()
-    uid: 'ExcelScript!ExcelScript.RangeFill#getPatternTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#getPatternTintAndShade:member(1)
     package: ExcelScript!
     fullName: getPatternTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a pattern color for the range fill. The value is between -1 (darkest)
-      and 1 (brightest), with 0 for the original color. A `null` value indicates that the range doesn't have uniform
-      `patternTintAndShade` settings.
+      Specifies a double that lightens or darkens a pattern color for the range
+      fill. The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the range doesn't have
+      uniform `patternTintAndShade` settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -123,14 +131,16 @@ methods:
         type: number
         description: ''
   - name: getTintAndShade()
-    uid: 'ExcelScript!ExcelScript.RangeFill#getTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#getTintAndShade:member(1)
     package: ExcelScript!
     fullName: getTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a color for the range fill. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the range doesn't have uniform
-      `tintAndShade` settings.
+      Specifies a double that lightens or darkens a color for the range fill.
+      The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the range doesn't have
+      uniform `tintAndShade` settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -139,13 +149,14 @@ methods:
         type: number
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.RangeFill#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      HTML color code representing the color of the background, in the form \#RRGGBB (e.g., "FFA500"), or as a named
-      HTML color (e.g., "orange")
+      HTML color code representing the color of the background, in the form
+      \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,13 +185,15 @@ methods:
           }
           ```
   - name: setPattern(pattern)
-    uid: 'ExcelScript!ExcelScript.RangeFill#setPattern:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#setPattern:member(1)
     package: ExcelScript!
     fullName: setPattern(pattern)
     summary: >-
-      The pattern of a range. See `ExcelScript.FillPattern` for details. LinearGradient and RectangularGradient are not
-      supported. A `null` value indicates that the entire range doesn't have a uniform pattern setting.
+      The pattern of a range. See `ExcelScript.FillPattern` for details.
+      LinearGradient and RectangularGradient are not supported. A `null` value
+      indicates that the entire range doesn't have a uniform pattern setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -188,7 +201,7 @@ methods:
       parameters:
         - id: pattern
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.FillPattern:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.FillPattern:enum" />
       return:
         type: void
         description: |-
@@ -207,13 +220,14 @@ methods:
           }
           ```
   - name: setPatternColor(patternColor)
-    uid: 'ExcelScript!ExcelScript.RangeFill#setPatternColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#setPatternColor:member(1)
     package: ExcelScript!
     fullName: setPatternColor(patternColor)
     summary: >-
-      The HTML color code representing the color of the range pattern, in the form \#RRGGBB (e.g., "FFA500"), or as a
-      named HTML color (e.g., "orange").
+      The HTML color code representing the color of the range pattern, in the
+      form \#RRGGBB (e.g., "FFA500"), or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -226,14 +240,16 @@ methods:
         type: void
         description: ''
   - name: setPatternTintAndShade(patternTintAndShade)
-    uid: 'ExcelScript!ExcelScript.RangeFill#setPatternTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#setPatternTintAndShade:member(1)
     package: ExcelScript!
     fullName: setPatternTintAndShade(patternTintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a pattern color for the range fill. The value is between -1 (darkest)
-      and 1 (brightest), with 0 for the original color. A `null` value indicates that the range doesn't have uniform
-      `patternTintAndShade` settings.
+      Specifies a double that lightens or darkens a pattern color for the range
+      fill. The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the range doesn't have
+      uniform `patternTintAndShade` settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -246,14 +262,16 @@ methods:
         type: void
         description: ''
   - name: setTintAndShade(tintAndShade)
-    uid: 'ExcelScript!ExcelScript.RangeFill#setTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFill#setTintAndShade:member(1)
     package: ExcelScript!
     fullName: setTintAndShade(tintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a color for the range fill. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the range doesn't have uniform
-      `tintAndShade` settings.
+      Specifies a double that lightens or darkens a color for the range fill.
+      The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the range doesn't have
+      uniform `tintAndShade` settings.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangefont.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangefont.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeFont
-uid: 'ExcelScript!ExcelScript.RangeFont:interface'
+uid: ExcelScript!ExcelScript.RangeFont:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeFont
-summary: 'This object represents the font attributes (font name, font size, color, etc.) for an object.'
+summary: >-
+  This object represents the font attributes (font name, font size, color, etc.)
+  for an object.
 remarks: |-
 
 
@@ -23,16 +25,18 @@ remarks: |-
     cellFont.setSize(16);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBold()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getBold:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getBold:member(1)
     package: ExcelScript!
     fullName: getBold()
     summary: Represents the bold status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -41,11 +45,14 @@ methods:
         type: boolean
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -54,11 +61,12 @@ methods:
         type: string
         description: ''
   - name: getItalic()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getItalic:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getItalic:member(1)
     package: ExcelScript!
     fullName: getItalic()
     summary: Specifies the italic status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -67,11 +75,14 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getName:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getName:member(1)
     package: ExcelScript!
     fullName: getName()
-    summary: 'Font name (e.g., "Calibri"). The name''s length should not be greater than 31 characters.'
+    summary: >-
+      Font name (e.g., "Calibri"). The name's length should not be greater than
+      31 characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,11 +91,12 @@ methods:
         type: string
         description: ''
   - name: getSize()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getSize:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getSize:member(1)
     package: ExcelScript!
     fullName: getSize()
     summary: Font size.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,13 +105,14 @@ methods:
         type: number
         description: ''
   - name: getStrikethrough()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getStrikethrough:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getStrikethrough:member(1)
     package: ExcelScript!
     fullName: getStrikethrough()
     summary: >-
-      Specifies the strikethrough status of font. A `null` value indicates that the entire range doesn't have a uniform
-      strikethrough setting.
+      Specifies the strikethrough status of font. A `null` value indicates that
+      the entire range doesn't have a uniform strikethrough setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -108,14 +121,16 @@ methods:
         type: boolean
         description: ''
   - name: getSubscript()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getSubscript:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getSubscript:member(1)
     package: ExcelScript!
     fullName: getSubscript()
     summary: >-
-      Specifies the subscript status of font. Returns `true` if all the fonts of the range are subscript. Returns
-      `false` if all the fonts of the range are superscript or normal (neither superscript, nor subscript). Returns
-      `null` otherwise.
+      Specifies the subscript status of font. Returns `true` if all the fonts of
+      the range are subscript. Returns `false` if all the fonts of the range are
+      superscript or normal (neither superscript, nor subscript). Returns `null`
+      otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -124,14 +139,16 @@ methods:
         type: boolean
         description: ''
   - name: getSuperscript()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getSuperscript:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getSuperscript:member(1)
     package: ExcelScript!
     fullName: getSuperscript()
     summary: >-
-      Specifies the superscript status of font. Returns `true` if all the fonts of the range are superscript. Returns
-      `false` if all the fonts of the range are subscript or normal (neither superscript, nor subscript). Returns `null`
-      otherwise.
+      Specifies the superscript status of font. Returns `true` if all the fonts
+      of the range are superscript. Returns `false` if all the fonts of the
+      range are subscript or normal (neither superscript, nor subscript).
+      Returns `null` otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,14 +157,16 @@ methods:
         type: boolean
         description: ''
   - name: getTintAndShade()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getTintAndShade:member(1)
     package: ExcelScript!
     fullName: getTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a color for the range font. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire range doesn't have a uniform
-      font `tintAndShade` setting.
+      Specifies a double that lightens or darkens a color for the range font.
+      The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the entire range doesn't
+      have a uniform font `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -156,24 +175,28 @@ methods:
         type: number
         description: ''
   - name: getUnderline()
-    uid: 'ExcelScript!ExcelScript.RangeFont#getUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#getUnderline:member(1)
     package: ExcelScript!
     fullName: getUnderline()
-    summary: Type of underline applied to the font. See `ExcelScript.RangeUnderlineStyle` for details.
+    summary: >-
+      Type of underline applied to the font. See
+      `ExcelScript.RangeUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getUnderline(): RangeUnderlineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeUnderlineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeUnderlineStyle:enum" />
         description: ''
   - name: setBold(bold)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setBold:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setBold:member(1)
     package: ExcelScript!
     fullName: setBold(bold)
     summary: Represents the bold status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -202,11 +225,14 @@ methods:
           }
           ```
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
-    summary: 'HTML color code representation of the text color (e.g., \#FF0000 represents Red).'
+    summary: >-
+      HTML color code representation of the text color (e.g., \#FF0000
+      represents Red).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -219,11 +245,12 @@ methods:
         type: void
         description: ''
   - name: setItalic(italic)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setItalic:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setItalic:member(1)
     package: ExcelScript!
     fullName: setItalic(italic)
     summary: Specifies the italic status of the font.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -236,11 +263,14 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setName:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
-    summary: 'Font name (e.g., "Calibri"). The name''s length should not be greater than 31 characters.'
+    summary: >-
+      Font name (e.g., "Calibri"). The name's length should not be greater than
+      31 characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -269,11 +299,12 @@ methods:
           }
           ```
   - name: setSize(size)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setSize:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setSize:member(1)
     package: ExcelScript!
     fullName: setSize(size)
     summary: Font size.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -302,13 +333,14 @@ methods:
           }
           ```
   - name: setStrikethrough(strikethrough)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setStrikethrough:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setStrikethrough:member(1)
     package: ExcelScript!
     fullName: setStrikethrough(strikethrough)
     summary: >-
-      Specifies the strikethrough status of font. A `null` value indicates that the entire range doesn't have a uniform
-      strikethrough setting.
+      Specifies the strikethrough status of font. A `null` value indicates that
+      the entire range doesn't have a uniform strikethrough setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -321,14 +353,16 @@ methods:
         type: void
         description: ''
   - name: setSubscript(subscript)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setSubscript:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setSubscript:member(1)
     package: ExcelScript!
     fullName: setSubscript(subscript)
     summary: >-
-      Specifies the subscript status of font. Returns `true` if all the fonts of the range are subscript. Returns
-      `false` if all the fonts of the range are superscript or normal (neither superscript, nor subscript). Returns
-      `null` otherwise.
+      Specifies the subscript status of font. Returns `true` if all the fonts of
+      the range are subscript. Returns `false` if all the fonts of the range are
+      superscript or normal (neither superscript, nor subscript). Returns `null`
+      otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -341,14 +375,16 @@ methods:
         type: void
         description: ''
   - name: setSuperscript(superscript)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setSuperscript:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setSuperscript:member(1)
     package: ExcelScript!
     fullName: setSuperscript(superscript)
     summary: >-
-      Specifies the superscript status of font. Returns `true` if all the fonts of the range are superscript. Returns
-      `false` if all the fonts of the range are subscript or normal (neither superscript, nor subscript). Returns `null`
-      otherwise.
+      Specifies the superscript status of font. Returns `true` if all the fonts
+      of the range are superscript. Returns `false` if all the fonts of the
+      range are subscript or normal (neither superscript, nor subscript).
+      Returns `null` otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -361,14 +397,16 @@ methods:
         type: void
         description: ''
   - name: setTintAndShade(tintAndShade)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setTintAndShade:member(1)
     package: ExcelScript!
     fullName: setTintAndShade(tintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a color for the range font. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire range doesn't have a uniform
-      font `tintAndShade` setting.
+      Specifies a double that lightens or darkens a color for the range font.
+      The value is between -1 (darkest) and 1 (brightest), with 0 for the
+      original color. A `null` value indicates that the entire range doesn't
+      have a uniform font `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -381,11 +419,14 @@ methods:
         type: void
         description: ''
   - name: setUnderline(underline)
-    uid: 'ExcelScript!ExcelScript.RangeFont#setUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFont#setUnderline:member(1)
     package: ExcelScript!
     fullName: setUnderline(underline)
-    summary: Type of underline applied to the font. See `ExcelScript.RangeUnderlineStyle` for details.
+    summary: >-
+      Type of underline applied to the font. See
+      `ExcelScript.RangeUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -393,7 +434,7 @@ methods:
       parameters:
         - id: underline
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.RangeUnderlineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.RangeUnderlineStyle:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeformat.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeFormat
-uid: 'ExcelScript!ExcelScript.RangeFormat:interface'
+uid: ExcelScript!ExcelScript.RangeFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeFormat
-summary: 'A format object encapsulating the range''s font, fill, borders, alignment, and other properties.'
+summary: >-
+  A format object encapsulating the range's font, fill, borders, alignment, and
+  other properties.
 remarks: |-
 
 
@@ -25,18 +27,20 @@ remarks: |-
     format.getFont().setBold(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: adjustIndent(amount)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#adjustIndent:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#adjustIndent:member(1)
     package: ExcelScript!
     fullName: adjustIndent(amount)
     summary: >-
-      Adjusts the indentation of the range formatting. The indent value ranges from 0 to 250 and is measured in
-      characters.
+      Adjusts the indentation of the range formatting. The indent value ranges
+      from 0 to 250 and is measured in characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -44,9 +48,11 @@ methods:
       parameters:
         - id: amount
           description: >-
-            The number of character spaces by which the current indent is adjusted. This value should be between -250
-            and 250. **Note**: If the amount would raise the indent level above 250, the indent level stays with
-            250. Similarly, if the amount would lower the indent level below 0, the indent level stays 0.
+            The number of character spaces by which the current indent is
+            adjusted. This value should be between -250 and 250. **Note**:
+            If the amount would raise the indent level above 250, the indent
+            level stays with 250. Similarly, if the amount would lower the
+            indent level below 0, the indent level stays 0.
           type: number
       return:
         type: void
@@ -73,13 +79,14 @@ methods:
           }
           ```
   - name: autofitColumns()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#autofitColumns:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#autofitColumns:member(1)
     package: ExcelScript!
     fullName: autofitColumns()
     summary: >-
-      Changes the width of the columns of the current range to achieve the best fit, based on the current data in the
-      columns.
+      Changes the width of the columns of the current range to achieve the best
+      fit, based on the current data in the columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -107,13 +114,14 @@ methods:
           }
           ```
   - name: autofitRows()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#autofitRows:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#autofitRows:member(1)
     package: ExcelScript!
     fullName: autofitRows()
     summary: >-
-      Changes the height of the rows of the current range to achieve the best fit, based on the current data in the
-      columns.
+      Changes the height of the rows of the current range to achieve the best
+      fit, based on the current data in the columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -141,11 +149,14 @@ methods:
           }
           ```
   - name: getAutoIndent()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getAutoIndent:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getAutoIndent:member(1)
     package: ExcelScript!
     fullName: getAutoIndent()
-    summary: Specifies if text is automatically indented when text alignment is set to equal distribution.
+    summary: >-
+      Specifies if text is automatically indented when text alignment is set to
+      equal distribution.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -154,26 +165,28 @@ methods:
         type: boolean
         description: ''
   - name: getBorders()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getBorders:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getBorders:member(1)
     package: ExcelScript!
     fullName: getBorders()
     summary: Collection of border objects that apply to the overall range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBorders(): RangeBorder[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />[]
         description: ''
   - name: getColumnWidth()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getColumnWidth:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getColumnWidth:member(1)
     package: ExcelScript!
     fullName: getColumnWidth()
     summary: >-
-      Specifies the width of all columns within the range. If the column widths are not uniform, `null` will be
-      returned.
+      Specifies the width of all columns within the range. If the column widths
+      are not uniform, `null` will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -205,17 +218,18 @@ methods:
             }
           ```
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Returns the fill object defined on the overall range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): RangeFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFill:interface" />
         description: |-
 
 
@@ -237,17 +251,18 @@ methods:
           }
           ```
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
     summary: Returns the font object defined on the overall range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): RangeFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeFont:interface" />
         description: |-
 
 
@@ -266,24 +281,28 @@ methods:
           }
           ```
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
-    summary: Represents the horizontal alignment for the specified object. See `ExcelScript.HorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment for the specified object. See
+      `ExcelScript.HorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): HorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />
         description: ''
   - name: getIndentLevel()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getIndentLevel:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getIndentLevel:member(1)
     package: ExcelScript!
     fullName: getIndentLevel()
     summary: An integer from 0 to 250 that indicates the indent level.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -292,34 +311,38 @@ methods:
         type: number
         description: ''
   - name: getProtection()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getProtection:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getProtection:member(1)
     package: ExcelScript!
     fullName: getProtection()
     summary: Returns the format protection object for a range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getProtection(): FormatProtection;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.FormatProtection:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.FormatProtection:interface" />
         description: ''
   - name: getRangeBorder(index)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getRangeBorder:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getRangeBorder:member(1)
     package: ExcelScript!
     fullName: getRangeBorder(index)
     summary: Gets a border object using its name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRangeBorder(index: BorderIndex): RangeBorder;'
       parameters:
         - id: index
-          description: Index value of the border object to be retrieved. See `ExcelScript.BorderIndex` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />'
+          description: >-
+            Index value of the border object to be retrieved. See
+            `ExcelScript.BorderIndex` for details.
+          type: <xref uid="ExcelScript!ExcelScript.BorderIndex:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeBorder:interface" />
         description: |-
 
 
@@ -342,14 +365,16 @@ methods:
           }
           ```
   - name: getRangeBorderTintAndShade()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getRangeBorderTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getRangeBorderTintAndShade:member(1)
     package: ExcelScript!
     fullName: getRangeBorderTintAndShade()
     summary: >-
-      Specifies a double that lightens or darkens a color for range borders. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire border collection doesn't
+      Specifies a double that lightens or darkens a color for range borders. The
+      value is between -1 (darkest) and 1 (brightest), with 0 for the original
+      color. A `null` value indicates that the entire border collection doesn't
       have a uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -358,24 +383,28 @@ methods:
         type: number
         description: ''
   - name: getReadingOrder()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getReadingOrder:member(1)
     package: ExcelScript!
     fullName: getReadingOrder()
     summary: The reading order for the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getReadingOrder(): ReadingOrder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />
         description: ''
   - name: getRowHeight()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getRowHeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getRowHeight:member(1)
     package: ExcelScript!
     fullName: getRowHeight()
-    summary: 'The height of all rows in the range. If the row heights are not uniform, `null` will be returned.'
+    summary: >-
+      The height of all rows in the range. If the row heights are not uniform,
+      `null` will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -408,11 +437,14 @@ methods:
           }
           ```
   - name: getShrinkToFit()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getShrinkToFit:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getShrinkToFit:member(1)
     package: ExcelScript!
     fullName: getShrinkToFit()
-    summary: Specifies if text automatically shrinks to fit in the available column width.
+    summary: >-
+      Specifies if text automatically shrinks to fit in the available column
+      width.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -421,14 +453,16 @@ methods:
         type: boolean
         description: ''
   - name: getTextOrientation()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getTextOrientation:member(1)
     package: ExcelScript!
     fullName: getTextOrientation()
     summary: >-
-      The text orientation of all the cells within the range. The text orientation should be an integer either from -90
-      to 90, or 180 for vertically-oriented text. If the orientation within a range are not uniform, then `null` will be
-      returned.
+      The text orientation of all the cells within the range. The text
+      orientation should be an integer either from -90 to 90, or 180 for
+      vertically-oriented text. If the orientation within a range are not
+      uniform, then `null` will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -437,14 +471,17 @@ methods:
         type: number
         description: ''
   - name: getUseStandardHeight()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getUseStandardHeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getUseStandardHeight:member(1)
     package: ExcelScript!
     fullName: getUseStandardHeight()
     summary: >-
-      Determines if the row height of the `Range` object equals the standard height of the sheet. Returns `true` if the
-      row height of the `Range` object equals the standard height of the sheet. Returns `null` if the range contains
-      more than one row and the rows aren't all the same height. Returns `false` otherwise.
+      Determines if the row height of the `Range` object equals the standard
+      height of the sheet. Returns `true` if the row height of the `Range`
+      object equals the standard height of the sheet. Returns `null` if the
+      range contains more than one row and the rows aren't all the same height.
+      Returns `false` otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -453,14 +490,17 @@ methods:
         type: boolean
         description: ''
   - name: getUseStandardWidth()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getUseStandardWidth:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getUseStandardWidth:member(1)
     package: ExcelScript!
     fullName: getUseStandardWidth()
     summary: >-
-      Specifies if the column width of the `Range` object equals the standard width of the sheet. Returns `true` if the
-      column width of the `Range` object equals the standard width of the sheet. Returns `null` if the range contains
-      more than one column and the columns aren't all the same height. Returns `false` otherwise.
+      Specifies if the column width of the `Range` object equals the standard
+      width of the sheet. Returns `true` if the column width of the `Range`
+      object equals the standard width of the sheet. Returns `null` if the range
+      contains more than one column and the columns aren't all the same height.
+      Returns `false` otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -469,26 +509,30 @@ methods:
         type: boolean
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
-    summary: Represents the vertical alignment for the specified object. See `ExcelScript.VerticalAlignment` for details.
+    summary: >-
+      Represents the vertical alignment for the specified object. See
+      `ExcelScript.VerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): VerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />
         description: ''
   - name: getWrapText()
-    uid: 'ExcelScript!ExcelScript.RangeFormat#getWrapText:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#getWrapText:member(1)
     package: ExcelScript!
     fullName: getWrapText()
     summary: >-
-      Specifies if Excel wraps the text in the object. A `null` value indicates that the entire range doesn't have a
-      uniform wrap setting
+      Specifies if Excel wraps the text in the object. A `null` value indicates
+      that the entire range doesn't have a uniform wrap setting
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -497,11 +541,14 @@ methods:
         type: boolean
         description: ''
   - name: setAutoIndent(autoIndent)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setAutoIndent:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setAutoIndent:member(1)
     package: ExcelScript!
     fullName: setAutoIndent(autoIndent)
-    summary: Specifies if text is automatically indented when text alignment is set to equal distribution.
+    summary: >-
+      Specifies if text is automatically indented when text alignment is set to
+      equal distribution.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -514,11 +561,12 @@ methods:
         type: void
         description: ''
   - name: setColumnWidth(columnWidth)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setColumnWidth:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setColumnWidth:member(1)
     package: ExcelScript!
     fullName: setColumnWidth(columnWidth)
     summary: Specifies the width of all columns within the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -550,11 +598,14 @@ methods:
           }
           ```
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
-    summary: Represents the horizontal alignment for the specified object. See `ExcelScript.HorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment for the specified object. See
+      `ExcelScript.HorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -562,7 +613,7 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.HorizontalAlignment:enum" />
       return:
         type: void
         description: |-
@@ -587,11 +638,12 @@ methods:
           }
           ```
   - name: setIndentLevel(indentLevel)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setIndentLevel:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setIndentLevel:member(1)
     package: ExcelScript!
     fullName: setIndentLevel(indentLevel)
     summary: An integer from 0 to 250 that indicates the indent level.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -604,14 +656,16 @@ methods:
         type: void
         description: ''
   - name: setRangeBorderTintAndShade(rangeBorderTintAndShade)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setRangeBorderTintAndShade:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setRangeBorderTintAndShade:member(1)
     package: ExcelScript!
     fullName: setRangeBorderTintAndShade(rangeBorderTintAndShade)
     summary: >-
-      Specifies a double that lightens or darkens a color for range borders. The value is between -1 (darkest) and 1
-      (brightest), with 0 for the original color. A `null` value indicates that the entire border collection doesn't
+      Specifies a double that lightens or darkens a color for range borders. The
+      value is between -1 (darkest) and 1 (brightest), with 0 for the original
+      color. A `null` value indicates that the entire border collection doesn't
       have a uniform `tintAndShade` setting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -624,11 +678,12 @@ methods:
         type: void
         description: ''
   - name: setReadingOrder(readingOrder)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setReadingOrder:member(1)
     package: ExcelScript!
     fullName: setReadingOrder(readingOrder)
     summary: The reading order for the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -636,16 +691,17 @@ methods:
       parameters:
         - id: readingOrder
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ReadingOrder:enum" />
       return:
         type: void
         description: ''
   - name: setRowHeight(rowHeight)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setRowHeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setRowHeight:member(1)
     package: ExcelScript!
     fullName: setRowHeight(rowHeight)
     summary: Specifies the height of all rows in the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -677,11 +733,14 @@ methods:
           }
           ```
   - name: setShrinkToFit(shrinkToFit)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setShrinkToFit:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setShrinkToFit:member(1)
     package: ExcelScript!
     fullName: setShrinkToFit(shrinkToFit)
-    summary: Specifies if text automatically shrinks to fit in the available column width.
+    summary: >-
+      Specifies if text automatically shrinks to fit in the available column
+      width.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -694,14 +753,16 @@ methods:
         type: void
         description: ''
   - name: setTextOrientation(textOrientation)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setTextOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setTextOrientation:member(1)
     package: ExcelScript!
     fullName: setTextOrientation(textOrientation)
     summary: >-
-      The text orientation of all the cells within the range. The text orientation should be an integer either from -90
-      to 90, or 180 for vertically-oriented text. If the orientation within a range are not uniform, then `null` will be
-      returned.
+      The text orientation of all the cells within the range. The text
+      orientation should be an integer either from -90 to 90, or 180 for
+      vertically-oriented text. If the orientation within a range are not
+      uniform, then `null` will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -714,13 +775,15 @@ methods:
         type: void
         description: ''
   - name: setUseStandardHeight(useStandardHeight)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setUseStandardHeight:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setUseStandardHeight:member(1)
     package: ExcelScript!
     fullName: setUseStandardHeight(useStandardHeight)
     summary: >-
-      Determines if the row height of the `Range` object equals the standard height of the sheet. Note: This property is
-      only intended to be set to `true`<!-- -->. Setting it to `false` has no effect.
+      Determines if the row height of the `Range` object equals the standard
+      height of the sheet. Note: This property is only intended to be set to
+      `true`<!-- -->. Setting it to `false` has no effect.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -733,13 +796,15 @@ methods:
         type: void
         description: ''
   - name: setUseStandardWidth(useStandardWidth)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setUseStandardWidth:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setUseStandardWidth:member(1)
     package: ExcelScript!
     fullName: setUseStandardWidth(useStandardWidth)
     summary: >-
-      Specifies if the column width of the `Range` object equals the standard width of the sheet. Note: This property is
-      only intended to be set to `true`<!-- -->. Setting it to `false` has no effect.
+      Specifies if the column width of the `Range` object equals the standard
+      width of the sheet. Note: This property is only intended to be set to
+      `true`<!-- -->. Setting it to `false` has no effect.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -752,11 +817,14 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
-    summary: Represents the vertical alignment for the specified object. See `ExcelScript.VerticalAlignment` for details.
+    summary: >-
+      Represents the vertical alignment for the specified object. See
+      `ExcelScript.VerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -764,7 +832,7 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.VerticalAlignment:enum" />
       return:
         type: void
         description: |-
@@ -787,13 +855,14 @@ methods:
           }
           ```
   - name: setWrapText(wrapText)
-    uid: 'ExcelScript!ExcelScript.RangeFormat#setWrapText:member(1)'
+    uid: ExcelScript!ExcelScript.RangeFormat#setWrapText:member(1)
     package: ExcelScript!
     fullName: setWrapText(wrapText)
     summary: >-
-      Specifies if Excel wraps the text in the object. A `null` value indicates that the entire range doesn't have a
-      uniform wrap setting
+      Specifies if Excel wraps the text in the object. A `null` value indicates
+      that the entire range doesn't have a uniform wrap setting
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangehyperlink.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangehyperlink.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeHyperlink
-uid: 'ExcelScript!ExcelScript.RangeHyperlink:interface'
+uid: ExcelScript!ExcelScript.RangeHyperlink:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeHyperlink
 summary: Represents the necessary strings to get/set a hyperlink (XHL) object.
@@ -29,16 +29,18 @@ remarks: |-
     cell.getFormat().autofitColumns();
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: address
-    uid: 'ExcelScript!ExcelScript.RangeHyperlink#address:member'
+    uid: ExcelScript!ExcelScript.RangeHyperlink#address:member
     package: ExcelScript!
     fullName: address
     summary: Represents the URL target for the hyperlink.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -46,11 +48,12 @@ properties:
       return:
         type: string
   - name: documentReference
-    uid: 'ExcelScript!ExcelScript.RangeHyperlink#documentReference:member'
+    uid: ExcelScript!ExcelScript.RangeHyperlink#documentReference:member
     package: ExcelScript!
     fullName: documentReference
     summary: Represents the document reference target for the hyperlink.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -81,11 +84,12 @@ properties:
           }
           ```
   - name: screenTip
-    uid: 'ExcelScript!ExcelScript.RangeHyperlink#screenTip:member'
+    uid: ExcelScript!ExcelScript.RangeHyperlink#screenTip:member
     package: ExcelScript!
     fullName: screenTip
     summary: Represents the string displayed when hovering over the hyperlink.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -93,11 +97,14 @@ properties:
       return:
         type: string
   - name: textToDisplay
-    uid: 'ExcelScript!ExcelScript.RangeHyperlink#textToDisplay:member'
+    uid: ExcelScript!ExcelScript.RangeHyperlink#textToDisplay:member
     package: ExcelScript!
     fullName: textToDisplay
-    summary: Represents the string that is displayed in the top left most cell in the range.
+    summary: >-
+      Represents the string that is displayed in the top left most cell in the
+      range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangesort.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangesort.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeSort
-uid: 'ExcelScript!ExcelScript.RangeSort:interface'
+uid: ExcelScript!ExcelScript.RangeSort:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeSort
 summary: Manages sorting operations on `Range` objects.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'apply(fields, matchCase, hasHeaders, orientation, method)'
-    uid: 'ExcelScript!ExcelScript.RangeSort#apply:member(1)'
+  - name: apply(fields, matchCase, hasHeaders, orientation, method)
+    uid: ExcelScript!ExcelScript.RangeSort#apply:member(1)
     package: ExcelScript!
-    fullName: 'apply(fields, matchCase, hasHeaders, orientation, method)'
+    fullName: apply(fields, matchCase, hasHeaders, orientation, method)
     summary: Perform a sort operation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -29,7 +31,7 @@ methods:
       parameters:
         - id: fields
           description: The list of conditions to sort on.
-          type: '<xref uid="ExcelScript!ExcelScript.SortField:interface" />[]'
+          type: <xref uid="ExcelScript!ExcelScript.SortField:interface" />[]
         - id: matchCase
           description: Optional. Whether to have the casing impact string ordering.
           type: boolean
@@ -38,10 +40,10 @@ methods:
           type: boolean
         - id: orientation
           description: Optional. Whether the operation is sorting rows or columns.
-          type: '<xref uid="ExcelScript!ExcelScript.SortOrientation:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortOrientation:enum" />
         - id: method
           description: Optional. The ordering method used for Chinese characters.
-          type: '<xref uid="ExcelScript!ExcelScript.SortMethod:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortMethod:enum" />
       return:
         type: void
         description: |-

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeunderlinestyle.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.RangeUnderlineStyle
-uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle:enum'
+uid: ExcelScript!ExcelScript.RangeUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeUnderlineStyle
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: double
-    uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle.double:member'
+    uid: ExcelScript!ExcelScript.RangeUnderlineStyle.double:member
     package: ExcelScript!
     summary: ''
   - name: doubleAccountant
-    uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle.doubleAccountant:member'
+    uid: ExcelScript!ExcelScript.RangeUnderlineStyle.doubleAccountant:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle.none:member'
+    uid: ExcelScript!ExcelScript.RangeUnderlineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: single
-    uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle.single:member'
+    uid: ExcelScript!ExcelScript.RangeUnderlineStyle.single:member
     package: ExcelScript!
     summary: ''
   - name: singleAccountant
-    uid: 'ExcelScript!ExcelScript.RangeUnderlineStyle.singleAccountant:member'
+    uid: ExcelScript!ExcelScript.RangeUnderlineStyle.singleAccountant:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangevaluetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangevaluetype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.RangeValueType
-uid: 'ExcelScript!ExcelScript.RangeValueType:enum'
+uid: ExcelScript!ExcelScript.RangeValueType:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeValueType
 summary: ''
@@ -43,38 +43,39 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: boolean
-    uid: 'ExcelScript!ExcelScript.RangeValueType.boolean:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.boolean:member
     package: ExcelScript!
     summary: ''
   - name: double
-    uid: 'ExcelScript!ExcelScript.RangeValueType.double:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.double:member
     package: ExcelScript!
     summary: ''
   - name: empty
-    uid: 'ExcelScript!ExcelScript.RangeValueType.empty:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.empty:member
     package: ExcelScript!
     summary: ''
   - name: error
-    uid: 'ExcelScript!ExcelScript.RangeValueType.error:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.error:member
     package: ExcelScript!
     summary: ''
   - name: integer
-    uid: 'ExcelScript!ExcelScript.RangeValueType.integer:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.integer:member
     package: ExcelScript!
     summary: ''
   - name: richValue
-    uid: 'ExcelScript!ExcelScript.RangeValueType.richValue:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.richValue:member
     package: ExcelScript!
     summary: ''
   - name: string
-    uid: 'ExcelScript!ExcelScript.RangeValueType.string:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.string:member
     package: ExcelScript!
     summary: ''
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.RangeValueType.unknown:member'
+    uid: ExcelScript!ExcelScript.RangeValueType.unknown:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeview.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rangeview.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.RangeView
-uid: 'ExcelScript!ExcelScript.RangeView:interface'
+uid: ExcelScript!ExcelScript.RangeView:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeView
 summary: RangeView represents a set of visible cells of the parent range.
@@ -27,22 +27,24 @@ remarks: |-
     otherRangeCorner.copyFrom(source, ExcelScript.RangeCopyType.all);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getCellAddresses()
-    uid: 'ExcelScript!ExcelScript.RangeView#getCellAddresses:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getCellAddresses:member(1)
     package: ExcelScript!
     fullName: getCellAddresses()
     summary: Represents the cell addresses of the `RangeView`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCellAddresses(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: |-
 
 
@@ -67,11 +69,12 @@ methods:
           }
           ```
   - name: getColumnCount()
-    uid: 'ExcelScript!ExcelScript.RangeView#getColumnCount:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getColumnCount:member(1)
     package: ExcelScript!
     fullName: getColumnCount()
     summary: The number of visible columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,53 +83,62 @@ methods:
         type: number
         description: ''
   - name: getFormulas()
-    uid: 'ExcelScript!ExcelScript.RangeView#getFormulas:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getFormulas:member(1)
     package: ExcelScript!
     fullName: getFormulas()
-    summary: 'Represents the formula in A1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in A1-style notation. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulas(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getFormulasLocal()
-    uid: 'ExcelScript!ExcelScript.RangeView#getFormulasLocal:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getFormulasLocal:member(1)
     package: ExcelScript!
     fullName: getFormulasLocal()
     summary: >-
-      Represents the formula in A1-style notation, in the user's language and number-formatting locale. For example, the
-      English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its value is
-      returned instead.
+      Represents the formula in A1-style notation, in the user's language and
+      number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula
+      would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulasLocal(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getFormulasR1C1()
-    uid: 'ExcelScript!ExcelScript.RangeView#getFormulasR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getFormulasR1C1:member(1)
     package: ExcelScript!
     fullName: getFormulasR1C1()
-    summary: 'Represents the formula in R1C1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in R1C1-style notation. If a cell has no formula,
+      its value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormulasR1C1(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getIndex()
-    uid: 'ExcelScript!ExcelScript.RangeView#getIndex:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getIndex:member(1)
     package: ExcelScript!
     fullName: getIndex()
     summary: Returns a value that represents the index of the `RangeView`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,37 +147,40 @@ methods:
         type: number
         description: ''
   - name: getNumberFormat()
-    uid: 'ExcelScript!ExcelScript.RangeView#getNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getNumberFormat:member(1)
     package: ExcelScript!
     fullName: getNumberFormat()
     summary: Represents Excel's number format code for the given cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNumberFormat(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.RangeView#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: Gets the parent range associated with the current `RangeView`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRowCount()
-    uid: 'ExcelScript!ExcelScript.RangeView#getRowCount:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getRowCount:member(1)
     package: ExcelScript!
     fullName: getRowCount()
     summary: The number of visible rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -174,67 +189,76 @@ methods:
         type: number
         description: ''
   - name: getRows()
-    uid: 'ExcelScript!ExcelScript.RangeView#getRows:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getRows:member(1)
     package: ExcelScript!
     fullName: getRows()
     summary: Represents a collection of range views associated with the range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRows(): RangeView[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeView:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeView:interface" />[]
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.RangeView#getText:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: >-
-      Text values of the specified range. The text value will not depend on the cell width. The \# sign substitution
-      that happens in Excel UI will not affect the text value returned by the API.
+      Text values of the specified range. The text value will not depend on the
+      cell width. The \# sign substitution that happens in Excel UI will not
+      affect the text value returned by the API.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getText(): string[][];'
       return:
-        type: 'string[][]'
+        type: string[][]
         description: ''
   - name: getValues()
-    uid: 'ExcelScript!ExcelScript.RangeView#getValues:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getValues:member(1)
     package: ExcelScript!
     fullName: getValues()
     summary: >-
-      Represents the raw values of the specified range view. The data returned could be of type string, number, or a
-      boolean. Cells that contain an error will return the error string.
+      Represents the raw values of the specified range view. The data returned
+      could be of type string, number, or a boolean. Cells that contain an error
+      will return the error string.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValues(): (string | number | boolean)[][];'
       return:
-        type: '(string | number | boolean)[][]'
+        type: (string | number | boolean)[][]
         description: ''
   - name: getValueTypes()
-    uid: 'ExcelScript!ExcelScript.RangeView#getValueTypes:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#getValueTypes:member(1)
     package: ExcelScript!
     fullName: getValueTypes()
     summary: Represents the type of data of each cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getValueTypes(): RangeValueType[][];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeValueType:enum" />[][]
         description: ''
   - name: setFormulas(formulas)
-    uid: 'ExcelScript!ExcelScript.RangeView#setFormulas:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#setFormulas:member(1)
     package: ExcelScript!
     fullName: setFormulas(formulas)
-    summary: 'Represents the formula in A1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in A1-style notation. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -242,19 +266,21 @@ methods:
       parameters:
         - id: formulas
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setFormulasLocal(formulasLocal)
-    uid: 'ExcelScript!ExcelScript.RangeView#setFormulasLocal:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#setFormulasLocal:member(1)
     package: ExcelScript!
     fullName: setFormulasLocal(formulasLocal)
     summary: >-
-      Represents the formula in A1-style notation, in the user's language and number-formatting locale. For example, the
-      English "=SUM(A1, 1.5)" formula would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its value is
-      returned instead.
+      Represents the formula in A1-style notation, in the user's language and
+      number-formatting locale. For example, the English "=SUM(A1, 1.5)" formula
+      would become "=SUMME(A1; 1,5)" in German. If a cell has no formula, its
+      value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -262,16 +288,19 @@ methods:
       parameters:
         - id: formulasLocal
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setFormulasR1C1(formulasR1C1)
-    uid: 'ExcelScript!ExcelScript.RangeView#setFormulasR1C1:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#setFormulasR1C1:member(1)
     package: ExcelScript!
     fullName: setFormulasR1C1(formulasR1C1)
-    summary: 'Represents the formula in R1C1-style notation. If a cell has no formula, its value is returned instead.'
+    summary: >-
+      Represents the formula in R1C1-style notation. If a cell has no formula,
+      its value is returned instead.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -279,16 +308,17 @@ methods:
       parameters:
         - id: formulasR1C1
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setNumberFormat(numberFormat)
-    uid: 'ExcelScript!ExcelScript.RangeView#setNumberFormat:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#setNumberFormat:member(1)
     package: ExcelScript!
     fullName: setNumberFormat(numberFormat)
     summary: Represents Excel's number format code for the given cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -296,18 +326,20 @@ methods:
       parameters:
         - id: numberFormat
           description: ''
-          type: 'string[][]'
+          type: string[][]
       return:
         type: void
         description: ''
   - name: setValues(values)
-    uid: 'ExcelScript!ExcelScript.RangeView#setValues:member(1)'
+    uid: ExcelScript!ExcelScript.RangeView#setValues:member(1)
     package: ExcelScript!
     fullName: setValues(values)
     summary: >-
-      Represents the raw values of the specified range view. The data returned could be of type string, number, or a
-      boolean. Cells that contain an error will return the error string.
+      Represents the raw values of the specified range view. The data returned
+      could be of type string, number, or a boolean. Cells that contain an error
+      will return the error string.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -315,7 +347,7 @@ methods:
       parameters:
         - id: values
           description: ''
-          type: '(string | number | boolean)[][]'
+          type: (string | number | boolean)[][]
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.readingorder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.readingorder.yml
@@ -1,25 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ReadingOrder
-uid: 'ExcelScript!ExcelScript.ReadingOrder:enum'
+uid: ExcelScript!ExcelScript.ReadingOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.ReadingOrder
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: context
-    uid: 'ExcelScript!ExcelScript.ReadingOrder.context:member'
+    uid: ExcelScript!ExcelScript.ReadingOrder.context:member
     package: ExcelScript!
     summary: >-
-      Reading order is determined by the language of the first character entered. If a right-to-left language character
-      is entered first, reading order is right to left. If a left-to-right language character is entered first, reading
-      order is left to right.
+      Reading order is determined by the language of the first character
+      entered. If a right-to-left language character is entered first, reading
+      order is right to left. If a left-to-right language character is entered
+      first, reading order is left to right.
   - name: leftToRight
-    uid: 'ExcelScript!ExcelScript.ReadingOrder.leftToRight:member'
+    uid: ExcelScript!ExcelScript.ReadingOrder.leftToRight:member
     package: ExcelScript!
     summary: Left to right reading order
   - name: rightToLeft
-    uid: 'ExcelScript!ExcelScript.ReadingOrder.rightToLeft:member'
+    uid: ExcelScript!ExcelScript.ReadingOrder.rightToLeft:member
     package: ExcelScript!
     summary: Right to left reading order

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.removeduplicatesresult.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.RemoveDuplicatesResult
-uid: 'ExcelScript!ExcelScript.RemoveDuplicatesResult:interface'
+uid: ExcelScript!ExcelScript.RemoveDuplicatesResult:interface
 package: ExcelScript!
 fullName: ExcelScript.RemoveDuplicatesResult
 summary: Represents the results from `Range.removeDuplicates`<!-- -->.
@@ -24,16 +24,18 @@ remarks: |-
     console.log(`Rows removed: ${removedResults.getRemoved()}.`);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getRemoved()
-    uid: 'ExcelScript!ExcelScript.RemoveDuplicatesResult#getRemoved:member(1)'
+    uid: ExcelScript!ExcelScript.RemoveDuplicatesResult#getRemoved:member(1)
     package: ExcelScript!
     fullName: getRemoved()
     summary: Number of duplicated rows removed by the operation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,11 +44,13 @@ methods:
         type: number
         description: ''
   - name: getUniqueRemaining()
-    uid: 'ExcelScript!ExcelScript.RemoveDuplicatesResult#getUniqueRemaining:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.RemoveDuplicatesResult#getUniqueRemaining:member(1)
     package: ExcelScript!
     fullName: getUniqueRemaining()
     summary: Number of remaining unique rows present in the resulting range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.replacecriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.replacecriteria.yml
@@ -1,23 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ReplaceCriteria
-uid: 'ExcelScript!ExcelScript.ReplaceCriteria:interface'
+uid: ExcelScript!ExcelScript.ReplaceCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.ReplaceCriteria
 summary: Represents the replace criteria to be used.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: completeMatch
-    uid: 'ExcelScript!ExcelScript.ReplaceCriteria#completeMatch:member'
+    uid: ExcelScript!ExcelScript.ReplaceCriteria#completeMatch:member
     package: ExcelScript!
     fullName: completeMatch
     summary: >-
-      Specifies if the match needs to be complete or partial. A complete match matches the entire contents of the cell.
-      A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar`
-      and `scatter`<!-- -->). Default is `false` (partial).
+      Specifies if the match needs to be complete or partial. A complete match
+      matches the entire contents of the cell. A partial match matches a
+      substring within the content of the cell (e.g., `cat` partially matches
+      `caterpillar` and `scatter`<!-- -->). Default is `false` (partial).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,11 +53,14 @@ properties:
           }
           ```
   - name: matchCase
-    uid: 'ExcelScript!ExcelScript.ReplaceCriteria#matchCase:member'
+    uid: ExcelScript!ExcelScript.ReplaceCriteria#matchCase:member
     package: ExcelScript!
     fullName: matchCase
-    summary: Specifies if the match is case-sensitive. Default is `false` (case-insensitive).
+    summary: >-
+      Specifies if the match is case-sensitive. Default is `false`
+      (case-insensitive).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.rowcolumnpivothierarchy.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.RowColumnPivotHierarchy
-uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface'
+uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.RowColumnPivotHierarchy
 summary: Represents the Excel RowColumnPivotHierarchy.
@@ -27,29 +27,32 @@ remarks: |-
     rowToSort.getFields()[0].sortByValues(ExcelScript.SortBy.descending, valueFieldToSortOn);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFields()
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#getFields:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#getFields:member(1)
     package: ExcelScript!
     fullName: getFields()
     summary: Returns the PivotFields associated with the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFields(): PivotField[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotField:interface" />[]
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#getId:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: ID of the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -58,11 +61,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#getName:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -71,11 +75,14 @@ methods:
         type: string
         description: ''
   - name: getPivotField(name)
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#getPivotField:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#getPivotField:member(1)
     package: ExcelScript!
     fullName: getPivotField(name)
-    summary: 'Gets a PivotField by name. If the PivotField does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotField by name. If the PivotField does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -85,14 +92,17 @@ methods:
           description: Name of the PivotField to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotField:interface" /> |
+          undefined
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: Position of the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -101,11 +111,12 @@ methods:
         type: number
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#setName:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -118,11 +129,12 @@ methods:
         type: void
         description: ''
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: Position of the RowColumnPivotHierarchy.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,11 +147,12 @@ methods:
         type: void
         description: ''
   - name: setToDefault()
-    uid: 'ExcelScript!ExcelScript.RowColumnPivotHierarchy#setToDefault:member(1)'
+    uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy#setToDefault:member(1)
     package: ExcelScript!
     fullName: setToDefault()
     summary: Reset the RowColumnPivotHierarchy back to its default values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.searchcriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.searchcriteria.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.SearchCriteria
-uid: 'ExcelScript!ExcelScript.SearchCriteria:interface'
+uid: ExcelScript!ExcelScript.SearchCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.SearchCriteria
 summary: Represents the search criteria to be used.
@@ -32,19 +32,22 @@ remarks: |-
     tkCell.clear(ExcelScript.ClearApplyTo.all);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: completeMatch
-    uid: 'ExcelScript!ExcelScript.SearchCriteria#completeMatch:member'
+    uid: ExcelScript!ExcelScript.SearchCriteria#completeMatch:member
     package: ExcelScript!
     fullName: completeMatch
     summary: >-
-      Specifies if the match needs to be complete or partial. A complete match matches the entire contents of the cell.
-      A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar`
-      and `scatter`<!-- -->). Default is `false` (partial).
+      Specifies if the match needs to be complete or partial. A complete match
+      matches the entire contents of the cell. A partial match matches a
+      substring within the content of the cell (e.g., `cat` partially matches
+      `caterpillar` and `scatter`<!-- -->). Default is `false` (partial).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -52,11 +55,14 @@ properties:
       return:
         type: boolean
   - name: matchCase
-    uid: 'ExcelScript!ExcelScript.SearchCriteria#matchCase:member'
+    uid: ExcelScript!ExcelScript.SearchCriteria#matchCase:member
     package: ExcelScript!
     fullName: matchCase
-    summary: Specifies if the match is case-sensitive. Default is `false` (case-insensitive).
+    summary: >-
+      Specifies if the match is case-sensitive. Default is `false`
+      (case-insensitive).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -64,14 +70,17 @@ properties:
       return:
         type: boolean
   - name: searchDirection
-    uid: 'ExcelScript!ExcelScript.SearchCriteria#searchDirection:member'
+    uid: ExcelScript!ExcelScript.SearchCriteria#searchDirection:member
     package: ExcelScript!
     fullName: searchDirection
-    summary: Specifies the search direction. Default is forward. See `ExcelScript.SearchDirection`<!-- -->.
+    summary: >-
+      Specifies the search direction. Default is forward. See
+      `ExcelScript.SearchDirection`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'searchDirection?: SearchDirection;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SearchDirection:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SearchDirection:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.searchdirection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.searchdirection.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SearchDirection
-uid: 'ExcelScript!ExcelScript.SearchDirection:enum'
+uid: ExcelScript!ExcelScript.SearchDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.SearchDirection
 summary: Specifies the search direction.
@@ -32,14 +32,15 @@ remarks: |-
     tkCell.clear(ExcelScript.ClearApplyTo.all);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: backwards
-    uid: 'ExcelScript!ExcelScript.SearchDirection.backwards:member'
+    uid: ExcelScript!ExcelScript.SearchDirection.backwards:member
     package: ExcelScript!
     summary: Search in reverse order.
   - name: forward
-    uid: 'ExcelScript!ExcelScript.SearchDirection.forward:member'
+    uid: ExcelScript!ExcelScript.SearchDirection.forward:member
     package: ExcelScript!
     summary: Search in forward order.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shape.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shape.yml
@@ -1,11 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.Shape
-uid: 'ExcelScript!ExcelScript.Shape:interface'
+uid: ExcelScript!ExcelScript.Shape:interface
 package: ExcelScript!
 fullName: ExcelScript.Shape
 summary: >-
-  Represents a generic shape object in the worksheet. A shape could be a geometric shape, a line, a group of shapes,
-  etc.
+  Represents a generic shape object in the worksheet. A shape could be a
+  geometric shape, a line, a group of shapes, etc.
 remarks: |-
 
 
@@ -29,33 +29,40 @@ remarks: |-
     hexagon.setTop(100);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: copyTo(destinationSheet)
-    uid: 'ExcelScript!ExcelScript.Shape#copyTo:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#copyTo:member(1)
     package: ExcelScript!
     fullName: copyTo(destinationSheet)
-    summary: Copies and pastes a `Shape` object. The pasted shape is copied to the same pixel location as this shape.
+    summary: >-
+      Copies and pastes a `Shape` object. The pasted shape is copied to the same
+      pixel location as this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'copyTo(destinationSheet?: Worksheet | string): Shape;'
       parameters:
         - id: destinationSheet
-          description: The sheet to which the shape object will be pasted. The default value is the copied shape's worksheet.
-          type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | string'
+          description: >-
+            The sheet to which the shape object will be pasted. The default
+            value is the copied shape's worksheet.
+          type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Shape#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Removes the shape from the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -82,11 +89,12 @@ methods:
           }
           ```
   - name: getAltTextDescription()
-    uid: 'ExcelScript!ExcelScript.Shape#getAltTextDescription:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getAltTextDescription:member(1)
     package: ExcelScript!
     fullName: getAltTextDescription()
     summary: Specifies the alternative description text for a `Shape` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -95,11 +103,12 @@ methods:
         type: string
         description: ''
   - name: getAltTextTitle()
-    uid: 'ExcelScript!ExcelScript.Shape#getAltTextTitle:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getAltTextTitle:member(1)
     package: ExcelScript!
     fullName: getAltTextTitle()
     summary: Specifies the alternative title text for a `Shape` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -108,14 +117,18 @@ methods:
         type: string
         description: ''
   - name: getAsImage(format)
-    uid: 'ExcelScript!ExcelScript.Shape#getAsImage:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getAsImage:member(1)
     package: ExcelScript!
     fullName: getAsImage(format)
     summary: >-
-      Converts the shape to an image and returns the image as a base64-encoded string. The DPI is 96. The only supported
-      formats are `ExcelScript.PictureFormat.BMP`<!-- -->, `ExcelScript.PictureFormat.PNG`<!-- -->,
-      `ExcelScript.PictureFormat.JPEG`<!-- -->, and `ExcelScript.PictureFormat.GIF`<!-- -->.
+      Converts the shape to an image and returns the image as a base64-encoded
+      string. The DPI is 96. The only supported formats are
+      `ExcelScript.PictureFormat.BMP`<!-- -->,
+      `ExcelScript.PictureFormat.PNG`<!-- -->,
+      `ExcelScript.PictureFormat.JPEG`<!-- -->, and
+      `ExcelScript.PictureFormat.GIF`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: true
     customDeprecatedMessage: Use `getImageAsBase64` instead.
@@ -124,7 +137,7 @@ methods:
       parameters:
         - id: format
           description: Specifies the format of the image.
-          type: '<xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />
       return:
         type: string
         description: |-
@@ -156,11 +169,12 @@ methods:
           }
           ```
   - name: getConnectionSiteCount()
-    uid: 'ExcelScript!ExcelScript.Shape#getConnectionSiteCount:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getConnectionSiteCount:member(1)
     package: ExcelScript!
     fullName: getConnectionSiteCount()
     summary: Returns the number of connection sites on this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -169,13 +183,16 @@ methods:
         type: number
         description: ''
   - name: getDisplayName()
-    uid: 'ExcelScript!ExcelScript.Shape#getDisplayName:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getDisplayName:member(1)
     package: ExcelScript!
     fullName: getDisplayName()
     summary: >-
-      Gets the display name of the shape. A newly created shape has a generated name that is localized and may not match
-      its `name`<!-- -->. In this scenario, you can use this API to get the name that is displayed in the UI.
+      Gets the display name of the shape. A newly created shape has a generated
+      name that is localized and may not match its `name`<!-- -->. In this
+      scenario, you can use this API to get the name that is displayed in the
+      UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -184,69 +201,77 @@ methods:
         type: string
         description: ''
   - name: getFill()
-    uid: 'ExcelScript!ExcelScript.Shape#getFill:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getFill:member(1)
     package: ExcelScript!
     fullName: getFill()
     summary: Returns the fill formatting of this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFill(): ShapeFill;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeFill:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeFill:interface" />
         description: ''
   - name: getGeometricShape()
-    uid: 'ExcelScript!ExcelScript.Shape#getGeometricShape:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getGeometricShape:member(1)
     package: ExcelScript!
     fullName: getGeometricShape()
     summary: >-
-      Returns the geometric shape associated with the shape. An error will be thrown if the shape type is not
-      "GeometricShape".
+      Returns the geometric shape associated with the shape. An error will be
+      thrown if the shape type is not "GeometricShape".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGeometricShape(): GeometricShape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.GeometricShape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.GeometricShape:interface" />
         description: ''
   - name: getGeometricShapeType()
-    uid: 'ExcelScript!ExcelScript.Shape#getGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: getGeometricShapeType()
     summary: >-
-      Specifies the geometric shape type of this geometric shape. See `ExcelScript.GeometricShapeType` for details.
-      Returns `null` if the shape type is not "GeometricShape".
+      Specifies the geometric shape type of this geometric shape. See
+      `ExcelScript.GeometricShapeType` for details. Returns `null` if the shape
+      type is not "GeometricShape".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGeometricShapeType(): GeometricShapeType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
         description: ''
   - name: getGroup()
-    uid: 'ExcelScript!ExcelScript.Shape#getGroup:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getGroup:member(1)
     package: ExcelScript!
     fullName: getGroup()
-    summary: Returns the shape group associated with the shape. An error will be thrown if the shape type is not "GroupShape".
+    summary: >-
+      Returns the shape group associated with the shape. An error will be thrown
+      if the shape type is not "GroupShape".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGroup(): ShapeGroup;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeGroup:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeGroup:interface" />
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.Shape#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
     summary: >-
-      Specifies the height, in points, of the shape. Throws an `InvalidArgument` exception when set with a negative
-      value or zero as an input.
+      Specifies the height, in points, of the shape. Throws an `InvalidArgument`
+      exception when set with a negative value or zero as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -255,11 +280,12 @@ methods:
         type: number
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Shape#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the shape identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -268,17 +294,20 @@ methods:
         type: string
         description: ''
   - name: getImage()
-    uid: 'ExcelScript!ExcelScript.Shape#getImage:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getImage:member(1)
     package: ExcelScript!
     fullName: getImage()
-    summary: Returns the image associated with the shape. An error will be thrown if the shape type is not "Image".
+    summary: >-
+      Returns the image associated with the shape. An error will be thrown if
+      the shape type is not "Image".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getImage(): Image;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Image:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Image:interface" />
         description: |-
 
 
@@ -308,14 +337,18 @@ methods:
           }
           ```
   - name: getImageAsBase64(format)
-    uid: 'ExcelScript!ExcelScript.Shape#getImageAsBase64:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getImageAsBase64:member(1)
     package: ExcelScript!
     fullName: getImageAsBase64(format)
     summary: >-
-      Converts the shape to an image and returns the image as a Base64-encoded string. The DPI is 96. The only supported
-      formats are `ExcelScript.PictureFormat.BMP`<!-- -->, `ExcelScript.PictureFormat.PNG`<!-- -->,
-      `ExcelScript.PictureFormat.JPEG`<!-- -->, and `ExcelScript.PictureFormat.GIF`<!-- -->.
+      Converts the shape to an image and returns the image as a Base64-encoded
+      string. The DPI is 96. The only supported formats are
+      `ExcelScript.PictureFormat.BMP`<!-- -->,
+      `ExcelScript.PictureFormat.PNG`<!-- -->,
+      `ExcelScript.PictureFormat.JPEG`<!-- -->, and
+      `ExcelScript.PictureFormat.GIF`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -323,18 +356,20 @@ methods:
       parameters:
         - id: format
           description: Specifies the format of the image.
-          type: '<xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.PictureFormat:enum" />
       return:
         type: string
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.Shape#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      The distance, in points, from the left side of the shape to the left side of the worksheet. Throws an
-      `InvalidArgument` exception when set with a negative value as an input.
+      The distance, in points, from the left side of the shape to the left side
+      of the worksheet. Throws an `InvalidArgument` exception when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -343,14 +378,16 @@ methods:
         type: number
         description: ''
   - name: getLevel()
-    uid: 'ExcelScript!ExcelScript.Shape#getLevel:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getLevel:member(1)
     package: ExcelScript!
     fullName: getLevel()
     summary: >-
-      Specifies the level of the specified shape. For example, a level of 0 means that the shape is not part of any
-      groups, a level of 1 means the shape is part of a top-level group, and a level of 2 means the shape is part of a
-      sub-group of the top level.
+      Specifies the level of the specified shape. For example, a level of 0
+      means that the shape is not part of any groups, a level of 1 means the
+      shape is part of a top-level group, and a level of 2 means the shape is
+      part of a sub-group of the top level.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -359,17 +396,20 @@ methods:
         type: number
         description: ''
   - name: getLine()
-    uid: 'ExcelScript!ExcelScript.Shape#getLine:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getLine:member(1)
     package: ExcelScript!
     fullName: getLine()
-    summary: Returns the line associated with the shape. An error will be thrown if the shape type is not "Line".
+    summary: >-
+      Returns the line associated with the shape. An error will be thrown if the
+      shape type is not "Line".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLine(): Line;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Line:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Line:interface" />
         description: |-
 
 
@@ -401,24 +441,26 @@ methods:
           }
           ```
   - name: getLineFormat()
-    uid: 'ExcelScript!ExcelScript.Shape#getLineFormat:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getLineFormat:member(1)
     package: ExcelScript!
     fullName: getLineFormat()
     summary: Returns the line formatting of this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLineFormat(): ShapeLineFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeLineFormat:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeLineFormat:interface" />
         description: ''
   - name: getLockAspectRatio()
-    uid: 'ExcelScript!ExcelScript.Shape#getLockAspectRatio:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getLockAspectRatio:member(1)
     package: ExcelScript!
     fullName: getLockAspectRatio()
     summary: Specifies if the aspect ratio of this shape is locked.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -427,11 +469,12 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Shape#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -440,37 +483,40 @@ methods:
         type: string
         description: ''
   - name: getParentGroup()
-    uid: 'ExcelScript!ExcelScript.Shape#getParentGroup:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getParentGroup:member(1)
     package: ExcelScript!
     fullName: getParentGroup()
     summary: Specifies the parent group of this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getParentGroup(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: getPlacement()
-    uid: 'ExcelScript!ExcelScript.Shape#getPlacement:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getPlacement:member(1)
     package: ExcelScript!
     fullName: getPlacement()
     summary: Represents how the object is attached to the cells below it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPlacement(): Placement;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Placement:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.Placement:enum" />
         description: ''
   - name: getRotation()
-    uid: 'ExcelScript!ExcelScript.Shape#getRotation:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getRotation:member(1)
     package: ExcelScript!
     fullName: getRotation()
-    summary: 'Specifies the rotation, in degrees, of the shape.'
+    summary: Specifies the rotation, in degrees, of the shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -479,17 +525,18 @@ methods:
         type: number
         description: ''
   - name: getTextFrame()
-    uid: 'ExcelScript!ExcelScript.Shape#getTextFrame:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getTextFrame:member(1)
     package: ExcelScript!
     fullName: getTextFrame()
     summary: Returns the text frame object of this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTextFrame(): TextFrame;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TextFrame:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TextFrame:interface" />
         description: |-
 
 
@@ -514,13 +561,15 @@ methods:
           }
           ```
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.Shape#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      The distance, in points, from the top edge of the shape to the top edge of the worksheet. Throws an
-      `InvalidArgument` exception when set with a negative value as an input.
+      The distance, in points, from the top edge of the shape to the top edge of
+      the worksheet. Throws an `InvalidArgument` exception when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -529,24 +578,26 @@ methods:
         type: number
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.Shape#getType:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getType:member(1)
     package: ExcelScript!
     fullName: getType()
     summary: Returns the type of this shape. See `ExcelScript.ShapeType` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ShapeType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeType:enum" />
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.Shape#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: Specifies if the shape is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -555,13 +606,14 @@ methods:
         type: boolean
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.Shape#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: >-
-      Specifies the width, in points, of the shape. Throws an `InvalidArgument` exception when set with a negative value
-      or zero as an input.
+      Specifies the width, in points, of the shape. Throws an `InvalidArgument`
+      exception when set with a negative value or zero as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -570,11 +622,14 @@ methods:
         type: number
         description: ''
   - name: getZOrderPosition()
-    uid: 'ExcelScript!ExcelScript.Shape#getZOrderPosition:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#getZOrderPosition:member(1)
     package: ExcelScript!
     fullName: getZOrderPosition()
-    summary: 'Returns the position of the specified shape in the z-order, with 0 representing the bottom of the order stack.'
+    summary: >-
+      Returns the position of the specified shape in the z-order, with 0
+      representing the bottom of the order stack.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -583,11 +638,12 @@ methods:
         type: number
         description: ''
   - name: incrementLeft(increment)
-    uid: 'ExcelScript!ExcelScript.Shape#incrementLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#incrementLeft:member(1)
     package: ExcelScript!
     fullName: incrementLeft(increment)
     summary: Moves the shape horizontally by the specified number of points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -595,21 +651,25 @@ methods:
       parameters:
         - id: increment
           description: >-
-            The increment, in points, the shape will be horizontally moved. A positive value moves the shape to the
-            right and a negative value moves it to the left. If the sheet is right-to-left oriented, this is reversed:
-            positive values will move the shape to the left and negative values will move it to the right.
+            The increment, in points, the shape will be horizontally moved. A
+            positive value moves the shape to the right and a negative value
+            moves it to the left. If the sheet is right-to-left oriented, this
+            is reversed: positive values will move the shape to the left and
+            negative values will move it to the right.
           type: number
       return:
         type: void
         description: ''
   - name: incrementRotation(increment)
-    uid: 'ExcelScript!ExcelScript.Shape#incrementRotation:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#incrementRotation:member(1)
     package: ExcelScript!
     fullName: incrementRotation(increment)
     summary: >-
-      Rotates the shape clockwise around the z-axis by the specified number of degrees. Use the `rotation` property to
-      set the absolute rotation of the shape.
+      Rotates the shape clockwise around the z-axis by the specified number of
+      degrees. Use the `rotation` property to set the absolute rotation of the
+      shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -617,18 +677,20 @@ methods:
       parameters:
         - id: increment
           description: >-
-            How many degrees the shape will be rotated. A positive value rotates the shape clockwise and a negative
-            value rotates it counterclockwise.
+            How many degrees the shape will be rotated. A positive value rotates
+            the shape clockwise and a negative value rotates it
+            counterclockwise.
           type: number
       return:
         type: void
         description: ''
   - name: incrementTop(increment)
-    uid: 'ExcelScript!ExcelScript.Shape#incrementTop:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#incrementTop:member(1)
     package: ExcelScript!
     fullName: incrementTop(increment)
     summary: Moves the shape vertically by the specified number of points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -636,21 +698,24 @@ methods:
       parameters:
         - id: increment
           description: >-
-            The increment, in points, the shape will be vertically moved. A positive value moves the shape down and a
-            negative value moves it up.
+            The increment, in points, the shape will be vertically moved. A
+            positive value moves the shape down and a negative value moves it
+            up.
           type: number
       return:
         type: void
         description: ''
-  - name: 'scaleHeight(scaleFactor, scaleType, scaleFrom)'
-    uid: 'ExcelScript!ExcelScript.Shape#scaleHeight:member(1)'
+  - name: scaleHeight(scaleFactor, scaleType, scaleFrom)
+    uid: ExcelScript!ExcelScript.Shape#scaleHeight:member(1)
     package: ExcelScript!
-    fullName: 'scaleHeight(scaleFactor, scaleType, scaleFrom)'
+    fullName: scaleHeight(scaleFactor, scaleType, scaleFrom)
     summary: >-
-      Scales the height of the shape by a specified factor. For images, you can indicate whether you want to scale the
-      shape relative to the original or the current size. Shapes other than pictures are always scaled relative to their
-      current height.
+      Scales the height of the shape by a specified factor. For images, you can
+      indicate whether you want to scale the shape relative to the original or
+      the current size. Shapes other than pictures are always scaled relative to
+      their current height.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -662,30 +727,36 @@ methods:
                 ): void;
       parameters:
         - id: scaleFactor
-          description: Specifies the ratio between the height of the shape after you resize it and the current or original height.
+          description: >-
+            Specifies the ratio between the height of the shape after you resize
+            it and the current or original height.
           type: number
         - id: scaleType
           description: >-
-            Specifies whether the shape is scaled relative to its original or current size. The original size scaling
-            option only works for images.
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeScaleType:enum" />'
+            Specifies whether the shape is scaled relative to its original or
+            current size. The original size scaling option only works for
+            images.
+          type: <xref uid="ExcelScript!ExcelScript.ShapeScaleType:enum" />
         - id: scaleFrom
           description: >-
-            Optional. Specifies which part of the shape retains its position when the shape is scaled. If omitted, it
-            represents the shape's upper left corner retains its position.
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeScaleFrom:enum" />'
+            Optional. Specifies which part of the shape retains its position
+            when the shape is scaled. If omitted, it represents the shape's
+            upper left corner retains its position.
+          type: <xref uid="ExcelScript!ExcelScript.ShapeScaleFrom:enum" />
       return:
         type: void
         description: ''
-  - name: 'scaleWidth(scaleFactor, scaleType, scaleFrom)'
-    uid: 'ExcelScript!ExcelScript.Shape#scaleWidth:member(1)'
+  - name: scaleWidth(scaleFactor, scaleType, scaleFrom)
+    uid: ExcelScript!ExcelScript.Shape#scaleWidth:member(1)
     package: ExcelScript!
-    fullName: 'scaleWidth(scaleFactor, scaleType, scaleFrom)'
+    fullName: scaleWidth(scaleFactor, scaleType, scaleFrom)
     summary: >-
-      Scales the width of the shape by a specified factor. For images, you can indicate whether you want to scale the
-      shape relative to the original or the current size. Shapes other than pictures are always scaled relative to their
-      current width.
+      Scales the width of the shape by a specified factor. For images, you can
+      indicate whether you want to scale the shape relative to the original or
+      the current size. Shapes other than pictures are always scaled relative to
+      their current width.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -697,27 +768,32 @@ methods:
                 ): void;
       parameters:
         - id: scaleFactor
-          description: Specifies the ratio between the width of the shape after you resize it and the current or original width.
+          description: >-
+            Specifies the ratio between the width of the shape after you resize
+            it and the current or original width.
           type: number
         - id: scaleType
           description: >-
-            Specifies whether the shape is scaled relative to its original or current size. The original size scaling
-            option only works for images.
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeScaleType:enum" />'
+            Specifies whether the shape is scaled relative to its original or
+            current size. The original size scaling option only works for
+            images.
+          type: <xref uid="ExcelScript!ExcelScript.ShapeScaleType:enum" />
         - id: scaleFrom
           description: >-
-            Optional. Specifies which part of the shape retains its position when the shape is scaled. If omitted, it
-            represents the shape's upper left corner retains its position.
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeScaleFrom:enum" />'
+            Optional. Specifies which part of the shape retains its position
+            when the shape is scaled. If omitted, it represents the shape's
+            upper left corner retains its position.
+          type: <xref uid="ExcelScript!ExcelScript.ShapeScaleFrom:enum" />
       return:
         type: void
         description: ''
   - name: setAltTextDescription(altTextDescription)
-    uid: 'ExcelScript!ExcelScript.Shape#setAltTextDescription:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setAltTextDescription:member(1)
     package: ExcelScript!
     fullName: setAltTextDescription(altTextDescription)
     summary: Specifies the alternative description text for a `Shape` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -730,11 +806,12 @@ methods:
         type: void
         description: ''
   - name: setAltTextTitle(altTextTitle)
-    uid: 'ExcelScript!ExcelScript.Shape#setAltTextTitle:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setAltTextTitle:member(1)
     package: ExcelScript!
     fullName: setAltTextTitle(altTextTitle)
     summary: Specifies the alternative title text for a `Shape` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -747,13 +824,15 @@ methods:
         type: void
         description: ''
   - name: setGeometricShapeType(geometricShapeType)
-    uid: 'ExcelScript!ExcelScript.Shape#setGeometricShapeType:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setGeometricShapeType:member(1)
     package: ExcelScript!
     fullName: setGeometricShapeType(geometricShapeType)
     summary: >-
-      Specifies the geometric shape type of this geometric shape. See `ExcelScript.GeometricShapeType` for details.
-      Returns `null` if the shape type is not "GeometricShape".
+      Specifies the geometric shape type of this geometric shape. See
+      `ExcelScript.GeometricShapeType` for details. Returns `null` if the shape
+      type is not "GeometricShape".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -761,18 +840,19 @@ methods:
       parameters:
         - id: geometricShapeType
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
       return:
         type: void
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.Shape#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
     summary: >-
-      Specifies the height, in points, of the shape. Throws an `InvalidArgument` exception when set with a negative
-      value or zero as an input.
+      Specifies the height, in points, of the shape. Throws an `InvalidArgument`
+      exception when set with a negative value or zero as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -785,13 +865,15 @@ methods:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.Shape#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      The distance, in points, from the left side of the shape to the left side of the worksheet. Throws an
-      `InvalidArgument` exception when set with a negative value as an input.
+      The distance, in points, from the left side of the shape to the left side
+      of the worksheet. Throws an `InvalidArgument` exception when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -804,11 +886,12 @@ methods:
         type: void
         description: ''
   - name: setLockAspectRatio(lockAspectRatio)
-    uid: 'ExcelScript!ExcelScript.Shape#setLockAspectRatio:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setLockAspectRatio:member(1)
     package: ExcelScript!
     fullName: setLockAspectRatio(lockAspectRatio)
     summary: Specifies if the aspect ratio of this shape is locked.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -821,11 +904,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.Shape#setName:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -854,11 +938,12 @@ methods:
           }
           ```
   - name: setPlacement(placement)
-    uid: 'ExcelScript!ExcelScript.Shape#setPlacement:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setPlacement:member(1)
     package: ExcelScript!
     fullName: setPlacement(placement)
     summary: Represents how the object is attached to the cells below it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -866,7 +951,7 @@ methods:
       parameters:
         - id: placement
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.Placement:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.Placement:enum" />
       return:
         type: void
         description: |-
@@ -897,11 +982,12 @@ methods:
           }
           ```
   - name: setRotation(rotation)
-    uid: 'ExcelScript!ExcelScript.Shape#setRotation:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setRotation:member(1)
     package: ExcelScript!
     fullName: setRotation(rotation)
-    summary: 'Specifies the rotation, in degrees, of the shape.'
+    summary: Specifies the rotation, in degrees, of the shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -914,13 +1000,15 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.Shape#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      The distance, in points, from the top edge of the shape to the top edge of the worksheet. Throws an
-      `InvalidArgument` exception when set with a negative value as an input.
+      The distance, in points, from the top edge of the shape to the top edge of
+      the worksheet. Throws an `InvalidArgument` exception when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -933,11 +1021,12 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.Shape#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: Specifies if the shape is visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -950,13 +1039,14 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.Shape#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
     summary: >-
-      Specifies the width, in points, of the shape. Throws an `InvalidArgument` exception when set with a negative value
-      or zero as an input.
+      Specifies the width, in points, of the shape. Throws an `InvalidArgument`
+      exception when set with a negative value or zero as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -969,11 +1059,14 @@ methods:
         type: void
         description: ''
   - name: setZOrder(position)
-    uid: 'ExcelScript!ExcelScript.Shape#setZOrder:member(1)'
+    uid: ExcelScript!ExcelScript.Shape#setZOrder:member(1)
     package: ExcelScript!
     fullName: setZOrder(position)
-    summary: 'Moves the specified shape up or down the collection''s z-order, which shifts it in front of or behind other shapes.'
+    summary: >-
+      Moves the specified shape up or down the collection's z-order, which
+      shifts it in front of or behind other shapes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -981,9 +1074,9 @@ methods:
       parameters:
         - id: position
           description: >-
-            Where to move the shape in the z-order stack relative to the other shapes. See `ExcelScript.ShapeZOrder` for
-            details.
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeZOrder:enum" />'
+            Where to move the shape in the z-order stack relative to the other
+            shapes. See `ExcelScript.ShapeZOrder` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ShapeZOrder:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapeautosize.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapeautosize.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeAutoSize
-uid: 'ExcelScript!ExcelScript.ShapeAutoSize:enum'
+uid: ExcelScript!ExcelScript.ShapeAutoSize:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeAutoSize
 summary: Determines the type of automatic sizing allowed.
@@ -27,22 +27,23 @@ remarks: |-
     textFrame.setAutoSizeSetting(ExcelScript.ShapeAutoSize.autoSizeShapeToFitText);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: autoSizeMixed
-    uid: 'ExcelScript!ExcelScript.ShapeAutoSize.autoSizeMixed:member'
+    uid: ExcelScript!ExcelScript.ShapeAutoSize.autoSizeMixed:member
     package: ExcelScript!
     summary: A combination of automatic sizing schemes are used.
   - name: autoSizeNone
-    uid: 'ExcelScript!ExcelScript.ShapeAutoSize.autoSizeNone:member'
+    uid: ExcelScript!ExcelScript.ShapeAutoSize.autoSizeNone:member
     package: ExcelScript!
     summary: No autosizing.
   - name: autoSizeShapeToFitText
-    uid: 'ExcelScript!ExcelScript.ShapeAutoSize.autoSizeShapeToFitText:member'
+    uid: ExcelScript!ExcelScript.ShapeAutoSize.autoSizeShapeToFitText:member
     package: ExcelScript!
     summary: The shape is adjusted to fit the text.
   - name: autoSizeTextToFitShape
-    uid: 'ExcelScript!ExcelScript.ShapeAutoSize.autoSizeTextToFitShape:member'
+    uid: ExcelScript!ExcelScript.ShapeAutoSize.autoSizeTextToFitShape:member
     package: ExcelScript!
     summary: The text is adjusted to fit the shape.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefill.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefill.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.ShapeFill
-uid: 'ExcelScript!ExcelScript.ShapeFill:interface'
+uid: ExcelScript!ExcelScript.ShapeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ShapeFill
 summary: Represents the fill formatting of a shape object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.ShapeFill#clear:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: Clears the fill formatting of this shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,13 +25,14 @@ methods:
         type: void
         description: ''
   - name: getForegroundColor()
-    uid: 'ExcelScript!ExcelScript.ShapeFill#getForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#getForegroundColor:member(1)
     package: ExcelScript!
     fullName: getForegroundColor()
     summary: >-
-      Represents the shape fill foreground color in HTML color format, in the form \#RRGGBB (e.g., "FFA500") or as a
-      named HTML color (e.g., "orange")
+      Represents the shape fill foreground color in HTML color format, in the
+      form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -38,14 +41,16 @@ methods:
         type: string
         description: ''
   - name: getTransparency()
-    uid: 'ExcelScript!ExcelScript.ShapeFill#getTransparency:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#getTransparency:member(1)
     package: ExcelScript!
     fullName: getTransparency()
     summary: >-
-      Specifies the transparency percentage of the fill as a value from 0.0 (opaque) through 1.0 (clear). Returns `null`
-      if the shape type does not support transparency or the shape fill has inconsistent transparency, such as with a
-      gradient fill type.
+      Specifies the transparency percentage of the fill as a value from 0.0
+      (opaque) through 1.0 (clear). Returns `null` if the shape type does not
+      support transparency or the shape fill has inconsistent transparency, such
+      as with a gradient fill type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -54,26 +59,30 @@ methods:
         type: number
         description: ''
   - name: getType()
-    uid: 'ExcelScript!ExcelScript.ShapeFill#getType:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#getType:member(1)
     package: ExcelScript!
     fullName: getType()
-    summary: Returns the fill type of the shape. See `ExcelScript.ShapeFillType` for details.
+    summary: >-
+      Returns the fill type of the shape. See `ExcelScript.ShapeFillType` for
+      details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getType(): ShapeFillType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeFillType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeFillType:enum" />
         description: ''
   - name: setForegroundColor(foregroundColor)
-    uid: 'ExcelScript!ExcelScript.ShapeFill#setForegroundColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#setForegroundColor:member(1)
     package: ExcelScript!
     fullName: setForegroundColor(foregroundColor)
     summary: >-
-      Represents the shape fill foreground color in HTML color format, in the form \#RRGGBB (e.g., "FFA500") or as a
-      named HTML color (e.g., "orange")
+      Represents the shape fill foreground color in HTML color format, in the
+      form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g., "orange")
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -86,11 +95,14 @@ methods:
         type: void
         description: ''
   - name: setSolidColor(color)
-    uid: 'ExcelScript!ExcelScript.ShapeFill#setSolidColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#setSolidColor:member(1)
     package: ExcelScript!
     fullName: setSolidColor(color)
-    summary: Sets the fill formatting of the shape to a uniform color. This changes the fill type to "Solid".
+    summary: >-
+      Sets the fill formatting of the shape to a uniform color. This changes the
+      fill type to "Solid".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -98,21 +110,24 @@ methods:
       parameters:
         - id: color
           description: >-
-            A string that represents the fill color in HTML color format, in the form \#RRGGBB (e.g., "FFA500") or as a
-            named HTML color (e.g., "orange").
+            A string that represents the fill color in HTML color format, in the
+            form \#RRGGBB (e.g., "FFA500") or as a named HTML color (e.g.,
+            "orange").
           type: string
       return:
         type: void
         description: ''
   - name: setTransparency(transparency)
-    uid: 'ExcelScript!ExcelScript.ShapeFill#setTransparency:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFill#setTransparency:member(1)
     package: ExcelScript!
     fullName: setTransparency(transparency)
     summary: >-
-      Specifies the transparency percentage of the fill as a value from 0.0 (opaque) through 1.0 (clear). Returns `null`
-      if the shape type does not support transparency or the shape fill has inconsistent transparency, such as with a
-      gradient fill type.
+      Specifies the transparency percentage of the fill as a value from 0.0
+      (opaque) through 1.0 (clear). Returns `null` if the shape type does not
+      support transparency or the shape fill has inconsistent transparency, such
+      as with a gradient fill type.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefilltype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefilltype.yml
@@ -1,34 +1,35 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeFillType
-uid: 'ExcelScript!ExcelScript.ShapeFillType:enum'
+uid: ExcelScript!ExcelScript.ShapeFillType:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeFillType
 summary: Specifies a shape's fill type.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: gradient
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.gradient:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.gradient:member
     package: ExcelScript!
     summary: Gradient fill.
   - name: mixed
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.mixed:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.mixed:member
     package: ExcelScript!
     summary: Mixed fill.
   - name: noFill
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.noFill:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.noFill:member
     package: ExcelScript!
     summary: No fill.
   - name: pattern
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.pattern:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.pattern:member
     package: ExcelScript!
     summary: Pattern fill.
   - name: pictureAndTexture
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.pictureAndTexture:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.pictureAndTexture:member
     package: ExcelScript!
     summary: Picture and texture fill.
   - name: solid
-    uid: 'ExcelScript!ExcelScript.ShapeFillType.solid:member'
+    uid: ExcelScript!ExcelScript.ShapeFillType.solid:member
     package: ExcelScript!
     summary: Solid fill.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefont.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefont.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.ShapeFont
-uid: 'ExcelScript!ExcelScript.ShapeFont:interface'
+uid: ExcelScript!ExcelScript.ShapeFont:interface
 package: ExcelScript!
 fullName: ExcelScript.ShapeFont
-summary: 'Represents the font attributes, such as font name, font size, and color, for a shape''s `TextRange` object.'
+summary: >-
+  Represents the font attributes, such as font name, font size, and color, for a
+  shape's `TextRange` object.
 remarks: |-
 
 
@@ -26,18 +28,20 @@ remarks: |-
     shapeTextFont.setBold(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getBold()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getBold:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getBold:member(1)
     package: ExcelScript!
     fullName: getBold()
     summary: >-
-      Represents the bold status of font. Returns `null` if the `TextRange` includes both bold and non-bold text
-      fragments.
+      Represents the bold status of font. Returns `null` if the `TextRange`
+      includes both bold and non-bold text fragments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -46,13 +50,15 @@ methods:
         type: boolean
         description: ''
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      HTML color code representation of the text color (e.g., "\#FF0000" represents red). Returns `null` if the
-      `TextRange` includes text fragments with different colors.
+      HTML color code representation of the text color (e.g., "\#FF0000"
+      represents red). Returns `null` if the `TextRange` includes text fragments
+      with different colors.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,13 +67,14 @@ methods:
         type: string
         description: ''
   - name: getItalic()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getItalic:member(1)
     package: ExcelScript!
     fullName: getItalic()
     summary: >-
-      Represents the italic status of font. Returns `null` if the `TextRange` includes both italic and non-italic text
-      fragments.
+      Represents the italic status of font. Returns `null` if the `TextRange`
+      includes both italic and non-italic text fragments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -76,13 +83,15 @@ methods:
         type: boolean
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getName:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: >-
-      Represents font name (e.g., "Calibri"). If the text is a Complex Script or East Asian language, this is the
-      corresponding font name; otherwise it is the Latin font name.
+      Represents font name (e.g., "Calibri"). If the text is a Complex Script or
+      East Asian language, this is the corresponding font name; otherwise it is
+      the Latin font name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,13 +100,14 @@ methods:
         type: string
         description: ''
   - name: getSize()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getSize:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getSize:member(1)
     package: ExcelScript!
     fullName: getSize()
     summary: >-
-      Represents font size in points (e.g., 11). Returns `null` if the `TextRange` includes text fragments with
-      different font sizes.
+      Represents font size in points (e.g., 11). Returns `null` if the
+      `TextRange` includes text fragments with different font sizes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -106,28 +116,31 @@ methods:
         type: number
         description: ''
   - name: getUnderline()
-    uid: 'ExcelScript!ExcelScript.ShapeFont#getUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#getUnderline:member(1)
     package: ExcelScript!
     fullName: getUnderline()
     summary: >-
-      Type of underline applied to the font. Returns `null` if the `TextRange` includes text fragments with different
-      underline styles. See `ExcelScript.ShapeFontUnderlineStyle` for details.
+      Type of underline applied to the font. Returns `null` if the `TextRange`
+      includes text fragments with different underline styles. See
+      `ExcelScript.ShapeFontUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getUnderline(): ShapeFontUnderlineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum" />
         description: ''
   - name: setBold(bold)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setBold:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setBold:member(1)
     package: ExcelScript!
     fullName: setBold(bold)
     summary: >-
-      Represents the bold status of font. Returns `null` if the `TextRange` includes both bold and non-bold text
-      fragments.
+      Represents the bold status of font. Returns `null` if the `TextRange`
+      includes both bold and non-bold text fragments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,13 +153,15 @@ methods:
         type: void
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      HTML color code representation of the text color (e.g., "\#FF0000" represents red). Returns `null` if the
-      `TextRange` includes text fragments with different colors.
+      HTML color code representation of the text color (e.g., "\#FF0000"
+      represents red). Returns `null` if the `TextRange` includes text fragments
+      with different colors.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -159,13 +174,14 @@ methods:
         type: void
         description: ''
   - name: setItalic(italic)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setItalic:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setItalic:member(1)
     package: ExcelScript!
     fullName: setItalic(italic)
     summary: >-
-      Represents the italic status of font. Returns `null` if the `TextRange` includes both italic and non-italic text
-      fragments.
+      Represents the italic status of font. Returns `null` if the `TextRange`
+      includes both italic and non-italic text fragments.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -178,13 +194,15 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setName:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: >-
-      Represents font name (e.g., "Calibri"). If the text is a Complex Script or East Asian language, this is the
-      corresponding font name; otherwise it is the Latin font name.
+      Represents font name (e.g., "Calibri"). If the text is a Complex Script or
+      East Asian language, this is the corresponding font name; otherwise it is
+      the Latin font name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,13 +215,14 @@ methods:
         type: void
         description: ''
   - name: setSize(size)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setSize:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setSize:member(1)
     package: ExcelScript!
     fullName: setSize(size)
     summary: >-
-      Represents font size in points (e.g., 11). Returns `null` if the `TextRange` includes text fragments with
-      different font sizes.
+      Represents font size in points (e.g., 11). Returns `null` if the
+      `TextRange` includes text fragments with different font sizes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -216,13 +235,15 @@ methods:
         type: void
         description: ''
   - name: setUnderline(underline)
-    uid: 'ExcelScript!ExcelScript.ShapeFont#setUnderline:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeFont#setUnderline:member(1)
     package: ExcelScript!
     fullName: setUnderline(underline)
     summary: >-
-      Type of underline applied to the font. Returns `null` if the `TextRange` includes text fragments with different
-      underline styles. See `ExcelScript.ShapeFontUnderlineStyle` for details.
+      Type of underline applied to the font. Returns `null` if the `TextRange`
+      includes text fragments with different underline styles. See
+      `ExcelScript.ShapeFontUnderlineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -230,7 +251,7 @@ methods:
       parameters:
         - id: underline
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefontunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapefontunderlinestyle.yml
@@ -1,78 +1,79 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeFontUnderlineStyle
-uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum'
+uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeFontUnderlineStyle
 summary: The type of underline applied to a font.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: dash
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dash:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: dashHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashHeavy:member
     package: ExcelScript!
     summary: ''
   - name: dashLong
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashLong:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashLong:member
     package: ExcelScript!
     summary: ''
   - name: dashLongHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashLongHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dashLongHeavy:member
     package: ExcelScript!
     summary: ''
   - name: dotDash
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDash:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDash:member
     package: ExcelScript!
     summary: ''
   - name: dotDashHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDashHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDashHeavy:member
     package: ExcelScript!
     summary: ''
   - name: dotDotDash
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDotDash:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDotDash:member
     package: ExcelScript!
     summary: ''
   - name: dotDotDashHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDotDashHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotDotDashHeavy:member
     package: ExcelScript!
     summary: ''
   - name: dotted
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotted:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dotted:member
     package: ExcelScript!
     summary: ''
   - name: dottedHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dottedHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.dottedHeavy:member
     package: ExcelScript!
     summary: ''
   - name: double
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.double:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.double:member
     package: ExcelScript!
     summary: ''
   - name: heavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.heavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.heavy:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.none:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.none:member
     package: ExcelScript!
     summary: ''
   - name: single
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.single:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.single:member
     package: ExcelScript!
     summary: ''
   - name: wavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavy:member
     package: ExcelScript!
     summary: ''
   - name: wavyDouble
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavyDouble:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavyDouble:member
     package: ExcelScript!
     summary: ''
   - name: wavyHeavy
-    uid: 'ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavyHeavy:member'
+    uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle.wavyHeavy:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapegroup.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapegroup.yml
@@ -1,33 +1,38 @@
 ### YamlMime:TSType
 name: ExcelScript.ShapeGroup
-uid: 'ExcelScript!ExcelScript.ShapeGroup:interface'
+uid: ExcelScript!ExcelScript.ShapeGroup:interface
 package: ExcelScript!
 fullName: ExcelScript.ShapeGroup
-summary: 'Represents a shape group inside a worksheet. To get the corresponding `Shape` object, use `ShapeGroup.shape`<!-- -->.'
+summary: >-
+  Represents a shape group inside a worksheet. To get the corresponding `Shape`
+  object, use `ShapeGroup.shape`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getGroupShape()
-    uid: 'ExcelScript!ExcelScript.ShapeGroup#getGroupShape:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeGroup#getGroupShape:member(1)
     package: ExcelScript!
     fullName: getGroupShape()
     summary: Returns the `Shape` object associated with the group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getGroupShape(): Shape;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.ShapeGroup#getId:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeGroup#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Specifies the shape identifier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,13 +41,14 @@ methods:
         type: string
         description: ''
   - name: getShape(key)
-    uid: 'ExcelScript!ExcelScript.ShapeGroup#getShape:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeGroup#getShape:member(1)
     package: ExcelScript!
     fullName: getShape(key)
     summary: >-
-      Gets a shape using its name or ID. If the shape object does not exist, then this method returns `undefined`<!--
-      -->.
+      Gets a shape using its name or ID. If the shape object does not exist,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -52,27 +58,29 @@ methods:
           description: The name or ID of the shape to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" /> | undefined
         description: ''
   - name: getShapes()
-    uid: 'ExcelScript!ExcelScript.ShapeGroup#getShapes:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeGroup#getShapes:member(1)
     package: ExcelScript!
     fullName: getShapes()
     summary: Returns the collection of `Shape` objects.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getShapes(): Shape[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />[]
         description: ''
   - name: ungroup()
-    uid: 'ExcelScript!ExcelScript.ShapeGroup#ungroup:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeGroup#ungroup:member(1)
     package: ExcelScript!
     fullName: ungroup()
     summary: Ungroups any grouped shapes in the specified shape group.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelinedashstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelinedashstyle.yml
@@ -1,58 +1,59 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeLineDashStyle
-uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle:enum'
+uid: ExcelScript!ExcelScript.ShapeLineDashStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeLineDashStyle
 summary: The dash style for a line.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: dash
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.dash:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.dash:member
     package: ExcelScript!
     summary: ''
   - name: dashDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.dashDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.dashDot:member
     package: ExcelScript!
     summary: ''
   - name: dashDotDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.dashDotDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.dashDotDot:member
     package: ExcelScript!
     summary: ''
   - name: longDash
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.longDash:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.longDash:member
     package: ExcelScript!
     summary: ''
   - name: longDashDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.longDashDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.longDashDot:member
     package: ExcelScript!
     summary: ''
   - name: longDashDotDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.longDashDotDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.longDashDotDot:member
     package: ExcelScript!
     summary: ''
   - name: roundDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.roundDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.roundDot:member
     package: ExcelScript!
     summary: ''
   - name: solid
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.solid:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.solid:member
     package: ExcelScript!
     summary: ''
   - name: squareDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.squareDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.squareDot:member
     package: ExcelScript!
     summary: ''
   - name: systemDash
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.systemDash:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.systemDash:member
     package: ExcelScript!
     summary: ''
   - name: systemDashDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.systemDashDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.systemDashDot:member
     package: ExcelScript!
     summary: ''
   - name: systemDot
-    uid: 'ExcelScript!ExcelScript.ShapeLineDashStyle.systemDot:member'
+    uid: ExcelScript!ExcelScript.ShapeLineDashStyle.systemDot:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelineformat.yml
@@ -1,24 +1,26 @@
 ### YamlMime:TSType
 name: ExcelScript.ShapeLineFormat
-uid: 'ExcelScript!ExcelScript.ShapeLineFormat:interface'
+uid: ExcelScript!ExcelScript.ShapeLineFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ShapeLineFormat
 summary: >-
-  Represents the line formatting for the shape object. For images and geometric shapes, line formatting represents the
-  border of the shape.
+  Represents the line formatting for the shape object. For images and geometric
+  shapes, line formatting represents the border of the shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getColor()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getColor:member(1)
     package: ExcelScript!
     fullName: getColor()
     summary: >-
-      Represents the line color in HTML color format, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color
-      (e.g., "orange").
+      Represents the line color in HTML color format, in the form \#RRGGBB
+      (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -27,43 +29,49 @@ methods:
         type: string
         description: ''
   - name: getDashStyle()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getDashStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getDashStyle:member(1)
     package: ExcelScript!
     fullName: getDashStyle()
     summary: >-
-      Represents the line style of the shape. Returns `null` when the line is not visible or there are inconsistent dash
-      styles. See `ExcelScript.ShapeLineDashStyle` for details.
+      Represents the line style of the shape. Returns `null` when the line is
+      not visible or there are inconsistent dash styles. See
+      `ExcelScript.ShapeLineDashStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDashStyle(): ShapeLineDashStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeLineDashStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeLineDashStyle:enum" />
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
     summary: >-
-      Represents the line style of the shape. Returns `null` when the line is not visible or there are inconsistent
-      styles. See `ExcelScript.ShapeLineStyle` for details.
+      Represents the line style of the shape. Returns `null` when the line is
+      not visible or there are inconsistent styles. See
+      `ExcelScript.ShapeLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getStyle(): ShapeLineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeLineStyle:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeLineStyle:enum" />
         description: ''
   - name: getTransparency()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getTransparency:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getTransparency:member(1)
     package: ExcelScript!
     fullName: getTransparency()
     summary: >-
-      Represents the degree of transparency of the specified line as a value from 0.0 (opaque) through 1.0 (clear).
-      Returns `null` when the shape has inconsistent transparencies.
+      Represents the degree of transparency of the specified line as a value
+      from 0.0 (opaque) through 1.0 (clear). Returns `null` when the shape has
+      inconsistent transparencies.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,13 +80,14 @@ methods:
         type: number
         description: ''
   - name: getVisible()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getVisible:member(1)
     package: ExcelScript!
     fullName: getVisible()
     summary: >-
-      Specifies if the line formatting of a shape element is visible. Returns `null` when the shape has inconsistent
-      visibilities.
+      Specifies if the line formatting of a shape element is visible. Returns
+      `null` when the shape has inconsistent visibilities.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -87,13 +96,14 @@ methods:
         type: boolean
         description: ''
   - name: getWeight()
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#getWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#getWeight:member(1)
     package: ExcelScript!
     fullName: getWeight()
     summary: >-
-      Represents the weight of the line, in points. Returns `null` when the line is not visible or there are
-      inconsistent line weights.
+      Represents the weight of the line, in points. Returns `null` when the line
+      is not visible or there are inconsistent line weights.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -102,13 +112,14 @@ methods:
         type: number
         description: ''
   - name: setColor(color)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setColor:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setColor:member(1)
     package: ExcelScript!
     fullName: setColor(color)
     summary: >-
-      Represents the line color in HTML color format, in the form \#RRGGBB (e.g., "FFA500") or as a named HTML color
-      (e.g., "orange").
+      Represents the line color in HTML color format, in the form \#RRGGBB
+      (e.g., "FFA500") or as a named HTML color (e.g., "orange").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -121,13 +132,15 @@ methods:
         type: void
         description: ''
   - name: setDashStyle(dashStyle)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setDashStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setDashStyle:member(1)
     package: ExcelScript!
     fullName: setDashStyle(dashStyle)
     summary: >-
-      Represents the line style of the shape. Returns `null` when the line is not visible or there are inconsistent dash
-      styles. See `ExcelScript.ShapeLineDashStyle` for details.
+      Represents the line style of the shape. Returns `null` when the line is
+      not visible or there are inconsistent dash styles. See
+      `ExcelScript.ShapeLineDashStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -135,18 +148,20 @@ methods:
       parameters:
         - id: dashStyle
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeLineDashStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeLineDashStyle:enum" />
       return:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
     summary: >-
-      Represents the line style of the shape. Returns `null` when the line is not visible or there are inconsistent
-      styles. See `ExcelScript.ShapeLineStyle` for details.
+      Represents the line style of the shape. Returns `null` when the line is
+      not visible or there are inconsistent styles. See
+      `ExcelScript.ShapeLineStyle` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -154,18 +169,20 @@ methods:
       parameters:
         - id: style
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeLineStyle:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeLineStyle:enum" />
       return:
         type: void
         description: ''
   - name: setTransparency(transparency)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setTransparency:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setTransparency:member(1)
     package: ExcelScript!
     fullName: setTransparency(transparency)
     summary: >-
-      Represents the degree of transparency of the specified line as a value from 0.0 (opaque) through 1.0 (clear).
-      Returns `null` when the shape has inconsistent transparencies.
+      Represents the degree of transparency of the specified line as a value
+      from 0.0 (opaque) through 1.0 (clear). Returns `null` when the shape has
+      inconsistent transparencies.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -178,13 +195,14 @@ methods:
         type: void
         description: ''
   - name: setVisible(visible)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setVisible:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setVisible:member(1)
     package: ExcelScript!
     fullName: setVisible(visible)
     summary: >-
-      Specifies if the line formatting of a shape element is visible. Returns `null` when the shape has inconsistent
-      visibilities.
+      Specifies if the line formatting of a shape element is visible. Returns
+      `null` when the shape has inconsistent visibilities.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,13 +215,14 @@ methods:
         type: void
         description: ''
   - name: setWeight(weight)
-    uid: 'ExcelScript!ExcelScript.ShapeLineFormat#setWeight:member(1)'
+    uid: ExcelScript!ExcelScript.ShapeLineFormat#setWeight:member(1)
     package: ExcelScript!
     fullName: setWeight(weight)
     summary: >-
-      Represents the weight of the line, in points. Returns `null` when the line is not visible or there are
-      inconsistent line weights.
+      Represents the weight of the line, in points. Returns `null` when the line
+      is not visible or there are inconsistent line weights.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapelinestyle.yml
@@ -1,34 +1,37 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeLineStyle
-uid: 'ExcelScript!ExcelScript.ShapeLineStyle:enum'
+uid: ExcelScript!ExcelScript.ShapeLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeLineStyle
 summary: The style for a line.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: single
-    uid: 'ExcelScript!ExcelScript.ShapeLineStyle.single:member'
+    uid: ExcelScript!ExcelScript.ShapeLineStyle.single:member
     package: ExcelScript!
     summary: Single line.
   - name: thickBetweenThin
-    uid: 'ExcelScript!ExcelScript.ShapeLineStyle.thickBetweenThin:member'
+    uid: ExcelScript!ExcelScript.ShapeLineStyle.thickBetweenThin:member
     package: ExcelScript!
     summary: Thick line with a thin line on each side.
   - name: thickThin
-    uid: 'ExcelScript!ExcelScript.ShapeLineStyle.thickThin:member'
+    uid: ExcelScript!ExcelScript.ShapeLineStyle.thickThin:member
     package: ExcelScript!
     summary: >-
-      Thick line next to thin line. For horizontal lines, the thick line is above the thin line. For vertical lines, the
-      thick line is to the left of the thin line.
+      Thick line next to thin line. For horizontal lines, the thick line is
+      above the thin line. For vertical lines, the thick line is to the left of
+      the thin line.
   - name: thinThick
-    uid: 'ExcelScript!ExcelScript.ShapeLineStyle.thinThick:member'
+    uid: ExcelScript!ExcelScript.ShapeLineStyle.thinThick:member
     package: ExcelScript!
     summary: >-
-      Thick line next to thin line. For horizontal lines, the thick line is below the thin line. For vertical lines, the
-      thick line is to the right of the thin line.
+      Thick line next to thin line. For horizontal lines, the thick line is
+      below the thin line. For vertical lines, the thick line is to the right of
+      the thin line.
   - name: thinThin
-    uid: 'ExcelScript!ExcelScript.ShapeLineStyle.thinThin:member'
+    uid: ExcelScript!ExcelScript.ShapeLineStyle.thinThin:member
     package: ExcelScript!
     summary: Two thin lines.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapescalefrom.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapescalefrom.yml
@@ -1,22 +1,25 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeScaleFrom
-uid: 'ExcelScript!ExcelScript.ShapeScaleFrom:enum'
+uid: ExcelScript!ExcelScript.ShapeScaleFrom:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeScaleFrom
-summary: Specifies which part of the shape retains its position when the shape is scaled.
+summary: >-
+  Specifies which part of the shape retains its position when the shape is
+  scaled.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: scaleFromBottomRight
-    uid: 'ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromBottomRight:member'
+    uid: ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromBottomRight:member
     package: ExcelScript!
     summary: ''
   - name: scaleFromMiddle
-    uid: 'ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromMiddle:member'
+    uid: ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromMiddle:member
     package: ExcelScript!
     summary: ''
   - name: scaleFromTopLeft
-    uid: 'ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromTopLeft:member'
+    uid: ExcelScript!ExcelScript.ShapeScaleFrom.scaleFromTopLeft:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapescaletype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapescaletype.yml
@@ -1,18 +1,21 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeScaleType
-uid: 'ExcelScript!ExcelScript.ShapeScaleType:enum'
+uid: ExcelScript!ExcelScript.ShapeScaleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeScaleType
-summary: Specifies whether the shape is scaled relative to its original or current size.
+summary: >-
+  Specifies whether the shape is scaled relative to its original or current
+  size.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: currentSize
-    uid: 'ExcelScript!ExcelScript.ShapeScaleType.currentSize:member'
+    uid: ExcelScript!ExcelScript.ShapeScaleType.currentSize:member
     package: ExcelScript!
     summary: ''
   - name: originalSize
-    uid: 'ExcelScript!ExcelScript.ShapeScaleType.originalSize:member'
+    uid: ExcelScript!ExcelScript.ShapeScaleType.originalSize:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetexthorizontalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetexthorizontalalignment.yml
@@ -1,38 +1,40 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextHorizontalAlignment
-uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum'
+uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextHorizontalAlignment
 summary: Specifies the horizontal alignment for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: center
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.center:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: justify
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.justify:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.justify:member
     package: ExcelScript!
     summary: ''
   - name: justifyLow
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.justifyLow:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.justifyLow:member
     package: ExcelScript!
     summary: ''
   - name: left
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.left:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.left:member
     package: ExcelScript!
     summary: ''
   - name: right
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.right:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.right:member
     package: ExcelScript!
     summary: ''
   - name: thaiDistributed
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.thaiDistributed:member'
+    uid: >-
+      ExcelScript!ExcelScript.ShapeTextHorizontalAlignment.thaiDistributed:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetexthorizontaloverflow.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetexthorizontaloverflow.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextHorizontalOverflow
-uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum'
+uid: ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextHorizontalOverflow
 summary: Specifies the horizontal overflow for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: clip
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalOverflow.clip:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalOverflow.clip:member
     package: ExcelScript!
     summary: ''
   - name: overflow
-    uid: 'ExcelScript!ExcelScript.ShapeTextHorizontalOverflow.overflow:member'
+    uid: ExcelScript!ExcelScript.ShapeTextHorizontalOverflow.overflow:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextorientation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextorientation.yml
@@ -1,38 +1,39 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextOrientation
-uid: 'ExcelScript!ExcelScript.ShapeTextOrientation:enum'
+uid: ExcelScript!ExcelScript.ShapeTextOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextOrientation
 summary: Specifies the orientation for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: eastAsianVertical
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.eastAsianVertical:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.eastAsianVertical:member
     package: ExcelScript!
     summary: ''
   - name: horizontal
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.horizontal:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.horizontal:member
     package: ExcelScript!
     summary: ''
   - name: mongolianVertical
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.mongolianVertical:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.mongolianVertical:member
     package: ExcelScript!
     summary: ''
   - name: vertical
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.vertical:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.vertical:member
     package: ExcelScript!
     summary: ''
   - name: vertical270
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.vertical270:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.vertical270:member
     package: ExcelScript!
     summary: ''
   - name: wordArtVertical
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.wordArtVertical:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.wordArtVertical:member
     package: ExcelScript!
     summary: ''
   - name: wordArtVerticalRTL
-    uid: 'ExcelScript!ExcelScript.ShapeTextOrientation.wordArtVerticalRTL:member'
+    uid: ExcelScript!ExcelScript.ShapeTextOrientation.wordArtVerticalRTL:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextreadingorder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextreadingorder.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextReadingOrder
-uid: 'ExcelScript!ExcelScript.ShapeTextReadingOrder:enum'
+uid: ExcelScript!ExcelScript.ShapeTextReadingOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextReadingOrder
 summary: Specifies the reading order for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: leftToRight
-    uid: 'ExcelScript!ExcelScript.ShapeTextReadingOrder.leftToRight:member'
+    uid: ExcelScript!ExcelScript.ShapeTextReadingOrder.leftToRight:member
     package: ExcelScript!
     summary: ''
   - name: rightToLeft
-    uid: 'ExcelScript!ExcelScript.ShapeTextReadingOrder.rightToLeft:member'
+    uid: ExcelScript!ExcelScript.ShapeTextReadingOrder.rightToLeft:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextverticalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextverticalalignment.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextVerticalAlignment
-uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum'
+uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextVerticalAlignment
 summary: Specifies the vertical alignment for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment.bottom:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment.bottom:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: justified
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment.justified:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment.justified:member
     package: ExcelScript!
     summary: ''
   - name: middle
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment.middle:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment.middle:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalAlignment.top:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextverticaloverflow.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetextverticaloverflow.yml
@@ -1,26 +1,27 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeTextVerticalOverflow
-uid: 'ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum'
+uid: ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextVerticalOverflow
 summary: Specifies the vertical overflow for the text frame in a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: clip
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalOverflow.clip:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalOverflow.clip:member
     package: ExcelScript!
     summary: Hide text that does not fit vertically within the text frame.
   - name: ellipsis
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalOverflow.ellipsis:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalOverflow.ellipsis:member
     package: ExcelScript!
     summary: >-
-      Hide text that does not fit vertically within the text frame, and add an ellipsis (...) at the end of the visible
-      text.
+      Hide text that does not fit vertically within the text frame, and add an
+      ellipsis (...) at the end of the visible text.
   - name: overflow
-    uid: 'ExcelScript!ExcelScript.ShapeTextVerticalOverflow.overflow:member'
+    uid: ExcelScript!ExcelScript.ShapeTextVerticalOverflow.overflow:member
     package: ExcelScript!
     summary: >-
-      Allow text to overflow the text frame vertically (can be from the top, bottom, or both depending on the text
-      alignment).
+      Allow text to overflow the text frame vertically (can be from the top,
+      bottom, or both depending on the text alignment).

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapetype.yml
@@ -1,30 +1,31 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeType
-uid: 'ExcelScript!ExcelScript.ShapeType:enum'
+uid: ExcelScript!ExcelScript.ShapeType:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeType
 summary: Specifies the type of a shape.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: geometricShape
-    uid: 'ExcelScript!ExcelScript.ShapeType.geometricShape:member'
+    uid: ExcelScript!ExcelScript.ShapeType.geometricShape:member
     package: ExcelScript!
     summary: ''
   - name: group
-    uid: 'ExcelScript!ExcelScript.ShapeType.group:member'
+    uid: ExcelScript!ExcelScript.ShapeType.group:member
     package: ExcelScript!
     summary: ''
   - name: image
-    uid: 'ExcelScript!ExcelScript.ShapeType.image:member'
+    uid: ExcelScript!ExcelScript.ShapeType.image:member
     package: ExcelScript!
     summary: ''
   - name: line
-    uid: 'ExcelScript!ExcelScript.ShapeType.line:member'
+    uid: ExcelScript!ExcelScript.ShapeType.line:member
     package: ExcelScript!
     summary: ''
   - name: unsupported
-    uid: 'ExcelScript!ExcelScript.ShapeType.unsupported:member'
+    uid: ExcelScript!ExcelScript.ShapeType.unsupported:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.shapezorder.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.shapezorder.yml
@@ -1,26 +1,29 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShapeZOrder
-uid: 'ExcelScript!ExcelScript.ShapeZOrder:enum'
+uid: ExcelScript!ExcelScript.ShapeZOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeZOrder
-summary: Specifies where in the z-order a shape should be moved relative to other shapes.
+summary: >-
+  Specifies where in the z-order a shape should be moved relative to other
+  shapes.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bringForward
-    uid: 'ExcelScript!ExcelScript.ShapeZOrder.bringForward:member'
+    uid: ExcelScript!ExcelScript.ShapeZOrder.bringForward:member
     package: ExcelScript!
     summary: ''
   - name: bringToFront
-    uid: 'ExcelScript!ExcelScript.ShapeZOrder.bringToFront:member'
+    uid: ExcelScript!ExcelScript.ShapeZOrder.bringToFront:member
     package: ExcelScript!
     summary: ''
   - name: sendBackward
-    uid: 'ExcelScript!ExcelScript.ShapeZOrder.sendBackward:member'
+    uid: ExcelScript!ExcelScript.ShapeZOrder.sendBackward:member
     package: ExcelScript!
     summary: ''
   - name: sendToBack
-    uid: 'ExcelScript!ExcelScript.ShapeZOrder.sendToBack:member'
+    uid: ExcelScript!ExcelScript.ShapeZOrder.sendToBack:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sheetvisibility.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sheetvisibility.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SheetVisibility
-uid: 'ExcelScript!ExcelScript.SheetVisibility:enum'
+uid: ExcelScript!ExcelScript.SheetVisibility:enum
 package: ExcelScript!
 fullName: ExcelScript.SheetVisibility
 summary: ''
@@ -21,18 +21,19 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: hidden
-    uid: 'ExcelScript!ExcelScript.SheetVisibility.hidden:member'
+    uid: ExcelScript!ExcelScript.SheetVisibility.hidden:member
     package: ExcelScript!
     summary: ''
   - name: veryHidden
-    uid: 'ExcelScript!ExcelScript.SheetVisibility.veryHidden:member'
+    uid: ExcelScript!ExcelScript.SheetVisibility.veryHidden:member
     package: ExcelScript!
     summary: ''
   - name: visible
-    uid: 'ExcelScript!ExcelScript.SheetVisibility.visible:member'
+    uid: ExcelScript!ExcelScript.SheetVisibility.visible:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.showascalculation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.showascalculation.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ShowAsCalculation
-uid: 'ExcelScript!ExcelScript.ShowAsCalculation:enum'
+uid: ExcelScript!ExcelScript.ShowAsCalculation:enum
 package: ExcelScript!
 fullName: ExcelScript.ShowAsCalculation
 summary: The ShowAs calculation function for the DataPivotField.
@@ -28,72 +28,74 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: differenceFrom
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.differenceFrom:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.differenceFrom:member
     package: ExcelScript!
     summary: Difference from the specified Base field and Base item.
   - name: index
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.index:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.index:member
     package: ExcelScript!
     summary: >-
-      Calculates the values as follows: ((value in cell) x (Grand Total of Grand Totals)) / ((Grand Row Total) x (Grand
-      Column Total))
+      Calculates the values as follows: ((value in cell) x (Grand Total of Grand
+      Totals)) / ((Grand Row Total) x (Grand Column Total))
   - name: none
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.none:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.none:member
     package: ExcelScript!
     summary: No calculation is applied.
   - name: percentDifferenceFrom
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentDifferenceFrom:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentDifferenceFrom:member
     package: ExcelScript!
     summary: Difference from the specified Base field and Base item.
   - name: percentOf
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOf:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOf:member
     package: ExcelScript!
     summary: Percent of the specified Base field and Base item.
   - name: percentOfColumnTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfColumnTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOfColumnTotal:member
     package: ExcelScript!
     summary: Percent of the column total.
   - name: percentOfGrandTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfGrandTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOfGrandTotal:member
     package: ExcelScript!
     summary: Percent of the grand total.
   - name: percentOfParentColumnTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentColumnTotal:member'
+    uid: >-
+      ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentColumnTotal:member
     package: ExcelScript!
     summary: Percent of the column total for the specified Base field.
   - name: percentOfParentRowTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentRowTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentRowTotal:member
     package: ExcelScript!
     summary: Percent of the row total for the specified Base field.
   - name: percentOfParentTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOfParentTotal:member
     package: ExcelScript!
     summary: Percent of the grand total for the specified Base field.
   - name: percentOfRowTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentOfRowTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentOfRowTotal:member
     package: ExcelScript!
     summary: Percent of the row total.
   - name: percentRunningTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.percentRunningTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.percentRunningTotal:member
     package: ExcelScript!
     summary: Percent running total of the specified Base field.
   - name: rankAscending
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.rankAscending:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.rankAscending:member
     package: ExcelScript!
     summary: Ascending rank of the specified Base field.
   - name: rankDecending
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.rankDecending:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.rankDecending:member
     package: ExcelScript!
     summary: Descending rank of the specified Base field.
   - name: runningTotal
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.runningTotal:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.runningTotal:member
     package: ExcelScript!
     summary: Running total of the specified Base field.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.ShowAsCalculation.unknown:member'
+    uid: ExcelScript!ExcelScript.ShowAsCalculation.unknown:member
     package: ExcelScript!
     summary: Calculation is unknown or unsupported.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.showasrule.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.showasrule.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.ShowAsRule
-uid: 'ExcelScript!ExcelScript.ShowAsRule:interface'
+uid: ExcelScript!ExcelScript.ShowAsRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ShowAsRule
 summary: ''
@@ -39,47 +39,53 @@ remarks: |-
     farmSales.setName("Difference from Lemons of Crates Sold at Farm");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: baseField
-    uid: 'ExcelScript!ExcelScript.ShowAsRule#baseField:member'
+    uid: ExcelScript!ExcelScript.ShowAsRule#baseField:member
     package: ExcelScript!
     fullName: baseField
     summary: >-
-      The PivotField to base the `ShowAs` calculation on, if applicable according to the `ShowAsCalculation` type, else
-      `null`<!-- -->.
+      The PivotField to base the `ShowAs` calculation on, if applicable
+      according to the `ShowAsCalculation` type, else `null`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'baseField?: PivotField;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotField:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotField:interface" />
   - name: baseItem
-    uid: 'ExcelScript!ExcelScript.ShowAsRule#baseItem:member'
+    uid: ExcelScript!ExcelScript.ShowAsRule#baseItem:member
     package: ExcelScript!
     fullName: baseItem
     summary: >-
-      The item to base the `ShowAs` calculation on, if applicable according to the `ShowAsCalculation` type, else
-      `null`<!-- -->.
+      The item to base the `ShowAs` calculation on, if applicable according to
+      the `ShowAsCalculation` type, else `null`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'baseItem?: PivotItem;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotItem:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotItem:interface" />
   - name: calculation
-    uid: 'ExcelScript!ExcelScript.ShowAsRule#calculation:member'
+    uid: ExcelScript!ExcelScript.ShowAsRule#calculation:member
     package: ExcelScript!
     fullName: calculation
-    summary: The `ShowAs` calculation to use for the PivotField. See `ExcelScript.ShowAsCalculation` for details.
+    summary: >-
+      The `ShowAs` calculation to use for the PivotField. See
+      `ExcelScript.ShowAsCalculation` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'calculation: ShowAsCalculation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShowAsCalculation:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShowAsCalculation:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.slicer.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.slicer.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.Slicer
-uid: 'ExcelScript!ExcelScript.Slicer:interface'
+uid: ExcelScript!ExcelScript.Slicer:interface
 package: ExcelScript!
 fullName: ExcelScript.Slicer
 summary: Represents a `Slicer` object in the workbook.
@@ -31,16 +31,18 @@ remarks: |-
     fruitSlicer.setLeft(400);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: clearFilters()
-    uid: 'ExcelScript!ExcelScript.Slicer#clearFilters:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#clearFilters:member(1)
     package: ExcelScript!
     fullName: clearFilters()
     summary: Clears all the filters currently applied on the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +51,12 @@ methods:
         type: void
         description: ''
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Slicer#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +65,12 @@ methods:
         type: void
         description: ''
   - name: getCaption()
-    uid: 'ExcelScript!ExcelScript.Slicer#getCaption:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getCaption:member(1)
     package: ExcelScript!
     fullName: getCaption()
     summary: Represents the caption of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -75,13 +79,15 @@ methods:
         type: string
         description: ''
   - name: getHeight()
-    uid: 'ExcelScript!ExcelScript.Slicer#getHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getHeight:member(1)
     package: ExcelScript!
     fullName: getHeight()
     summary: >-
-      Represents the height, in points, of the slicer. Throws an `InvalidArgument` exception when set with a negative
-      value or zero as an input.
+      Represents the height, in points, of the slicer. Throws an
+      `InvalidArgument` exception when set with a negative value or zero as an
+      input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -90,11 +96,12 @@ methods:
         type: number
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Slicer#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Represents the unique ID of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -103,11 +110,14 @@ methods:
         type: string
         description: ''
   - name: getIsFilterCleared()
-    uid: 'ExcelScript!ExcelScript.Slicer#getIsFilterCleared:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getIsFilterCleared:member(1)
     package: ExcelScript!
     fullName: getIsFilterCleared()
-    summary: Value is `true` if all filters currently applied on the slicer are cleared.
+    summary: >-
+      Value is `true` if all filters currently applied on the slicer are
+      cleared.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,13 +126,15 @@ methods:
         type: boolean
         description: ''
   - name: getLeft()
-    uid: 'ExcelScript!ExcelScript.Slicer#getLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getLeft:member(1)
     package: ExcelScript!
     fullName: getLeft()
     summary: >-
-      Represents the distance, in points, from the left side of the slicer to the left of the worksheet. Throws an
-      `InvalidArgument` error when set with a negative value as an input.
+      Represents the distance, in points, from the left side of the slicer to
+      the left of the worksheet. Throws an `InvalidArgument` error when set with
+      a negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -131,11 +143,12 @@ methods:
         type: number
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Slicer#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Represents the name of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -144,26 +157,28 @@ methods:
         type: string
         description: ''
   - name: getSelectedItems()
-    uid: 'ExcelScript!ExcelScript.Slicer#getSelectedItems:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getSelectedItems:member(1)
     package: ExcelScript!
     fullName: getSelectedItems()
     summary: Returns an array of selected items' keys.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSelectedItems(): string[];'
       return:
-        type: 'string[]'
+        type: string[]
         description: ''
   - name: getSlicerItem(key)
-    uid: 'ExcelScript!ExcelScript.Slicer#getSlicerItem:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getSlicerItem:member(1)
     package: ExcelScript!
     fullName: getSlicerItem(key)
     summary: >-
-      Gets a slicer item using its key or name. If the slicer item doesn't exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a slicer item using its key or name. If the slicer item doesn't
+      exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -173,45 +188,51 @@ methods:
           description: Key or name of the slicer to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerItem:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.SlicerItem:interface" /> |
+          undefined
         description: ''
   - name: getSlicerItems()
-    uid: 'ExcelScript!ExcelScript.Slicer#getSlicerItems:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getSlicerItems:member(1)
     package: ExcelScript!
     fullName: getSlicerItems()
     summary: Represents the collection of slicer items that are part of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSlicerItems(): SlicerItem[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerItem:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerItem:interface" />[]
         description: ''
   - name: getSortBy()
-    uid: 'ExcelScript!ExcelScript.Slicer#getSortBy:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getSortBy:member(1)
     package: ExcelScript!
     fullName: getSortBy()
     summary: >-
-      Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending",
-      "Descending".
+      Represents the sort order of the items in the slicer. Possible values are:
+      "DataSourceOrder", "Ascending", "Descending".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSortBy(): SlicerSortType;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerSortType:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerSortType:enum" />
         description: ''
   - name: getStyle()
-    uid: 'ExcelScript!ExcelScript.Slicer#getStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getStyle:member(1)
     package: ExcelScript!
     fullName: getStyle()
     summary: >-
-      Constant value that represents the slicer style. Possible values are: "SlicerStyleLight1" through
-      "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6".
+      Constant value that represents the slicer style. Possible values are:
+      "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1"
+      through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6".
       A custom user-defined style present in the workbook can also be specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -220,13 +241,15 @@ methods:
         type: string
         description: ''
   - name: getTop()
-    uid: 'ExcelScript!ExcelScript.Slicer#getTop:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getTop:member(1)
     package: ExcelScript!
     fullName: getTop()
     summary: >-
-      Represents the distance, in points, from the top edge of the slicer to the top of the worksheet. Throws an
-      `InvalidArgument` error when set with a negative value as an input.
+      Represents the distance, in points, from the top edge of the slicer to the
+      top of the worksheet. Throws an `InvalidArgument` error when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -235,13 +258,15 @@ methods:
         type: number
         description: ''
   - name: getWidth()
-    uid: 'ExcelScript!ExcelScript.Slicer#getWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getWidth:member(1)
     package: ExcelScript!
     fullName: getWidth()
     summary: >-
-      Represents the width, in points, of the slicer. Throws an `InvalidArgument` error when set with a negative value
-      or zero as an input.
+      Represents the width, in points, of the slicer. Throws an
+      `InvalidArgument` error when set with a negative value or zero as an
+      input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -250,26 +275,28 @@ methods:
         type: number
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.Slicer#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: Represents the worksheet containing the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: selectItems(items)
-    uid: 'ExcelScript!ExcelScript.Slicer#selectItems:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#selectItems:member(1)
     package: ExcelScript!
     fullName: selectItems(items)
     summary: >-
-      Selects slicer items based on their keys. The previous selections are cleared. All items will be selected by
-      default if the array is empty.
+      Selects slicer items based on their keys. The previous selections are
+      cleared. All items will be selected by default if the array is empty.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -277,16 +304,17 @@ methods:
       parameters:
         - id: items
           description: Optional. The specified slicer item names to be selected.
-          type: 'string[]'
+          type: string[]
       return:
         type: void
         description: ''
   - name: setCaption(caption)
-    uid: 'ExcelScript!ExcelScript.Slicer#setCaption:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setCaption:member(1)
     package: ExcelScript!
     fullName: setCaption(caption)
     summary: Represents the caption of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -299,13 +327,15 @@ methods:
         type: void
         description: ''
   - name: setHeight(height)
-    uid: 'ExcelScript!ExcelScript.Slicer#setHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setHeight:member(1)
     package: ExcelScript!
     fullName: setHeight(height)
     summary: >-
-      Represents the height, in points, of the slicer. Throws an `InvalidArgument` exception when set with a negative
-      value or zero as an input.
+      Represents the height, in points, of the slicer. Throws an
+      `InvalidArgument` exception when set with a negative value or zero as an
+      input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -318,13 +348,15 @@ methods:
         type: void
         description: ''
   - name: setLeft(left)
-    uid: 'ExcelScript!ExcelScript.Slicer#setLeft:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setLeft:member(1)
     package: ExcelScript!
     fullName: setLeft(left)
     summary: >-
-      Represents the distance, in points, from the left side of the slicer to the left of the worksheet. Throws an
-      `InvalidArgument` error when set with a negative value as an input.
+      Represents the distance, in points, from the left side of the slicer to
+      the left of the worksheet. Throws an `InvalidArgument` error when set with
+      a negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -337,11 +369,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.Slicer#setName:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Represents the name of the slicer.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -354,13 +387,14 @@ methods:
         type: void
         description: ''
   - name: setSortBy(sortBy)
-    uid: 'ExcelScript!ExcelScript.Slicer#setSortBy:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setSortBy:member(1)
     package: ExcelScript!
     fullName: setSortBy(sortBy)
     summary: >-
-      Represents the sort order of the items in the slicer. Possible values are: "DataSourceOrder", "Ascending",
-      "Descending".
+      Represents the sort order of the items in the slicer. Possible values are:
+      "DataSourceOrder", "Ascending", "Descending".
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -368,19 +402,21 @@ methods:
       parameters:
         - id: sortBy
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.SlicerSortType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SlicerSortType:enum" />
       return:
         type: void
         description: ''
   - name: setStyle(style)
-    uid: 'ExcelScript!ExcelScript.Slicer#setStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setStyle:member(1)
     package: ExcelScript!
     fullName: setStyle(style)
     summary: >-
-      Constant value that represents the slicer style. Possible values are: "SlicerStyleLight1" through
-      "SlicerStyleLight6", "TableStyleOther1" through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6".
+      Constant value that represents the slicer style. Possible values are:
+      "SlicerStyleLight1" through "SlicerStyleLight6", "TableStyleOther1"
+      through "TableStyleOther2", "SlicerStyleDark1" through "SlicerStyleDark6".
       A custom user-defined style present in the workbook can also be specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -393,13 +429,15 @@ methods:
         type: void
         description: ''
   - name: setTop(top)
-    uid: 'ExcelScript!ExcelScript.Slicer#setTop:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setTop:member(1)
     package: ExcelScript!
     fullName: setTop(top)
     summary: >-
-      Represents the distance, in points, from the top edge of the slicer to the top of the worksheet. Throws an
-      `InvalidArgument` error when set with a negative value as an input.
+      Represents the distance, in points, from the top edge of the slicer to the
+      top of the worksheet. Throws an `InvalidArgument` error when set with a
+      negative value as an input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -412,13 +450,15 @@ methods:
         type: void
         description: ''
   - name: setWidth(width)
-    uid: 'ExcelScript!ExcelScript.Slicer#setWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Slicer#setWidth:member(1)
     package: ExcelScript!
     fullName: setWidth(width)
     summary: >-
-      Represents the width, in points, of the slicer. Throws an `InvalidArgument` error when set with a negative value
-      or zero as an input.
+      Represents the width, in points, of the slicer. Throws an
+      `InvalidArgument` error when set with a negative value or zero as an
+      input.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sliceritem.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sliceritem.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.SlicerItem
-uid: 'ExcelScript!ExcelScript.SlicerItem:interface'
+uid: ExcelScript!ExcelScript.SlicerItem:interface
 package: ExcelScript!
 fullName: ExcelScript.SlicerItem
 summary: Represents a slicer item in a slicer.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getHasData()
-    uid: 'ExcelScript!ExcelScript.SlicerItem#getHasData:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerItem#getHasData:member(1)
     package: ExcelScript!
     fullName: getHasData()
     summary: Value is `true` if the slicer item has data.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,14 +25,16 @@ methods:
         type: boolean
         description: ''
   - name: getIsSelected()
-    uid: 'ExcelScript!ExcelScript.SlicerItem#getIsSelected:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerItem#getIsSelected:member(1)
     package: ExcelScript!
     fullName: getIsSelected()
     summary: >-
-      Value is `true` if the slicer item is selected. Setting this value will not clear the selected state of other
-      slicer items. By default, if the slicer item is the only one selected, when it is deselected, all items will be
-      selected.
+      Value is `true` if the slicer item is selected. Setting this value will
+      not clear the selected state of other slicer items. By default, if the
+      slicer item is the only one selected, when it is deselected, all items
+      will be selected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -39,11 +43,12 @@ methods:
         type: boolean
         description: ''
   - name: getKey()
-    uid: 'ExcelScript!ExcelScript.SlicerItem#getKey:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerItem#getKey:member(1)
     package: ExcelScript!
     fullName: getKey()
     summary: Represents the unique value representing the slicer item.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -52,11 +57,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.SlicerItem#getName:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerItem#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Represents the title displayed in the Excel UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -65,14 +71,16 @@ methods:
         type: string
         description: ''
   - name: setIsSelected(isSelected)
-    uid: 'ExcelScript!ExcelScript.SlicerItem#setIsSelected:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerItem#setIsSelected:member(1)
     package: ExcelScript!
     fullName: setIsSelected(isSelected)
     summary: >-
-      Value is `true` if the slicer item is selected. Setting this value will not clear the selected state of other
-      slicer items. By default, if the slicer item is the only one selected, when it is deselected, all items will be
-      selected.
+      Value is `true` if the slicer item is selected. Setting this value will
+      not clear the selected state of other slicer items. By default, if the
+      slicer item is the only one selected, when it is deselected, all items
+      will be selected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.slicersorttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.slicersorttype.yml
@@ -1,22 +1,23 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SlicerSortType
-uid: 'ExcelScript!ExcelScript.SlicerSortType:enum'
+uid: ExcelScript!ExcelScript.SlicerSortType:enum
 package: ExcelScript!
 fullName: ExcelScript.SlicerSortType
 summary: Specifies the slicer sort behavior for `Slicer.sortBy`<!-- -->.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: ascending
-    uid: 'ExcelScript!ExcelScript.SlicerSortType.ascending:member'
+    uid: ExcelScript!ExcelScript.SlicerSortType.ascending:member
     package: ExcelScript!
     summary: Sort slicer items in ascending order by item captions.
   - name: dataSourceOrder
-    uid: 'ExcelScript!ExcelScript.SlicerSortType.dataSourceOrder:member'
+    uid: ExcelScript!ExcelScript.SlicerSortType.dataSourceOrder:member
     package: ExcelScript!
     summary: Sort slicer items in the order provided by the data source.
   - name: descending
-    uid: 'ExcelScript!ExcelScript.SlicerSortType.descending:member'
+    uid: ExcelScript!ExcelScript.SlicerSortType.descending:member
     package: ExcelScript!
     summary: Sort slicer items in descending order by item captions.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.slicerstyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.slicerstyle.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.SlicerStyle
-uid: 'ExcelScript!ExcelScript.SlicerStyle:interface'
+uid: ExcelScript!ExcelScript.SlicerStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.SlicerStyle
-summary: 'Represents a slicer style, which defines style elements by region of the slicer.'
+summary: >-
+  Represents a slicer style, which defines style elements by region of the
+  slicer.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.SlicerStyle#delete:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerStyle#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the slicer style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,28 @@ methods:
         type: void
         description: ''
   - name: duplicate()
-    uid: 'ExcelScript!ExcelScript.SlicerStyle#duplicate:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerStyle#duplicate:member(1)
     package: ExcelScript!
     fullName: duplicate()
-    summary: Creates a duplicate of this slicer style with copies of all the style elements.
+    summary: >-
+      Creates a duplicate of this slicer style with copies of all the style
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'duplicate(): SlicerStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.SlicerStyle#getName:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerStyle#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the slicer style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: string
         description: ''
   - name: getReadOnly()
-    uid: 'ExcelScript!ExcelScript.SlicerStyle#getReadOnly:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerStyle#getReadOnly:member(1)
     package: ExcelScript!
     fullName: getReadOnly()
     summary: Specifies if this `SlicerStyle` object is read-only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,12 @@ methods:
         type: boolean
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.SlicerStyle#setName:member(1)'
+    uid: ExcelScript!ExcelScript.SlicerStyle#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the slicer style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sortby.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sortby.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SortBy
-uid: 'ExcelScript!ExcelScript.SortBy:enum'
+uid: ExcelScript!ExcelScript.SortBy:enum
 package: ExcelScript!
 fullName: ExcelScript.SortBy
 summary: Represents the sort direction.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: ascending
-    uid: 'ExcelScript!ExcelScript.SortBy.ascending:member'
+    uid: ExcelScript!ExcelScript.SortBy.ascending:member
     package: ExcelScript!
     summary: Ascending sort. Smallest to largest or A to Z.
   - name: descending
-    uid: 'ExcelScript!ExcelScript.SortBy.descending:member'
+    uid: ExcelScript!ExcelScript.SortBy.descending:member
     package: ExcelScript!
     summary: Descending sort. Largest to smallest or Z to A.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sortdataoption.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sortdataoption.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SortDataOption
-uid: 'ExcelScript!ExcelScript.SortDataOption:enum'
+uid: ExcelScript!ExcelScript.SortDataOption:enum
 package: ExcelScript!
 fullName: ExcelScript.SortDataOption
 summary: ''
@@ -33,14 +33,15 @@ remarks: |-
     sort.apply([countSortField]);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: normal
-    uid: 'ExcelScript!ExcelScript.SortDataOption.normal:member'
+    uid: ExcelScript!ExcelScript.SortDataOption.normal:member
     package: ExcelScript!
     summary: ''
   - name: textAsNumber
-    uid: 'ExcelScript!ExcelScript.SortDataOption.textAsNumber:member'
+    uid: ExcelScript!ExcelScript.SortDataOption.textAsNumber:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sortfield.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sortfield.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.SortField
-uid: 'ExcelScript!ExcelScript.SortField:interface'
+uid: ExcelScript!ExcelScript.SortField:interface
 package: ExcelScript!
 fullName: ExcelScript.SortField
 summary: Represents a condition in a sorting operation.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: ascending
-    uid: 'ExcelScript!ExcelScript.SortField#ascending:member'
+    uid: ExcelScript!ExcelScript.SortField#ascending:member
     package: ExcelScript!
     fullName: ascending
     summary: Specifies if the sorting is done in an ascending fashion.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -22,11 +24,14 @@ properties:
       return:
         type: boolean
   - name: color
-    uid: 'ExcelScript!ExcelScript.SortField#color:member'
+    uid: ExcelScript!ExcelScript.SortField#color:member
     package: ExcelScript!
     fullName: color
-    summary: Specifies the color that is the target of the condition if the sorting is on font or cell color.
+    summary: >-
+      Specifies the color that is the target of the condition if the sorting is
+      on font or cell color.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,17 +67,18 @@ properties:
           }
           ```
   - name: dataOption
-    uid: 'ExcelScript!ExcelScript.SortField#dataOption:member'
+    uid: ExcelScript!ExcelScript.SortField#dataOption:member
     package: ExcelScript!
     fullName: dataOption
     summary: Represents additional sorting options for this field.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'dataOption?: SortDataOption;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SortDataOption:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SortDataOption:enum" />
         description: |-
 
 
@@ -103,25 +109,29 @@ properties:
           }
           ```
   - name: icon
-    uid: 'ExcelScript!ExcelScript.SortField#icon:member'
+    uid: ExcelScript!ExcelScript.SortField#icon:member
     package: ExcelScript!
     fullName: icon
-    summary: 'Specifies the icon that is the target of the condition, if the sorting is on the cell''s icon.'
+    summary: >-
+      Specifies the icon that is the target of the condition, if the sorting is
+      on the cell's icon.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'icon?: Icon;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Icon:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Icon:interface" />
   - name: key
-    uid: 'ExcelScript!ExcelScript.SortField#key:member'
+    uid: ExcelScript!ExcelScript.SortField#key:member
     package: ExcelScript!
     fullName: key
     summary: >-
-      Specifies the column (or row, depending on the sort orientation) that the condition is on. Represented as an
-      offset from the first column (or row).
+      Specifies the column (or row, depending on the sort orientation) that the
+      condition is on. Represented as an offset from the first column (or row).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -154,23 +164,27 @@ properties:
           }
           ```
   - name: sortOn
-    uid: 'ExcelScript!ExcelScript.SortField#sortOn:member'
+    uid: ExcelScript!ExcelScript.SortField#sortOn:member
     package: ExcelScript!
     fullName: sortOn
     summary: Specifies the type of sorting of this condition.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'sortOn?: SortOn;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SortOn:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SortOn:enum" />
   - name: subField
-    uid: 'ExcelScript!ExcelScript.SortField#subField:member'
+    uid: ExcelScript!ExcelScript.SortField#subField:member
     package: ExcelScript!
     fullName: subField
-    summary: Specifies the subfield that is the target property name of a rich value to sort on.
+    summary: >-
+      Specifies the subfield that is the target property name of a rich value to
+      sort on.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sortmethod.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sortmethod.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SortMethod
-uid: 'ExcelScript!ExcelScript.SortMethod:enum'
+uid: ExcelScript!ExcelScript.SortMethod:enum
 package: ExcelScript!
 fullName: ExcelScript.SortMethod
 summary: Represents the ordering method to be used when sorting Chinese characters.
@@ -35,14 +35,15 @@ remarks: |-
       );
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: pinYin
-    uid: 'ExcelScript!ExcelScript.SortMethod.pinYin:member'
+    uid: ExcelScript!ExcelScript.SortMethod.pinYin:member
     package: ExcelScript!
     summary: ''
   - name: strokeCount
-    uid: 'ExcelScript!ExcelScript.SortMethod.strokeCount:member'
+    uid: ExcelScript!ExcelScript.SortMethod.strokeCount:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sorton.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sorton.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SortOn
-uid: 'ExcelScript!ExcelScript.SortOn:enum'
+uid: ExcelScript!ExcelScript.SortOn:enum
 package: ExcelScript!
 fullName: ExcelScript.SortOn
 summary: Represents the part of the cell used as the sorting criteria.
@@ -32,22 +32,23 @@ remarks: |-
     rangeToSort.getSort().apply([colorSort]);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: cellColor
-    uid: 'ExcelScript!ExcelScript.SortOn.cellColor:member'
+    uid: ExcelScript!ExcelScript.SortOn.cellColor:member
     package: ExcelScript!
     summary: ''
   - name: fontColor
-    uid: 'ExcelScript!ExcelScript.SortOn.fontColor:member'
+    uid: ExcelScript!ExcelScript.SortOn.fontColor:member
     package: ExcelScript!
     summary: ''
   - name: icon
-    uid: 'ExcelScript!ExcelScript.SortOn.icon:member'
+    uid: ExcelScript!ExcelScript.SortOn.icon:member
     package: ExcelScript!
     summary: ''
   - name: value
-    uid: 'ExcelScript!ExcelScript.SortOn.value:member'
+    uid: ExcelScript!ExcelScript.SortOn.value:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.sortorientation.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.sortorientation.yml
@@ -1,18 +1,19 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SortOrientation
-uid: 'ExcelScript!ExcelScript.SortOrientation:enum'
+uid: ExcelScript!ExcelScript.SortOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.SortOrientation
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: columns
-    uid: 'ExcelScript!ExcelScript.SortOrientation.columns:member'
+    uid: ExcelScript!ExcelScript.SortOrientation.columns:member
     package: ExcelScript!
     summary: ''
   - name: rows
-    uid: 'ExcelScript!ExcelScript.SortOrientation.rows:member'
+    uid: ExcelScript!ExcelScript.SortOrientation.rows:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.specialcelltype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.specialcelltype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SpecialCellType
-uid: 'ExcelScript!ExcelScript.SpecialCellType:enum'
+uid: ExcelScript!ExcelScript.SpecialCellType:enum
 package: ExcelScript!
 fullName: ExcelScript.SpecialCellType
 summary: ''
@@ -25,38 +25,41 @@ remarks: |-
     formulaCells.getFormat().getFill().setColor("#ADD8E6");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: blanks
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.blanks:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.blanks:member
     package: ExcelScript!
     summary: Cells with no content.
   - name: conditionalFormats
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.conditionalFormats:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.conditionalFormats:member
     package: ExcelScript!
     summary: All cells with conditional formats.
   - name: constants
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.constants:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.constants:member
     package: ExcelScript!
     summary: Cells containing constants.
   - name: dataValidations
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.dataValidations:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.dataValidations:member
     package: ExcelScript!
     summary: Cells with validation criteria.
   - name: formulas
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.formulas:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.formulas:member
     package: ExcelScript!
     summary: Cells containing formulas.
   - name: sameConditionalFormat
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.sameConditionalFormat:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.sameConditionalFormat:member
     package: ExcelScript!
     summary: Cells with the same conditional format as the first cell in the range.
   - name: sameDataValidation
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.sameDataValidation:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.sameDataValidation:member
     package: ExcelScript!
-    summary: Cells with the same data validation criteria as the first cell in the range.
+    summary: >-
+      Cells with the same data validation criteria as the first cell in the
+      range.
   - name: visible
-    uid: 'ExcelScript!ExcelScript.SpecialCellType.visible:member'
+    uid: ExcelScript!ExcelScript.SpecialCellType.visible:member
     package: ExcelScript!
     summary: Cells that are visible.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.specialcellvaluetype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.specialcellvaluetype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SpecialCellValueType
-uid: 'ExcelScript!ExcelScript.SpecialCellValueType:enum'
+uid: ExcelScript!ExcelScript.SpecialCellValueType:enum
 package: ExcelScript!
 fullName: ExcelScript.SpecialCellValueType
 summary: ''
@@ -27,66 +27,67 @@ remarks: |-
     textCells.getFormat().getFont().setBold(true);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: all
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.all:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.all:member
     package: ExcelScript!
-    summary: 'Cells that have errors, boolean, numeric, or string values.'
+    summary: Cells that have errors, boolean, numeric, or string values.
   - name: errors
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errors:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errors:member
     package: ExcelScript!
     summary: Cells that have errors.
   - name: errorsLogical
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsLogical:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsLogical:member
     package: ExcelScript!
     summary: Cells that have errors or boolean values.
   - name: errorsLogicalNumber
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsLogicalNumber:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsLogicalNumber:member
     package: ExcelScript!
-    summary: 'Cells that have errors, boolean, or numeric values.'
+    summary: Cells that have errors, boolean, or numeric values.
   - name: errorsLogicalText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsLogicalText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsLogicalText:member
     package: ExcelScript!
-    summary: 'Cells that have errors, boolean, or string values.'
+    summary: Cells that have errors, boolean, or string values.
   - name: errorsNumbers
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsNumbers:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsNumbers:member
     package: ExcelScript!
     summary: Cells that have errors or numeric values.
   - name: errorsNumberText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsNumberText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsNumberText:member
     package: ExcelScript!
-    summary: 'Cells that have errors, numeric, or string values.'
+    summary: Cells that have errors, numeric, or string values.
   - name: errorsText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.errorsText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.errorsText:member
     package: ExcelScript!
     summary: Cells that have errors or string values.
   - name: logical
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.logical:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.logical:member
     package: ExcelScript!
     summary: Cells that have a boolean value.
   - name: logicalNumbers
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.logicalNumbers:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.logicalNumbers:member
     package: ExcelScript!
     summary: Cells that have a boolean or numeric value.
   - name: logicalNumbersText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.logicalNumbersText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.logicalNumbersText:member
     package: ExcelScript!
-    summary: 'Cells that have a boolean, numeric, or string value.'
+    summary: Cells that have a boolean, numeric, or string value.
   - name: logicalText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.logicalText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.logicalText:member
     package: ExcelScript!
     summary: Cells that have a boolean or string value.
   - name: numbers
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.numbers:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.numbers:member
     package: ExcelScript!
     summary: Cells that have a numeric value.
   - name: numbersText
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.numbersText:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.numbersText:member
     package: ExcelScript!
     summary: Cells that have a numeric or string value.
   - name: text
-    uid: 'ExcelScript!ExcelScript.SpecialCellValueType.text:member'
+    uid: ExcelScript!ExcelScript.SpecialCellValueType.text:member
     package: ExcelScript!
     summary: Cells that have a string value.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.subtotallocationtype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.subtotallocationtype.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.SubtotalLocationType
-uid: 'ExcelScript!ExcelScript.SubtotalLocationType:enum'
+uid: ExcelScript!ExcelScript.SubtotalLocationType:enum
 package: ExcelScript!
 fullName: ExcelScript.SubtotalLocationType
 summary: ''
@@ -24,18 +24,19 @@ remarks: |-
     layout.setSubtotalLocation(ExcelScript.SubtotalLocationType.atBottom);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: atBottom
-    uid: 'ExcelScript!ExcelScript.SubtotalLocationType.atBottom:member'
+    uid: ExcelScript!ExcelScript.SubtotalLocationType.atBottom:member
     package: ExcelScript!
     summary: Subtotals are at the bottom.
   - name: atTop
-    uid: 'ExcelScript!ExcelScript.SubtotalLocationType.atTop:member'
+    uid: ExcelScript!ExcelScript.SubtotalLocationType.atTop:member
     package: ExcelScript!
     summary: Subtotals are at the top.
   - name: 'off'
-    uid: 'ExcelScript!ExcelScript.SubtotalLocationType.off:member'
+    uid: ExcelScript!ExcelScript.SubtotalLocationType.off:member
     package: ExcelScript!
     summary: Subtotals are off.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.subtotals.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.subtotals.yml
@@ -1,22 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.Subtotals
-uid: 'ExcelScript!ExcelScript.Subtotals:interface'
+uid: ExcelScript!ExcelScript.Subtotals:interface
 package: ExcelScript!
 fullName: ExcelScript.Subtotals
 summary: Subtotals for the Pivot Field.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.Subtotals#automatic:member'
+    uid: ExcelScript!ExcelScript.Subtotals#automatic:member
     package: ExcelScript!
     fullName: automatic
     summary: >-
-      If `Automatic` is set to `true`<!-- -->, then all other values will be ignored when setting the `Subtotals`<!--
-      -->.
+      If `Automatic` is set to `true`<!-- -->, then all other values will be
+      ignored when setting the `Subtotals`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -24,11 +26,12 @@ properties:
       return:
         type: boolean
   - name: average
-    uid: 'ExcelScript!ExcelScript.Subtotals#average:member'
+    uid: ExcelScript!ExcelScript.Subtotals#average:member
     package: ExcelScript!
     fullName: average
     summary: Average
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -36,11 +39,12 @@ properties:
       return:
         type: boolean
   - name: count
-    uid: 'ExcelScript!ExcelScript.Subtotals#count:member'
+    uid: ExcelScript!ExcelScript.Subtotals#count:member
     package: ExcelScript!
     fullName: count
     summary: Count
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -48,11 +52,12 @@ properties:
       return:
         type: boolean
   - name: countNumbers
-    uid: 'ExcelScript!ExcelScript.Subtotals#countNumbers:member'
+    uid: ExcelScript!ExcelScript.Subtotals#countNumbers:member
     package: ExcelScript!
     fullName: countNumbers
     summary: CountNumbers
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -60,11 +65,12 @@ properties:
       return:
         type: boolean
   - name: max
-    uid: 'ExcelScript!ExcelScript.Subtotals#max:member'
+    uid: ExcelScript!ExcelScript.Subtotals#max:member
     package: ExcelScript!
     fullName: max
     summary: Max
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -72,11 +78,12 @@ properties:
       return:
         type: boolean
   - name: min
-    uid: 'ExcelScript!ExcelScript.Subtotals#min:member'
+    uid: ExcelScript!ExcelScript.Subtotals#min:member
     package: ExcelScript!
     fullName: min
     summary: Min
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -84,11 +91,12 @@ properties:
       return:
         type: boolean
   - name: product
-    uid: 'ExcelScript!ExcelScript.Subtotals#product:member'
+    uid: ExcelScript!ExcelScript.Subtotals#product:member
     package: ExcelScript!
     fullName: product
     summary: Product
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -96,11 +104,12 @@ properties:
       return:
         type: boolean
   - name: standardDeviation
-    uid: 'ExcelScript!ExcelScript.Subtotals#standardDeviation:member'
+    uid: ExcelScript!ExcelScript.Subtotals#standardDeviation:member
     package: ExcelScript!
     fullName: standardDeviation
     summary: StandardDeviation
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -108,11 +117,12 @@ properties:
       return:
         type: boolean
   - name: standardDeviationP
-    uid: 'ExcelScript!ExcelScript.Subtotals#standardDeviationP:member'
+    uid: ExcelScript!ExcelScript.Subtotals#standardDeviationP:member
     package: ExcelScript!
     fullName: standardDeviationP
     summary: StandardDeviationP
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -120,11 +130,12 @@ properties:
       return:
         type: boolean
   - name: sum
-    uid: 'ExcelScript!ExcelScript.Subtotals#sum:member'
+    uid: ExcelScript!ExcelScript.Subtotals#sum:member
     package: ExcelScript!
     fullName: sum
     summary: Sum
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -132,11 +143,12 @@ properties:
       return:
         type: boolean
   - name: variance
-    uid: 'ExcelScript!ExcelScript.Subtotals#variance:member'
+    uid: ExcelScript!ExcelScript.Subtotals#variance:member
     package: ExcelScript!
     fullName: variance
     summary: Variance
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -144,11 +156,12 @@ properties:
       return:
         type: boolean
   - name: varianceP
-    uid: 'ExcelScript!ExcelScript.Subtotals#varianceP:member'
+    uid: ExcelScript!ExcelScript.Subtotals#varianceP:member
     package: ExcelScript!
     fullName: varianceP
     summary: VarianceP
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.table.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.table.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.Table
-uid: 'ExcelScript!ExcelScript.Table:interface'
+uid: ExcelScript!ExcelScript.Table:interface
 package: ExcelScript!
 fullName: ExcelScript.Table
 summary: Represents an Excel table.
@@ -28,16 +28,18 @@ remarks: |-
       lastColumn.getTotalRowRange().setFormula(`=SUBTOTAL(109,[${lastColumn.getName()}])`);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'addColumn(index, values, name)'
-    uid: 'ExcelScript!ExcelScript.Table#addColumn:member(1)'
+  - name: addColumn(index, values, name)
+    uid: ExcelScript!ExcelScript.Table#addColumn:member(1)
     package: ExcelScript!
-    fullName: 'addColumn(index, values, name)'
+    fullName: addColumn(index, values, name)
     summary: Adds a new column to the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,17 +52,22 @@ methods:
       parameters:
         - id: index
           description: >-
-            Optional. Specifies the relative position of the new column. If null or -1, the addition happens at the end.
-            Columns with a higher index will be shifted to the side. Zero-indexed.
+            Optional. Specifies the relative position of the new column. If null
+            or -1, the addition happens at the end. Columns with a higher index
+            will be shifted to the side. Zero-indexed.
           type: number
         - id: values
-          description: Optional. A 1-dimensional array of unformatted values of the table column.
-          type: '(boolean | string | number)[]'
+          description: >-
+            Optional. A 1-dimensional array of unformatted values of the table
+            column.
+          type: (boolean | string | number)[]
         - id: name
-          description: 'Optional. Specifies the name of the new column. If null, the default name will be used.'
+          description: >-
+            Optional. Specifies the name of the new column. If null, the default
+            name will be used.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TableColumn:interface" />
         description: |-
 
 
@@ -78,12 +85,13 @@ methods:
             table.addColumn(-1, null, "Total");
           }
           ```
-  - name: 'addRow(index, values)'
-    uid: 'ExcelScript!ExcelScript.Table#addRow:member(1)'
+  - name: addRow(index, values)
+    uid: ExcelScript!ExcelScript.Table#addRow:member(1)
     package: ExcelScript!
-    fullName: 'addRow(index, values)'
+    fullName: addRow(index, values)
     summary: Adds one row to the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -91,12 +99,15 @@ methods:
       parameters:
         - id: index
           description: >-
-            Optional. Specifies the relative position of the new row. If null or -1, the addition happens at the end.
-            Any rows below the inserted row are shifted downwards. Zero-indexed.
+            Optional. Specifies the relative position of the new row. If null or
+            -1, the addition happens at the end. Any rows below the inserted row
+            are shifted downwards. Zero-indexed.
           type: number
         - id: values
-          description: Optional. A 1-dimensional array of unformatted values of the table row.
-          type: '(boolean | string | number)[]'
+          description: >-
+            Optional. A 1-dimensional array of unformatted values of the table
+            row.
+          type: (boolean | string | number)[]
       return:
         type: void
         description: |-
@@ -121,12 +132,13 @@ methods:
               table.addRow(-1, rowData);
           }
           ```
-  - name: 'addRows(index, values)'
-    uid: 'ExcelScript!ExcelScript.Table#addRows:member(1)'
+  - name: addRows(index, values)
+    uid: ExcelScript!ExcelScript.Table#addRows:member(1)
     package: ExcelScript!
-    fullName: 'addRows(index, values)'
+    fullName: addRows(index, values)
     summary: Adds one or more rows to the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -134,12 +146,15 @@ methods:
       parameters:
         - id: index
           description: >-
-            Optional. Specifies the relative position of the new row. If null or -1, the addition happens at the end.
-            Any rows below the inserted row are shifted downwards. Zero-indexed.
+            Optional. Specifies the relative position of the new row. If null or
+            -1, the addition happens at the end. Any rows below the inserted row
+            are shifted downwards. Zero-indexed.
           type: number
         - id: values
-          description: Optional. A 2-dimensional array of unformatted values of the table row.
-          type: '(boolean | string | number)[][]'
+          description: >-
+            Optional. A 2-dimensional array of unformatted values of the table
+            row.
+          type: (boolean | string | number)[][]
       return:
         type: void
         description: |-
@@ -167,11 +182,12 @@ methods:
           }
           ```
   - name: clearFilters()
-    uid: 'ExcelScript!ExcelScript.Table#clearFilters:member(1)'
+    uid: ExcelScript!ExcelScript.Table#clearFilters:member(1)
     package: ExcelScript!
     fullName: clearFilters()
     summary: Clears all the filters currently applied on the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -198,17 +214,18 @@ methods:
           }
           ```
   - name: convertToRange()
-    uid: 'ExcelScript!ExcelScript.Table#convertToRange:member(1)'
+    uid: ExcelScript!ExcelScript.Table#convertToRange:member(1)
     package: ExcelScript!
     fullName: convertToRange()
     summary: Converts the table into a normal range of cells. All data is preserved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'convertToRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -231,11 +248,12 @@ methods:
           }
           ```
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Table#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Table#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -260,12 +278,13 @@ methods:
               table.delete();
           }
           ```
-  - name: 'deleteRowsAt(index, count)'
-    uid: 'ExcelScript!ExcelScript.Table#deleteRowsAt:member(1)'
+  - name: deleteRowsAt(index, count)
+    uid: ExcelScript!ExcelScript.Table#deleteRowsAt:member(1)
     package: ExcelScript!
-    fullName: 'deleteRowsAt(index, count)'
+    fullName: deleteRowsAt(index, count)
     summary: Delete a specified number of rows at a given index.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -273,36 +292,42 @@ methods:
       parameters:
         - id: index
           description: >-
-            The index value of the row to be deleted. Caution: the index of the row may have moved from the time you
-            determined the value to use for removal.
+            The index value of the row to be deleted. Caution: the index of the
+            row may have moved from the time you determined the value to use for
+            removal.
           type: number
         - id: count
           description: >-
-            Number of rows to delete. By default, a single row will be deleted. Note: Deleting more than 1000 rows at
-            the same time could result in a Power Automate timeout.
+            Number of rows to delete. By default, a single row will be deleted.
+            Note: Deleting more than 1000 rows at the same time could result in
+            a Power Automate timeout.
           type: number
       return:
         type: void
         description: ''
   - name: getAutoFilter()
-    uid: 'ExcelScript!ExcelScript.Table#getAutoFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getAutoFilter:member(1)
     package: ExcelScript!
     fullName: getAutoFilter()
     summary: Represents the `AutoFilter` object of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAutoFilter(): AutoFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.AutoFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.AutoFilter:interface" />
         description: ''
   - name: getColumn(key)
-    uid: 'ExcelScript!ExcelScript.Table#getColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getColumn:member(1)
     package: ExcelScript!
     fullName: getColumn(key)
-    summary: 'Gets a column object by name or ID. If the column doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a column object by name or ID. If the column doesn't exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -312,7 +337,9 @@ methods:
           description: Column name or ID.
           type: number | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> |
+          undefined
         description: |-
 
 
@@ -336,11 +363,14 @@ methods:
           }
           ```
   - name: getColumnById(key)
-    uid: 'ExcelScript!ExcelScript.Table#getColumnById:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getColumnById:member(1)
     package: ExcelScript!
     fullName: getColumnById(key)
-    summary: 'Gets a column object by ID. If the column does not exist, will return undefined.'
+    summary: >-
+      Gets a column object by ID. If the column does not exist, will return
+      undefined.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -350,14 +380,19 @@ methods:
           description: Column ID.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> |
+          undefined
         description: ''
   - name: getColumnByName(key)
-    uid: 'ExcelScript!ExcelScript.Table#getColumnByName:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getColumnByName:member(1)
     package: ExcelScript!
     fullName: getColumnByName(key)
-    summary: 'Gets a column object by Name. If the column does not exist, will return undefined.'
+    summary: >-
+      Gets a column object by Name. If the column does not exist, will return
+      undefined.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -367,7 +402,9 @@ methods:
           description: Column Name.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TableColumn:interface" /> |
+          undefined
         description: |-
 
 
@@ -389,17 +426,18 @@ methods:
           }
           ```
   - name: getColumns()
-    uid: 'ExcelScript!ExcelScript.Table#getColumns:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getColumns:member(1)
     package: ExcelScript!
     fullName: getColumns()
     summary: Represents a collection of all the columns in the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getColumns(): TableColumn[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableColumn:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.TableColumn:interface" />[]
         description: |-
 
 
@@ -429,17 +467,18 @@ methods:
           }
           ```
   - name: getHeaderRowRange()
-    uid: 'ExcelScript!ExcelScript.Table#getHeaderRowRange:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getHeaderRowRange:member(1)
     package: ExcelScript!
     fullName: getHeaderRowRange()
     summary: Gets the range object associated with the header row of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHeaderRowRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -462,11 +501,12 @@ methods:
           }
           ```
   - name: getHighlightFirstColumn()
-    uid: 'ExcelScript!ExcelScript.Table#getHighlightFirstColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getHighlightFirstColumn:member(1)
     package: ExcelScript!
     fullName: getHighlightFirstColumn()
     summary: Specifies if the first column contains special formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -475,11 +515,12 @@ methods:
         type: boolean
         description: ''
   - name: getHighlightLastColumn()
-    uid: 'ExcelScript!ExcelScript.Table#getHighlightLastColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getHighlightLastColumn:member(1)
     package: ExcelScript!
     fullName: getHighlightLastColumn()
     summary: Specifies if the last column contains special formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -488,13 +529,15 @@ methods:
         type: boolean
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Table#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: >-
-      Returns a value that uniquely identifies the table in a given workbook. The value of the identifier remains the
-      same even when the table is renamed.
+      Returns a value that uniquely identifies the table in a given workbook.
+      The value of the identifier remains the same even when the table is
+      renamed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -503,11 +546,12 @@ methods:
         type: string
         description: ''
   - name: getLegacyId()
-    uid: 'ExcelScript!ExcelScript.Table#getLegacyId:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getLegacyId:member(1)
     package: ExcelScript!
     fullName: getLegacyId()
     summary: Returns a numeric ID.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -516,11 +560,12 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Table#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Name of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -529,14 +574,17 @@ methods:
         type: string
         description: ''
   - name: getPredefinedTableStyle()
-    uid: 'ExcelScript!ExcelScript.Table#getPredefinedTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getPredefinedTableStyle:member(1)
     package: ExcelScript!
     fullName: getPredefinedTableStyle()
     summary: >-
-      Constant value that represents the table style. Possible values are: "TableStyleLight1" through
-      "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through
-      "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
+      Constant value that represents the table style. Possible values are:
+      "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1"
+      through "TableStyleMedium28", "TableStyleDark1" through
+      "TableStyleDark11". A custom user-defined style present in the workbook
+      can also be specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -545,17 +593,18 @@ methods:
         type: string
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.Table#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: Gets the range object associated with the entire table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -580,24 +629,26 @@ methods:
           }
           ```
   - name: getRangeBetweenHeaderAndTotal()
-    uid: 'ExcelScript!ExcelScript.Table#getRangeBetweenHeaderAndTotal:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getRangeBetweenHeaderAndTotal:member(1)
     package: ExcelScript!
     fullName: getRangeBetweenHeaderAndTotal()
     summary: Gets the range object associated with the data body of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRangeBetweenHeaderAndTotal(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRowCount()
-    uid: 'ExcelScript!ExcelScript.Table#getRowCount:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getRowCount:member(1)
     package: ExcelScript!
     fullName: getRowCount()
     summary: Gets the number of rows in the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -606,13 +657,14 @@ methods:
         type: number
         description: ''
   - name: getShowBandedColumns()
-    uid: 'ExcelScript!ExcelScript.Table#getShowBandedColumns:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getShowBandedColumns:member(1)
     package: ExcelScript!
     fullName: getShowBandedColumns()
     summary: >-
-      Specifies if the columns show banded formatting in which odd columns are highlighted differently from even ones,
-      to make reading the table easier.
+      Specifies if the columns show banded formatting in which odd columns are
+      highlighted differently from even ones, to make reading the table easier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -621,13 +673,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowBandedRows()
-    uid: 'ExcelScript!ExcelScript.Table#getShowBandedRows:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getShowBandedRows:member(1)
     package: ExcelScript!
     fullName: getShowBandedRows()
     summary: >-
-      Specifies if the rows show banded formatting in which odd rows are highlighted differently from even ones, to make
-      reading the table easier.
+      Specifies if the rows show banded formatting in which odd rows are
+      highlighted differently from even ones, to make reading the table easier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -636,13 +689,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowFilterButton()
-    uid: 'ExcelScript!ExcelScript.Table#getShowFilterButton:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getShowFilterButton:member(1)
     package: ExcelScript!
     fullName: getShowFilterButton()
     summary: >-
-      Specifies if the filter buttons are visible at the top of each column header. Setting this is only allowed if the
-      table contains a header row.
+      Specifies if the filter buttons are visible at the top of each column
+      header. Setting this is only allowed if the table contains a header row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -651,11 +705,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowHeaders()
-    uid: 'ExcelScript!ExcelScript.Table#getShowHeaders:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getShowHeaders:member(1)
     package: ExcelScript!
     fullName: getShowHeaders()
-    summary: Specifies if the header row is visible. This value can be set to show or remove the header row.
+    summary: >-
+      Specifies if the header row is visible. This value can be set to show or
+      remove the header row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -664,11 +721,14 @@ methods:
         type: boolean
         description: ''
   - name: getShowTotals()
-    uid: 'ExcelScript!ExcelScript.Table#getShowTotals:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getShowTotals:member(1)
     package: ExcelScript!
     fullName: getShowTotals()
-    summary: Specifies if the total row is visible. This value can be set to show or remove the total row.
+    summary: >-
+      Specifies if the total row is visible. This value can be set to show or
+      remove the total row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -677,50 +737,54 @@ methods:
         type: boolean
         description: ''
   - name: getSort()
-    uid: 'ExcelScript!ExcelScript.Table#getSort:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getSort:member(1)
     package: ExcelScript!
     fullName: getSort()
     summary: Represents the sorting for the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSort(): TableSort;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableSort:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TableSort:interface" />
         description: ''
   - name: getTotalRowRange()
-    uid: 'ExcelScript!ExcelScript.Table#getTotalRowRange:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getTotalRowRange:member(1)
     package: ExcelScript!
     fullName: getTotalRowRange()
     summary: Gets the range object associated with the totals row of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTotalRowRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getWorksheet()
-    uid: 'ExcelScript!ExcelScript.Table#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Table#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet()
     summary: The worksheet containing the current table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: reapplyFilters()
-    uid: 'ExcelScript!ExcelScript.Table#reapplyFilters:member(1)'
+    uid: ExcelScript!ExcelScript.Table#reapplyFilters:member(1)
     package: ExcelScript!
     fullName: reapplyFilters()
     summary: Reapplies all the filters currently on the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -748,30 +812,35 @@ methods:
           }
           ```
   - name: resize(newRange)
-    uid: 'ExcelScript!ExcelScript.Table#resize:member(1)'
+    uid: ExcelScript!ExcelScript.Table#resize:member(1)
     package: ExcelScript!
     fullName: resize(newRange)
     summary: >-
-      Resize the table to the new range. The new range must overlap with the original table range and the headers (or
-      the top of the table) must be in the same row.
+      Resize the table to the new range. The new range must overlap with the
+      original table range and the headers (or the top of the table) must be in
+      the same row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'resize(newRange: Range | string): void;'
       parameters:
         - id: newRange
-          description: The range object or range address that will be used to determine the new size of the table.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            The range object or range address that will be used to determine the
+            new size of the table.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: ''
   - name: setHighlightFirstColumn(highlightFirstColumn)
-    uid: 'ExcelScript!ExcelScript.Table#setHighlightFirstColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setHighlightFirstColumn:member(1)
     package: ExcelScript!
     fullName: setHighlightFirstColumn(highlightFirstColumn)
     summary: Specifies if the first column contains special formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -784,11 +853,12 @@ methods:
         type: void
         description: ''
   - name: setHighlightLastColumn(highlightLastColumn)
-    uid: 'ExcelScript!ExcelScript.Table#setHighlightLastColumn:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setHighlightLastColumn:member(1)
     package: ExcelScript!
     fullName: setHighlightLastColumn(highlightLastColumn)
     summary: Specifies if the last column contains special formatting.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -801,11 +871,12 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.Table#setName:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Name of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -818,14 +889,17 @@ methods:
         type: void
         description: ''
   - name: setPredefinedTableStyle(predefinedTableStyle)
-    uid: 'ExcelScript!ExcelScript.Table#setPredefinedTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setPredefinedTableStyle:member(1)
     package: ExcelScript!
     fullName: setPredefinedTableStyle(predefinedTableStyle)
     summary: >-
-      Constant value that represents the table style. Possible values are: "TableStyleLight1" through
-      "TableStyleLight21", "TableStyleMedium1" through "TableStyleMedium28", "TableStyleDark1" through
-      "TableStyleDark11". A custom user-defined style present in the workbook can also be specified.
+      Constant value that represents the table style. Possible values are:
+      "TableStyleLight1" through "TableStyleLight21", "TableStyleMedium1"
+      through "TableStyleMedium28", "TableStyleDark1" through
+      "TableStyleDark11". A custom user-defined style present in the workbook
+      can also be specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -838,13 +912,14 @@ methods:
         type: void
         description: ''
   - name: setShowBandedColumns(showBandedColumns)
-    uid: 'ExcelScript!ExcelScript.Table#setShowBandedColumns:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setShowBandedColumns:member(1)
     package: ExcelScript!
     fullName: setShowBandedColumns(showBandedColumns)
     summary: >-
-      Specifies if the columns show banded formatting in which odd columns are highlighted differently from even ones,
-      to make reading the table easier.
+      Specifies if the columns show banded formatting in which odd columns are
+      highlighted differently from even ones, to make reading the table easier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -857,13 +932,14 @@ methods:
         type: void
         description: ''
   - name: setShowBandedRows(showBandedRows)
-    uid: 'ExcelScript!ExcelScript.Table#setShowBandedRows:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setShowBandedRows:member(1)
     package: ExcelScript!
     fullName: setShowBandedRows(showBandedRows)
     summary: >-
-      Specifies if the rows show banded formatting in which odd rows are highlighted differently from even ones, to make
-      reading the table easier.
+      Specifies if the rows show banded formatting in which odd rows are
+      highlighted differently from even ones, to make reading the table easier.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -894,13 +970,14 @@ methods:
           }
           ```
   - name: setShowFilterButton(showFilterButton)
-    uid: 'ExcelScript!ExcelScript.Table#setShowFilterButton:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setShowFilterButton:member(1)
     package: ExcelScript!
     fullName: setShowFilterButton(showFilterButton)
     summary: >-
-      Specifies if the filter buttons are visible at the top of each column header. Setting this is only allowed if the
-      table contains a header row.
+      Specifies if the filter buttons are visible at the top of each column
+      header. Setting this is only allowed if the table contains a header row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -913,11 +990,14 @@ methods:
         type: void
         description: ''
   - name: setShowHeaders(showHeaders)
-    uid: 'ExcelScript!ExcelScript.Table#setShowHeaders:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setShowHeaders:member(1)
     package: ExcelScript!
     fullName: setShowHeaders(showHeaders)
-    summary: Specifies if the header row is visible. This value can be set to show or remove the header row.
+    summary: >-
+      Specifies if the header row is visible. This value can be set to show or
+      remove the header row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -946,11 +1026,14 @@ methods:
           }
           ```
   - name: setShowTotals(showTotals)
-    uid: 'ExcelScript!ExcelScript.Table#setShowTotals:member(1)'
+    uid: ExcelScript!ExcelScript.Table#setShowTotals:member(1)
     package: ExcelScript!
     fullName: setShowTotals(showTotals)
-    summary: Specifies if the total row is visible. This value can be set to show or remove the total row.
+    summary: >-
+      Specifies if the total row is visible. This value can be set to show or
+      remove the total row.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.tablecolumn.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.TableColumn
-uid: 'ExcelScript!ExcelScript.TableColumn:interface'
+uid: ExcelScript!ExcelScript.TableColumn:interface
 package: ExcelScript!
 fullName: ExcelScript.TableColumn
 summary: Represents a column in a table.
@@ -24,16 +24,18 @@ remarks: |-
     // Do something with the range...
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.TableColumn#delete:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the column from the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,17 +63,18 @@ methods:
           }
           ```
   - name: getFilter()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getFilter:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getFilter:member(1)
     package: ExcelScript!
     fullName: getFilter()
     summary: Retrieves the filter applied to the column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFilter(): Filter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Filter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Filter:interface" />
         description: |-
 
 
@@ -94,24 +97,26 @@ methods:
           }
           ```
   - name: getHeaderRowRange()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getHeaderRowRange:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getHeaderRowRange:member(1)
     package: ExcelScript!
     fullName: getHeaderRowRange()
     summary: Gets the range object associated with the header row of the column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHeaderRowRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getId:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: Returns a unique key that identifies the column within the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -120,11 +125,14 @@ methods:
         type: number
         description: ''
   - name: getIndex()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getIndex:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getIndex:member(1)
     package: ExcelScript!
     fullName: getIndex()
-    summary: Returns the index number of the column within the columns collection of the table. Zero-indexed.
+    summary: >-
+      Returns the index number of the column within the columns collection of
+      the table. Zero-indexed.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -133,11 +141,12 @@ methods:
         type: number
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getName:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the table column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -146,30 +155,33 @@ methods:
         type: string
         description: ''
   - name: getRange()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getRange:member(1)
     package: ExcelScript!
     fullName: getRange()
     summary: Gets the range object associated with the entire column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRangeBetweenHeaderAndTotal()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getRangeBetweenHeaderAndTotal:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.TableColumn#getRangeBetweenHeaderAndTotal:member(1)
     package: ExcelScript!
     fullName: getRangeBetweenHeaderAndTotal()
     summary: Gets the range object associated with the data body of the column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRangeBetweenHeaderAndTotal(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -199,17 +211,18 @@ methods:
           }
           ```
   - name: getTotalRowRange()
-    uid: 'ExcelScript!ExcelScript.TableColumn#getTotalRowRange:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#getTotalRowRange:member(1)
     package: ExcelScript!
     fullName: getTotalRowRange()
     summary: Gets the range object associated with the totals row of the column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTotalRowRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -232,11 +245,12 @@ methods:
           }
           ```
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.TableColumn#setName:member(1)'
+    uid: ExcelScript!ExcelScript.TableColumn#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the table column.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.tablesort.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.tablesort.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.TableSort
-uid: 'ExcelScript!ExcelScript.TableSort:interface'
+uid: ExcelScript!ExcelScript.TableSort:interface
 package: ExcelScript!
 fullName: ExcelScript.TableSort
 summary: Manages sorting operations on `Table` objects.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'apply(fields, matchCase, method)'
-    uid: 'ExcelScript!ExcelScript.TableSort#apply:member(1)'
+  - name: apply(fields, matchCase, method)
+    uid: ExcelScript!ExcelScript.TableSort#apply:member(1)
     package: ExcelScript!
-    fullName: 'apply(fields, matchCase, method)'
+    fullName: apply(fields, matchCase, method)
     summary: Perform a sort operation.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -27,13 +29,13 @@ methods:
       parameters:
         - id: fields
           description: The list of conditions to sort on.
-          type: '<xref uid="ExcelScript!ExcelScript.SortField:interface" />[]'
+          type: <xref uid="ExcelScript!ExcelScript.SortField:interface" />[]
         - id: matchCase
           description: Optional. Whether to have the casing impact string ordering.
           type: boolean
         - id: method
           description: Optional. The ordering method used for Chinese characters.
-          type: '<xref uid="ExcelScript!ExcelScript.SortMethod:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SortMethod:enum" />
       return:
         type: void
         description: |-
@@ -58,13 +60,14 @@ methods:
           }
           ```
   - name: clear()
-    uid: 'ExcelScript!ExcelScript.TableSort#clear:member(1)'
+    uid: ExcelScript!ExcelScript.TableSort#clear:member(1)
     package: ExcelScript!
     fullName: clear()
     summary: >-
-      Clears the sorting that is currently on the table. While this doesn't modify the table's ordering, it clears the
-      state of the header buttons.
+      Clears the sorting that is currently on the table. While this doesn't
+      modify the table's ordering, it clears the state of the header buttons.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -73,24 +76,26 @@ methods:
         type: void
         description: ''
   - name: getFields()
-    uid: 'ExcelScript!ExcelScript.TableSort#getFields:member(1)'
+    uid: ExcelScript!ExcelScript.TableSort#getFields:member(1)
     package: ExcelScript!
     fullName: getFields()
     summary: Specifies the current conditions used to last sort the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFields(): SortField[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SortField:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.SortField:interface" />[]
         description: ''
   - name: getMatchCase()
-    uid: 'ExcelScript!ExcelScript.TableSort#getMatchCase:member(1)'
+    uid: ExcelScript!ExcelScript.TableSort#getMatchCase:member(1)
     package: ExcelScript!
     fullName: getMatchCase()
     summary: Specifies if the casing impacts the last sort of the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -99,24 +104,28 @@ methods:
         type: boolean
         description: ''
   - name: getMethod()
-    uid: 'ExcelScript!ExcelScript.TableSort#getMethod:member(1)'
+    uid: ExcelScript!ExcelScript.TableSort#getMethod:member(1)
     package: ExcelScript!
     fullName: getMethod()
-    summary: Represents the Chinese character ordering method last used to sort the table.
+    summary: >-
+      Represents the Chinese character ordering method last used to sort the
+      table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getMethod(): SortMethod;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SortMethod:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SortMethod:enum" />
         description: ''
   - name: reapply()
-    uid: 'ExcelScript!ExcelScript.TableSort#reapply:member(1)'
+    uid: ExcelScript!ExcelScript.TableSort#reapply:member(1)
     package: ExcelScript!
     fullName: reapply()
     summary: Reapplies the current sorting parameters to the table.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.tablestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.tablestyle.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.TableStyle
-uid: 'ExcelScript!ExcelScript.TableStyle:interface'
+uid: ExcelScript!ExcelScript.TableStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.TableStyle
-summary: 'Represents a table style, which defines the style elements by region of the table.'
+summary: >-
+  Represents a table style, which defines the style elements by region of the
+  table.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.TableStyle#delete:member(1)'
+    uid: ExcelScript!ExcelScript.TableStyle#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the table style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,28 @@ methods:
         type: void
         description: ''
   - name: duplicate()
-    uid: 'ExcelScript!ExcelScript.TableStyle#duplicate:member(1)'
+    uid: ExcelScript!ExcelScript.TableStyle#duplicate:member(1)
     package: ExcelScript!
     fullName: duplicate()
-    summary: Creates a duplicate of this table style with copies of all the style elements.
+    summary: >-
+      Creates a duplicate of this table style with copies of all the style
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'duplicate(): TableStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TableStyle:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.TableStyle#getName:member(1)'
+    uid: ExcelScript!ExcelScript.TableStyle#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the table style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: string
         description: ''
   - name: getReadOnly()
-    uid: 'ExcelScript!ExcelScript.TableStyle#getReadOnly:member(1)'
+    uid: ExcelScript!ExcelScript.TableStyle#getReadOnly:member(1)
     package: ExcelScript!
     fullName: getReadOnly()
     summary: Specifies if this `TableStyle` object is read-only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,12 @@ methods:
         type: boolean
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.TableStyle#setName:member(1)'
+    uid: ExcelScript!ExcelScript.TableStyle#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the table style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.textconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.TextConditionalFormat
-uid: 'ExcelScript!ExcelScript.TextConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.TextConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.TextConditionalFormat
 summary: Represents a specific text conditional format.
@@ -34,42 +34,53 @@ remarks: |-
     textConditionFormat.setRule(textRule);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.TextConditionalFormat#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.TextConditionalFormat#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the conditional format''s font, fill, borders, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the conditional format's font,
+      fill, borders, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ConditionalRangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface"
+          />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.TextConditionalFormat#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.TextConditionalFormat#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
     summary: The rule of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): ConditionalTextComparisonRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface"
+          />
         description: ''
   - name: setRule(rule)
-    uid: 'ExcelScript!ExcelScript.TextConditionalFormat#setRule:member(1)'
+    uid: ExcelScript!ExcelScript.TextConditionalFormat#setRule:member(1)
     package: ExcelScript!
     fullName: setRule(rule)
     summary: The rule of the conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,7 +88,10 @@ methods:
       parameters:
         - id: rule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.textframe.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.textframe.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.TextFrame
-uid: 'ExcelScript!ExcelScript.TextFrame:interface'
+uid: ExcelScript!ExcelScript.TextFrame:interface
 package: ExcelScript!
 fullName: ExcelScript.TextFrame
 summary: Represents the text frame of a shape object.
@@ -27,16 +27,18 @@ remarks: |-
     textFrame.setAutoSizeSetting(ExcelScript.ShapeAutoSize.autoSizeShapeToFitText);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: deleteText()
-    uid: 'ExcelScript!ExcelScript.TextFrame#deleteText:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#deleteText:member(1)
     package: ExcelScript!
     fullName: deleteText()
     summary: Deletes all the text in the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -45,26 +47,29 @@ methods:
         type: void
         description: ''
   - name: getAutoSizeSetting()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getAutoSizeSetting:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getAutoSizeSetting:member(1)
     package: ExcelScript!
     fullName: getAutoSizeSetting()
     summary: >-
-      The automatic sizing settings for the text frame. A text frame can be set to automatically fit the text to the
-      text frame, to automatically fit the text frame to the text, or not perform any automatic sizing.
+      The automatic sizing settings for the text frame. A text frame can be set
+      to automatically fit the text to the text frame, to automatically fit the
+      text frame to the text, or not perform any automatic sizing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAutoSizeSetting(): ShapeAutoSize;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeAutoSize:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeAutoSize:enum" />
         description: ''
   - name: getBottomMargin()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getBottomMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getBottomMargin:member(1)
     package: ExcelScript!
     fullName: getBottomMargin()
-    summary: 'Represents the bottom margin, in points, of the text frame.'
+    summary: Represents the bottom margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -73,11 +78,12 @@ methods:
         type: number
         description: ''
   - name: getHasText()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getHasText:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getHasText:member(1)
     package: ExcelScript!
     fullName: getHasText()
     summary: Specifies if the text frame contains text.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -86,39 +92,48 @@ methods:
         type: boolean
         description: ''
   - name: getHorizontalAlignment()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: getHorizontalAlignment()
-    summary: Represents the horizontal alignment of the text frame. See `ExcelScript.ShapeTextHorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment of the text frame. See
+      `ExcelScript.ShapeTextHorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalAlignment(): ShapeTextHorizontalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum"
+          />
         description: ''
   - name: getHorizontalOverflow()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getHorizontalOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getHorizontalOverflow:member(1)
     package: ExcelScript!
     fullName: getHorizontalOverflow()
     summary: >-
-      Represents the horizontal overflow behavior of the text frame. See `ExcelScript.ShapeTextHorizontalOverflow` for
-      details.
+      Represents the horizontal overflow behavior of the text frame. See
+      `ExcelScript.ShapeTextHorizontalOverflow` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalOverflow(): ShapeTextHorizontalOverflow;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum"
+          />
         description: ''
   - name: getLeftMargin()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getLeftMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getLeftMargin:member(1)
     package: ExcelScript!
     fullName: getLeftMargin()
-    summary: 'Represents the left margin, in points, of the text frame.'
+    summary: Represents the left margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,41 +142,44 @@ methods:
         type: number
         description: ''
   - name: getOrientation()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getOrientation:member(1)
     package: ExcelScript!
     fullName: getOrientation()
     summary: >-
-      Represents the angle to which the text is oriented for the text frame. See `ExcelScript.ShapeTextOrientation` for
-      details.
+      Represents the angle to which the text is oriented for the text frame. See
+      `ExcelScript.ShapeTextOrientation` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getOrientation(): ShapeTextOrientation;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextOrientation:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeTextOrientation:enum" />
         description: ''
   - name: getReadingOrder()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getReadingOrder:member(1)
     package: ExcelScript!
     fullName: getReadingOrder()
     summary: >-
-      Represents the reading order of the text frame, either left-to-right or right-to-left. See
-      `ExcelScript.ShapeTextReadingOrder` for details.
+      Represents the reading order of the text frame, either left-to-right or
+      right-to-left. See `ExcelScript.ShapeTextReadingOrder` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getReadingOrder(): ShapeTextReadingOrder;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextReadingOrder:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeTextReadingOrder:enum" />
         description: ''
   - name: getRightMargin()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getRightMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getRightMargin:member(1)
     package: ExcelScript!
     fullName: getRightMargin()
-    summary: 'Represents the right margin, in points, of the text frame.'
+    summary: Represents the right margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -170,26 +188,29 @@ methods:
         type: number
         description: ''
   - name: getTextRange()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getTextRange:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getTextRange:member(1)
     package: ExcelScript!
     fullName: getTextRange()
     summary: >-
-      Represents the text that is attached to a shape in the text frame, and properties and methods for manipulating the
-      text. See `ExcelScript.TextRange` for details.
+      Represents the text that is attached to a shape in the text frame, and
+      properties and methods for manipulating the text. See
+      `ExcelScript.TextRange` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTextRange(): TextRange;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TextRange:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TextRange:interface" />
         description: ''
   - name: getTopMargin()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getTopMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getTopMargin:member(1)
     package: ExcelScript!
     fullName: getTopMargin()
-    summary: 'Represents the top margin, in points, of the text frame.'
+    summary: Represents the top margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -198,41 +219,47 @@ methods:
         type: number
         description: ''
   - name: getVerticalAlignment()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: getVerticalAlignment()
-    summary: Represents the vertical alignment of the text frame. See `ExcelScript.ShapeTextVerticalAlignment` for details.
+    summary: >-
+      Represents the vertical alignment of the text frame. See
+      `ExcelScript.ShapeTextVerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalAlignment(): ShapeTextVerticalAlignment;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum" />
         description: ''
   - name: getVerticalOverflow()
-    uid: 'ExcelScript!ExcelScript.TextFrame#getVerticalOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#getVerticalOverflow:member(1)
     package: ExcelScript!
     fullName: getVerticalOverflow()
     summary: >-
-      Represents the vertical overflow behavior of the text frame. See `ExcelScript.ShapeTextVerticalOverflow` for
-      details.
+      Represents the vertical overflow behavior of the text frame. See
+      `ExcelScript.ShapeTextVerticalOverflow` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalOverflow(): ShapeTextVerticalOverflow;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum" />
         description: ''
   - name: setAutoSizeSetting(autoSizeSetting)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setAutoSizeSetting:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setAutoSizeSetting:member(1)
     package: ExcelScript!
     fullName: setAutoSizeSetting(autoSizeSetting)
     summary: >-
-      The automatic sizing settings for the text frame. A text frame can be set to automatically fit the text to the
-      text frame, to automatically fit the text frame to the text, or not perform any automatic sizing.
+      The automatic sizing settings for the text frame. A text frame can be set
+      to automatically fit the text to the text frame, to automatically fit the
+      text frame to the text, or not perform any automatic sizing.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -240,16 +267,17 @@ methods:
       parameters:
         - id: autoSizeSetting
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeAutoSize:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeAutoSize:enum" />
       return:
         type: void
         description: ''
   - name: setBottomMargin(bottomMargin)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setBottomMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setBottomMargin:member(1)
     package: ExcelScript!
     fullName: setBottomMargin(bottomMargin)
-    summary: 'Represents the bottom margin, in points, of the text frame.'
+    summary: Represents the bottom margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -262,11 +290,14 @@ methods:
         type: void
         description: ''
   - name: setHorizontalAlignment(horizontalAlignment)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setHorizontalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setHorizontalAlignment:member(1)
     package: ExcelScript!
     fullName: setHorizontalAlignment(horizontalAlignment)
-    summary: Represents the horizontal alignment of the text frame. See `ExcelScript.ShapeTextHorizontalAlignment` for details.
+    summary: >-
+      Represents the horizontal alignment of the text frame. See
+      `ExcelScript.ShapeTextHorizontalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -277,18 +308,21 @@ methods:
       parameters:
         - id: horizontalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum" />
       return:
         type: void
         description: ''
   - name: setHorizontalOverflow(horizontalOverflow)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setHorizontalOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setHorizontalOverflow:member(1)
     package: ExcelScript!
     fullName: setHorizontalOverflow(horizontalOverflow)
     summary: >-
-      Represents the horizontal overflow behavior of the text frame. See `ExcelScript.ShapeTextHorizontalOverflow` for
-      details.
+      Represents the horizontal overflow behavior of the text frame. See
+      `ExcelScript.ShapeTextHorizontalOverflow` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -299,16 +333,19 @@ methods:
       parameters:
         - id: horizontalOverflow
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum"
+            />
       return:
         type: void
         description: ''
   - name: setLeftMargin(leftMargin)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setLeftMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setLeftMargin:member(1)
     package: ExcelScript!
     fullName: setLeftMargin(leftMargin)
-    summary: 'Represents the left margin, in points, of the text frame.'
+    summary: Represents the left margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -321,13 +358,14 @@ methods:
         type: void
         description: ''
   - name: setOrientation(orientation)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setOrientation:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setOrientation:member(1)
     package: ExcelScript!
     fullName: setOrientation(orientation)
     summary: >-
-      Represents the angle to which the text is oriented for the text frame. See `ExcelScript.ShapeTextOrientation` for
-      details.
+      Represents the angle to which the text is oriented for the text frame. See
+      `ExcelScript.ShapeTextOrientation` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -335,18 +373,19 @@ methods:
       parameters:
         - id: orientation
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextOrientation:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeTextOrientation:enum" />
       return:
         type: void
         description: ''
   - name: setReadingOrder(readingOrder)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setReadingOrder:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setReadingOrder:member(1)
     package: ExcelScript!
     fullName: setReadingOrder(readingOrder)
     summary: >-
-      Represents the reading order of the text frame, either left-to-right or right-to-left. See
-      `ExcelScript.ShapeTextReadingOrder` for details.
+      Represents the reading order of the text frame, either left-to-right or
+      right-to-left. See `ExcelScript.ShapeTextReadingOrder` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -354,16 +393,17 @@ methods:
       parameters:
         - id: readingOrder
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextReadingOrder:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.ShapeTextReadingOrder:enum" />
       return:
         type: void
         description: ''
   - name: setRightMargin(rightMargin)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setRightMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setRightMargin:member(1)
     package: ExcelScript!
     fullName: setRightMargin(rightMargin)
-    summary: 'Represents the right margin, in points, of the text frame.'
+    summary: Represents the right margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -376,11 +416,12 @@ methods:
         type: void
         description: ''
   - name: setTopMargin(topMargin)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setTopMargin:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setTopMargin:member(1)
     package: ExcelScript!
     fullName: setTopMargin(topMargin)
-    summary: 'Represents the top margin, in points, of the text frame.'
+    summary: Represents the top margin, in points, of the text frame.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -393,11 +434,14 @@ methods:
         type: void
         description: ''
   - name: setVerticalAlignment(verticalAlignment)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setVerticalAlignment:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setVerticalAlignment:member(1)
     package: ExcelScript!
     fullName: setVerticalAlignment(verticalAlignment)
-    summary: Represents the vertical alignment of the text frame. See `ExcelScript.ShapeTextVerticalAlignment` for details.
+    summary: >-
+      Represents the vertical alignment of the text frame. See
+      `ExcelScript.ShapeTextVerticalAlignment` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -408,18 +452,21 @@ methods:
       parameters:
         - id: verticalAlignment
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum"
+            />
       return:
         type: void
         description: ''
   - name: setVerticalOverflow(verticalOverflow)
-    uid: 'ExcelScript!ExcelScript.TextFrame#setVerticalOverflow:member(1)'
+    uid: ExcelScript!ExcelScript.TextFrame#setVerticalOverflow:member(1)
     package: ExcelScript!
     fullName: setVerticalOverflow(verticalOverflow)
     summary: >-
-      Represents the vertical overflow behavior of the text frame. See `ExcelScript.ShapeTextVerticalOverflow` for
-      details.
+      Represents the vertical overflow behavior of the text frame. See
+      `ExcelScript.ShapeTextVerticalOverflow` for details.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -427,7 +474,9 @@ methods:
       parameters:
         - id: verticalOverflow
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum" />'
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.textrange.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.textrange.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.TextRange
-uid: 'ExcelScript!ExcelScript.TextRange:interface'
+uid: ExcelScript!ExcelScript.TextRange:interface
 package: ExcelScript!
 fullName: ExcelScript.TextRange
-summary: 'Contains the text that is attached to a shape, in addition to properties and methods for manipulating the text.'
+summary: >-
+  Contains the text that is attached to a shape, in addition to properties and
+  methods for manipulating the text.
 remarks: |-
 
 
@@ -23,22 +25,26 @@ remarks: |-
     hexText.setText("Forest");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFont()
-    uid: 'ExcelScript!ExcelScript.TextRange#getFont:member(1)'
+    uid: ExcelScript!ExcelScript.TextRange#getFont:member(1)
     package: ExcelScript!
     fullName: getFont()
-    summary: Returns a `ShapeFont` object that represents the font attributes for the text range.
+    summary: >-
+      Returns a `ShapeFont` object that represents the font attributes for the
+      text range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFont(): ShapeFont;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ShapeFont:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.ShapeFont:interface" />
         description: |-
 
 
@@ -61,34 +67,39 @@ methods:
             shapeTextFont.setBold(true);
           }
           ```
-  - name: 'getSubstring(start, length)'
-    uid: 'ExcelScript!ExcelScript.TextRange#getSubstring:member(1)'
+  - name: getSubstring(start, length)
+    uid: ExcelScript!ExcelScript.TextRange#getSubstring:member(1)
     package: ExcelScript!
-    fullName: 'getSubstring(start, length)'
+    fullName: getSubstring(start, length)
     summary: Returns a TextRange object for the substring in the given range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSubstring(start: number, length?: number): TextRange;'
       parameters:
         - id: start
-          description: The zero-based index of the first character to get from the text range.
+          description: >-
+            The zero-based index of the first character to get from the text
+            range.
           type: number
         - id: length
           description: >-
-            Optional. The number of characters to be returned in the new text range. If length is omitted, all the
-            characters from start to the end of the text range's last paragraph will be returned.
+            Optional. The number of characters to be returned in the new text
+            range. If length is omitted, all the characters from start to the
+            end of the text range's last paragraph will be returned.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TextRange:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TextRange:interface" />
         description: ''
   - name: getText()
-    uid: 'ExcelScript!ExcelScript.TextRange#getText:member(1)'
+    uid: ExcelScript!ExcelScript.TextRange#getText:member(1)
     package: ExcelScript!
     fullName: getText()
     summary: Represents the plain text content of the text range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -130,11 +141,12 @@ methods:
           }
           ```
   - name: setText(text)
-    uid: 'ExcelScript!ExcelScript.TextRange#setText:member(1)'
+    uid: ExcelScript!ExcelScript.TextRange#setText:member(1)
     package: ExcelScript!
     fullName: setText(text)
     summary: Represents the plain text content of the text range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.timelinestyle.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.timelinestyle.yml
@@ -1,20 +1,24 @@
 ### YamlMime:TSType
 name: ExcelScript.TimelineStyle
-uid: 'ExcelScript!ExcelScript.TimelineStyle:interface'
+uid: ExcelScript!ExcelScript.TimelineStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.TimelineStyle
-summary: 'Represents a `TimelineStyle`<!-- -->, which defines style elements by region in the timeline.'
+summary: >-
+  Represents a `TimelineStyle`<!-- -->, which defines style elements by region
+  in the timeline.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.TimelineStyle#delete:member(1)'
+    uid: ExcelScript!ExcelScript.TimelineStyle#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the table style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,24 +27,28 @@ methods:
         type: void
         description: ''
   - name: duplicate()
-    uid: 'ExcelScript!ExcelScript.TimelineStyle#duplicate:member(1)'
+    uid: ExcelScript!ExcelScript.TimelineStyle#duplicate:member(1)
     package: ExcelScript!
     fullName: duplicate()
-    summary: Creates a duplicate of this timeline style with copies of all the style elements.
+    summary: >-
+      Creates a duplicate of this timeline style with copies of all the style
+      elements.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'duplicate(): TimelineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.TimelineStyle#getName:member(1)'
+    uid: ExcelScript!ExcelScript.TimelineStyle#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Specifies the name of the timeline style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -49,11 +57,12 @@ methods:
         type: string
         description: ''
   - name: getReadOnly()
-    uid: 'ExcelScript!ExcelScript.TimelineStyle#getReadOnly:member(1)'
+    uid: ExcelScript!ExcelScript.TimelineStyle#getReadOnly:member(1)
     package: ExcelScript!
     fullName: getReadOnly()
     summary: Specifies if this `TimelineStyle` object is read-only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -62,11 +71,12 @@ methods:
         type: boolean
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.TimelineStyle#setName:member(1)'
+    uid: ExcelScript!ExcelScript.TimelineStyle#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
     summary: Specifies the name of the timeline style.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomconditionalformat.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.TopBottomConditionalFormat
-uid: 'ExcelScript!ExcelScript.TopBottomConditionalFormat:interface'
+uid: ExcelScript!ExcelScript.TopBottomConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.TopBottomConditionalFormat
 summary: Represents a top/bottom conditional format.
@@ -30,42 +30,52 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getFormat()
-    uid: 'ExcelScript!ExcelScript.TopBottomConditionalFormat#getFormat:member(1)'
+    uid: ExcelScript!ExcelScript.TopBottomConditionalFormat#getFormat:member(1)
     package: ExcelScript!
     fullName: getFormat()
-    summary: 'Returns a format object, encapsulating the conditional format''s font, fill, borders, and other properties.'
+    summary: >-
+      Returns a format object, encapsulating the conditional format's font,
+      fill, borders, and other properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFormat(): ConditionalRangeFormat;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalRangeFormat:interface"
+          />
         description: ''
   - name: getRule()
-    uid: 'ExcelScript!ExcelScript.TopBottomConditionalFormat#getRule:member(1)'
+    uid: ExcelScript!ExcelScript.TopBottomConditionalFormat#getRule:member(1)
     package: ExcelScript!
     fullName: getRule()
     summary: The criteria of the top/bottom conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRule(): ConditionalTopBottomRule;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface"
+          />
         description: ''
   - name: setRule(rule)
-    uid: 'ExcelScript!ExcelScript.TopBottomConditionalFormat#setRule:member(1)'
+    uid: ExcelScript!ExcelScript.TopBottomConditionalFormat#setRule:member(1)
     package: ExcelScript!
     fullName: setRule(rule)
     summary: The criteria of the top/bottom conditional format.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -73,7 +83,9 @@ methods:
       parameters:
         - id: rule
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.ConditionalTopBottomRule:interface" />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomselectiontype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.topbottomselectiontype.yml
@@ -1,24 +1,25 @@
 ### YamlMime:TSEnum
 name: ExcelScript.TopBottomSelectionType
-uid: 'ExcelScript!ExcelScript.TopBottomSelectionType:enum'
+uid: ExcelScript!ExcelScript.TopBottomSelectionType:enum
 package: ExcelScript!
 fullName: ExcelScript.TopBottomSelectionType
 summary: >-
-  A simple enum for top/bottom filters to select whether to filter by the top N or bottom N percent, number, or sum of
-  values.
+  A simple enum for top/bottom filters to select whether to filter by the top N
+  or bottom N percent, number, or sum of values.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: items
-    uid: 'ExcelScript!ExcelScript.TopBottomSelectionType.items:member'
+    uid: ExcelScript!ExcelScript.TopBottomSelectionType.items:member
     package: ExcelScript!
     summary: Filter the top/bottom N number of items as measured by the chosen value.
   - name: percent
-    uid: 'ExcelScript!ExcelScript.TopBottomSelectionType.percent:member'
+    uid: ExcelScript!ExcelScript.TopBottomSelectionType.percent:member
     package: ExcelScript!
     summary: Filter the top/bottom N percent of items as measured by the chosen value.
   - name: sum
-    uid: 'ExcelScript!ExcelScript.TopBottomSelectionType.sum:member'
+    uid: ExcelScript!ExcelScript.TopBottomSelectionType.sum:member
     package: ExcelScript!
     summary: Filter the top/bottom N sum as measured by the chosen value.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.unknowncellcontrol.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.unknowncellcontrol.yml
@@ -1,25 +1,28 @@
 ### YamlMime:TSType
 name: ExcelScript.UnknownCellControl
-uid: 'ExcelScript!ExcelScript.UnknownCellControl:interface'
+uid: ExcelScript!ExcelScript.UnknownCellControl:interface
 package: ExcelScript!
 fullName: ExcelScript.UnknownCellControl
 summary: >-
-  Represents an unknown cell control. This represents a control that was added in a future version of Excel, and the
-  current version of Excel doesn't know how to display this control.
+  Represents an unknown cell control. This represents a control that was added
+  in a future version of Excel, and the current version of Excel doesn't know
+  how to display this control.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: type
-    uid: 'ExcelScript!ExcelScript.UnknownCellControl#type:member'
+    uid: ExcelScript!ExcelScript.UnknownCellControl#type:member
     package: ExcelScript!
     fullName: type
     summary: ''
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'type: CellControlType.unknown;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CellControlType.unknown:member" />'
+        type: <xref uid="ExcelScript!ExcelScript.CellControlType.unknown:member" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.valuefiltercondition.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.valuefiltercondition.yml
@@ -1,11 +1,12 @@
 ### YamlMime:TSEnum
 name: ExcelScript.ValueFilterCondition
-uid: 'ExcelScript!ExcelScript.ValueFilterCondition:enum'
+uid: ExcelScript!ExcelScript.ValueFilterCondition:enum
 package: ExcelScript!
 fullName: ExcelScript.ValueFilterCondition
 summary: >-
-  Enum representing all accepted conditions by which a value filter can be applied. Used to configure the type of
-  PivotFilter that is applied to the field. `PivotFilter.exclusive` can be set to `true` to invert many of these
+  Enum representing all accepted conditions by which a value filter can be
+  applied. Used to configure the type of PivotFilter that is applied to the
+  field. `PivotFilter.exclusive` can be set to `true` to invert many of these
   conditions.
 remarks: |-
 
@@ -40,70 +41,77 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: between
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.between:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.between:member
     package: ExcelScript!
     summary: >-
       Between `lowerBound` and `upperBound` criteria.
 
 
-      Required Criteria: {`value`<!-- -->, `lowerBound`<!-- -->, `upperBound`<!-- -->}<!-- -->. Optional Criteria:
-      {`exclusive`<!-- -->}<!-- -->.
+      Required Criteria: {`value`<!-- -->, `lowerBound`<!-- -->,
+      `upperBound`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!--
+      -->}<!-- -->.
   - name: bottomN
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.bottomN:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.bottomN:member
     package: ExcelScript!
-    summary: |-
-      In bottom N (`threshold`<!-- -->) \[items, percent, sum\] of value category.
+    summary: >-
+      In bottom N (`threshold`<!-- -->) \[items, percent, sum\] of value
+      category.
 
-      Required Criteria: {`value`<!-- -->, `threshold`<!-- -->, `selectionType`<!-- -->}<!-- -->.
+
+      Required Criteria: {`value`<!-- -->, `threshold`<!-- -->,
+      `selectionType`<!-- -->}<!-- -->.
   - name: equals
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.equals:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.equals:member
     package: ExcelScript!
     summary: >-
       Equals comparator criterion.
 
 
-      Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->. Optional Criteria: {`exclusive`<!-- -->}<!--
-      -->.
+      Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->.
+      Optional Criteria: {`exclusive`<!-- -->}<!-- -->.
   - name: greaterThan
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.greaterThan:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.greaterThan:member
     package: ExcelScript!
     summary: |-
       Greater than comparator criterion.
 
       Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->.
   - name: greaterThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.greaterThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.greaterThanOrEqualTo:member
     package: ExcelScript!
     summary: |-
       Greater than or equal to comparator criterion.
 
       Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->.
   - name: lessThan
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.lessThan:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.lessThan:member
     package: ExcelScript!
     summary: |-
       Less than comparator criterion.
 
       Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->.
   - name: lessThanOrEqualTo
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.lessThanOrEqualTo:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.lessThanOrEqualTo:member
     package: ExcelScript!
     summary: |-
       Less than or equal to comparator criterion.
 
       Required Criteria: {`value`<!-- -->, `comparator`<!-- -->}<!-- -->.
   - name: topN
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.topN:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.topN:member
     package: ExcelScript!
-    summary: |-
+    summary: >-
       In top N (`threshold`<!-- -->) \[items, percent, sum\] of value category.
 
-      Required Criteria: {`value`<!-- -->, `threshold`<!-- -->, `selectionType`<!-- -->}<!-- -->.
+
+      Required Criteria: {`value`<!-- -->, `threshold`<!-- -->,
+      `selectionType`<!-- -->}<!-- -->.
   - name: unknown
-    uid: 'ExcelScript!ExcelScript.ValueFilterCondition.unknown:member'
+    uid: ExcelScript!ExcelScript.ValueFilterCondition.unknown:member
     package: ExcelScript!
     summary: '`ValueFilterCondition` is unknown or unsupported.'

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.verticalalignment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.verticalalignment.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.VerticalAlignment
-uid: 'ExcelScript!ExcelScript.VerticalAlignment:enum'
+uid: ExcelScript!ExcelScript.VerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.VerticalAlignment
 summary: ''
@@ -23,26 +23,27 @@ remarks: |-
     firstRow.getFormat().setVerticalAlignment(ExcelScript.VerticalAlignment.top);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: bottom
-    uid: 'ExcelScript!ExcelScript.VerticalAlignment.bottom:member'
+    uid: ExcelScript!ExcelScript.VerticalAlignment.bottom:member
     package: ExcelScript!
     summary: ''
   - name: center
-    uid: 'ExcelScript!ExcelScript.VerticalAlignment.center:member'
+    uid: ExcelScript!ExcelScript.VerticalAlignment.center:member
     package: ExcelScript!
     summary: ''
   - name: distributed
-    uid: 'ExcelScript!ExcelScript.VerticalAlignment.distributed:member'
+    uid: ExcelScript!ExcelScript.VerticalAlignment.distributed:member
     package: ExcelScript!
     summary: ''
   - name: justify
-    uid: 'ExcelScript!ExcelScript.VerticalAlignment.justify:member'
+    uid: ExcelScript!ExcelScript.VerticalAlignment.justify:member
     package: ExcelScript!
     summary: ''
   - name: top
-    uid: 'ExcelScript!ExcelScript.VerticalAlignment.top:member'
+    uid: ExcelScript!ExcelScript.VerticalAlignment.top:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbook.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.Workbook
-uid: 'ExcelScript!ExcelScript.Workbook:interface'
+uid: ExcelScript!ExcelScript.Workbook:interface
 package: ExcelScript!
 fullName: ExcelScript.Workbook
-summary: 'Workbook is the top level object which contains related workbook objects such as worksheets, tables, and ranges.'
+summary: >-
+  Workbook is the top level object which contains related workbook objects such
+  as worksheets, tables, and ranges.
 remarks: |-
 
 
@@ -21,16 +23,18 @@ remarks: |-
     worksheet.activate();
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'addBinding(range, bindingType, id)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addBinding:member(1)'
+  - name: addBinding(range, bindingType, id)
+    uid: ExcelScript!ExcelScript.Workbook#addBinding:member(1)
     package: ExcelScript!
-    fullName: 'addBinding(range, bindingType, id)'
+    fullName: addBinding(range, bindingType, id)
     summary: Add a new binding to a particular Range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -43,26 +47,28 @@ methods:
       parameters:
         - id: range
           description: >-
-            Range to bind the binding to. May be a `Range` object or a string. If string, must contain the full address,
-            including the sheet name
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            Range to bind the binding to. May be a `Range` object or a string.
+            If string, must contain the full address, including the sheet name
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: bindingType
           description: Type of binding. See `ExcelScript.BindingType`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.BindingType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.BindingType:enum" />
         - id: id
           description: Name of the binding.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Binding:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Binding:interface" />
         description: ''
-  - name: 'addBindingFromNamedItem(name, bindingType, id)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addBindingFromNamedItem:member(1)'
+  - name: addBindingFromNamedItem(name, bindingType, id)
+    uid: ExcelScript!ExcelScript.Workbook#addBindingFromNamedItem:member(1)
     package: ExcelScript!
-    fullName: 'addBindingFromNamedItem(name, bindingType, id)'
+    fullName: addBindingFromNamedItem(name, bindingType, id)
     summary: >-
-      Add a new binding based on a named item in the workbook. If the named item references to multiple areas, the
-      `InvalidReference` error will be returned.
+      Add a new binding based on a named item in the workbook. If the named item
+      references to multiple areas, the `InvalidReference` error will be
+      returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -78,21 +84,22 @@ methods:
           type: string
         - id: bindingType
           description: Type of binding. See `ExcelScript.BindingType`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.BindingType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.BindingType:enum" />
         - id: id
           description: Name of the binding.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Binding:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Binding:interface" />
         description: ''
-  - name: 'addBindingFromSelection(bindingType, id)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addBindingFromSelection:member(1)'
+  - name: addBindingFromSelection(bindingType, id)
+    uid: ExcelScript!ExcelScript.Workbook#addBindingFromSelection:member(1)
     package: ExcelScript!
-    fullName: 'addBindingFromSelection(bindingType, id)'
+    fullName: addBindingFromSelection(bindingType, id)
     summary: >-
-      Add a new binding based on the current selection. If the selection has multiple areas, the `InvalidReference`
-      error will be returned.
+      Add a new binding based on the current selection. If the selection has
+      multiple areas, the `InvalidReference` error will be returned.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -100,21 +107,23 @@ methods:
       parameters:
         - id: bindingType
           description: Type of binding. See `ExcelScript.BindingType`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.BindingType:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.BindingType:enum" />
         - id: id
           description: Name of the binding.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Binding:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Binding:interface" />
         description: ''
-  - name: 'addComment(cellAddress, content, contentType)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addComment:member(1)'
+  - name: addComment(cellAddress, content, contentType)
+    uid: ExcelScript!ExcelScript.Workbook#addComment:member(1)
     package: ExcelScript!
-    fullName: 'addComment(cellAddress, content, contentType)'
+    fullName: addComment(cellAddress, content, contentType)
     summary: >-
-      Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the
-      provided range is larger than one cell.
+      Creates a new comment with the given content on the given cell. An
+      `InvalidArgument` error is thrown if the provided range is larger than one
+      cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,29 +136,35 @@ methods:
       parameters:
         - id: cellAddress
           description: >-
-            The cell to which the comment is added. This can be a `Range` object or a string. If it's a string, it must
-            contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided
-            range is larger than one cell.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell to which the comment is added. This can be a `Range` object
+            or a string. If it's a string, it must contain the full address,
+            including the sheet name. An `InvalidArgument` error is thrown if
+            the provided range is larger than one cell.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: content
           description: >-
-            The comment's content. This can be either a string or `CommentRichContent` object. Strings are used for
-            plain text. `CommentRichContent` objects allow for other comment features, such as mentions.
-          type: '<xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" /> | string'
+            The comment's content. This can be either a string or
+            `CommentRichContent` object. Strings are used for plain text.
+            `CommentRichContent` objects allow for other comment features, such
+            as mentions.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />
+            | string
         - id: contentType
           description: >-
-            Optional. The type of content contained within the comment. The default value is enum
-            `ContentType.Plain`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.ContentType:enum" />'
+            Optional. The type of content contained within the comment. The
+            default value is enum `ContentType.Plain`<!-- -->.
+          type: <xref uid="ExcelScript!ExcelScript.ContentType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: addCustomXmlPart(xml)
-    uid: 'ExcelScript!ExcelScript.Workbook#addCustomXmlPart:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#addCustomXmlPart:member(1)
     package: ExcelScript!
     fullName: addCustomXmlPart(xml)
     summary: Adds a new custom XML part to the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -159,14 +174,15 @@ methods:
           description: XML content. Must be a valid XML fragment.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />
         description: ''
-  - name: 'addNamedItem(name, reference, comment)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addNamedItem:member(1)'
+  - name: addNamedItem(name, reference, comment)
+    uid: ExcelScript!ExcelScript.Workbook#addNamedItem:member(1)
     package: ExcelScript!
-    fullName: 'addNamedItem(name, reference, comment)'
+    fullName: addNamedItem(name, reference, comment)
     summary: Adds a new name to the collection of the given scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -182,12 +198,12 @@ methods:
           type: string
         - id: reference
           description: The formula or the range that the name will refer to.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: comment
           description: Optional. The comment associated with the named item.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />
         description: |-
 
 
@@ -214,12 +230,15 @@ methods:
             otherSheet.activate();
           }
           ```
-  - name: 'addNamedItemFormulaLocal(name, formula, comment)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addNamedItemFormulaLocal:member(1)'
+  - name: addNamedItemFormulaLocal(name, formula, comment)
+    uid: ExcelScript!ExcelScript.Workbook#addNamedItemFormulaLocal:member(1)
     package: ExcelScript!
-    fullName: 'addNamedItemFormulaLocal(name, formula, comment)'
-    summary: Adds a new name to the collection of the given scope using the user's locale for the formula.
+    fullName: addNamedItemFormulaLocal(name, formula, comment)
+    summary: >-
+      Adds a new name to the collection of the given scope using the user's
+      locale for the formula.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -240,14 +259,17 @@ methods:
           description: Optional. The comment associated with the named item.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />
         description: ''
-  - name: 'addPivotTable(name, source, destination)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addPivotTable:member(1)'
+  - name: addPivotTable(name, source, destination)
+    uid: ExcelScript!ExcelScript.Workbook#addPivotTable:member(1)
     package: ExcelScript!
-    fullName: 'addPivotTable(name, source, destination)'
-    summary: Add a PivotTable based on the specified source data and insert it at the top-left cell of the destination range.
+    fullName: addPivotTable(name, source, destination)
+    summary: >-
+      Add a PivotTable based on the specified source data and insert it at the
+      top-left cell of the destination range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -263,18 +285,19 @@ methods:
           type: string
         - id: source
           description: >-
-            The source data for the new PivotTable, this can either be a range (or string address including the
-            worksheet name) or a table.
+            The source data for the new PivotTable, this can either be a range
+            (or string address including the worksheet name) or a table.
           type: >-
-            <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string | <xref
-            uid="ExcelScript!ExcelScript.Table:interface" />
+            <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string |
+            <xref uid="ExcelScript!ExcelScript.Table:interface" />
         - id: destination
           description: >-
-            The cell in the upper-left corner of the PivotTable report's destination range (the range on the worksheet
-            where the resulting report will be placed).
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell in the upper-left corner of the PivotTable report's
+            destination range (the range on the worksheet where the resulting
+            report will be placed).
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />
         description: |-
 
 
@@ -297,12 +320,13 @@ methods:
             pivotTable.addDataHierarchy(pivotTable.getHierarchy("Sales"));
           }
           ```
-  - name: 'addPivotTableStyle(name, makeUniqueName)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addPivotTableStyle:member(1)'
+  - name: addPivotTableStyle(name, makeUniqueName)
+    uid: ExcelScript!ExcelScript.Workbook#addPivotTableStyle:member(1)
     package: ExcelScript!
-    fullName: 'addPivotTableStyle(name, makeUniqueName)'
+    fullName: addPivotTableStyle(name, makeUniqueName)
     summary: Creates a blank `PivotTableStyle` with the specified name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -314,23 +338,24 @@ methods:
       parameters:
         - id: name
           description: >-
-            The unique name for the new PivotTable style. Will throw an `InvalidArgument` error if the name is already
-            in use.
+            The unique name for the new PivotTable style. Will throw an
+            `InvalidArgument` error if the name is already in use.
           type: string
         - id: makeUniqueName
           description: >-
-            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will append numbers to the name in order to make
-            it unique, if needed.
+            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will
+            append numbers to the name in order to make it unique, if needed.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />
         description: ''
   - name: addPredefinedCellStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#addPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#addPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: addPredefinedCellStyle(name)
     summary: Adds a new style to the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -342,12 +367,13 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'addSlicer(slicerSource, sourceField, slicerDestination)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addSlicer:member(1)'
+  - name: addSlicer(slicerSource, sourceField, slicerDestination)
+    uid: ExcelScript!ExcelScript.Workbook#addSlicer:member(1)
     package: ExcelScript!
-    fullName: 'addSlicer(slicerSource, sourceField, slicerDestination)'
+    fullName: addSlicer(slicerSource, sourceField, slicerDestination)
     summary: Adds a new slicer to the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -360,27 +386,33 @@ methods:
       parameters:
         - id: slicerSource
           description: >-
-            The data source that the new slicer will be based on. It can be a `PivotTable` object, a `Table` object, or
-            a string. When a PivotTable object is passed, the data source is the source of the `PivotTable` object. When
-            a `Table` object is passed, the data source is the `Table` object. When a string is passed, it is
+            The data source that the new slicer will be based on. It can be a
+            `PivotTable` object, a `Table` object, or a string. When a
+            PivotTable object is passed, the data source is the source of the
+            `PivotTable` object. When a `Table` object is passed, the data
+            source is the `Table` object. When a string is passed, it is
             interpreted as the name or ID of a PivotTable or table.
           type: >-
-            string | <xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> | <xref
-            uid="ExcelScript!ExcelScript.Table:interface" />
+            string | <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />
+            | <xref uid="ExcelScript!ExcelScript.Table:interface" />
         - id: sourceField
           description: >-
-            The field in the data source to filter by. It can be a `PivotField` object, a `TableColumn` object, the ID
-            of a `PivotField` or the name or ID of a `TableColumn`<!-- -->.
+            The field in the data source to filter by. It can be a `PivotField`
+            object, a `TableColumn` object, the ID of a `PivotField` or the name
+            or ID of a `TableColumn`<!-- -->.
           type: >-
-            string | <xref uid="ExcelScript!ExcelScript.PivotField:interface" /> | number | <xref
-            uid="ExcelScript!ExcelScript.TableColumn:interface" />
+            string | <xref uid="ExcelScript!ExcelScript.PivotField:interface" />
+            | number | <xref uid="ExcelScript!ExcelScript.TableColumn:interface"
+            />
         - id: slicerDestination
           description: >-
-            Optional. The worksheet in which the new slicer will be created. It can be a `Worksheet` object or the name
-            or ID of a worksheet. This parameter can be omitted if the slicer collection is retrieved from a worksheet.
-          type: 'string | <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+            Optional. The worksheet in which the new slicer will be created. It
+            can be a `Worksheet` object or the name or ID of a worksheet. This
+            parameter can be omitted if the slicer collection is retrieved from
+            a worksheet.
+          type: string | <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" />
         description: |-
 
 
@@ -408,12 +440,13 @@ methods:
             fruitSlicer.setLeft(400);
           }
           ```
-  - name: 'addSlicerStyle(name, makeUniqueName)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addSlicerStyle:member(1)'
+  - name: addSlicerStyle(name, makeUniqueName)
+    uid: ExcelScript!ExcelScript.Workbook#addSlicerStyle:member(1)
     package: ExcelScript!
-    fullName: 'addSlicerStyle(name, makeUniqueName)'
+    fullName: addSlicerStyle(name, makeUniqueName)
     summary: Creates a blank slicer style with the specified name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -421,26 +454,28 @@ methods:
       parameters:
         - id: name
           description: >-
-            The unique name for the new slicer style. Will throw an `InvalidArgument` exception if the name is already
-            in use.
+            The unique name for the new slicer style. Will throw an
+            `InvalidArgument` exception if the name is already in use.
           type: string
         - id: makeUniqueName
           description: >-
-            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will append numbers to the name in order to make
-            it unique, if needed.
+            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will
+            append numbers to the name in order to make it unique, if needed.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />
         description: ''
-  - name: 'addTable(address, hasHeaders)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addTable:member(1)'
+  - name: addTable(address, hasHeaders)
+    uid: ExcelScript!ExcelScript.Workbook#addTable:member(1)
     package: ExcelScript!
-    fullName: 'addTable(address, hasHeaders)'
+    fullName: addTable(address, hasHeaders)
     summary: >-
-      Creates a new table. The range object or source address determines the worksheet under which the table will be
-      added. If the table cannot be added (e.g., because the address is invalid, or the table would overlap with another
-      table), an error will be thrown.
+      Creates a new table. The range object or source address determines the
+      worksheet under which the table will be added. If the table cannot be
+      added (e.g., because the address is invalid, or the table would overlap
+      with another table), an error will be thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -448,17 +483,19 @@ methods:
       parameters:
         - id: address
           description: >-
-            A `Range` object, or a string address or name of the range representing the data source. If the address does
-            not contain a sheet name, the currently-active sheet is used.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            A `Range` object, or a string address or name of the range
+            representing the data source. If the address does not contain a
+            sheet name, the currently-active sheet is used.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: hasHeaders
           description: >-
-            A boolean value that indicates whether the data being imported has column labels. If the source does not
-            contain headers (i.e., when this property set to `false`<!-- -->), Excel will automatically generate a
-            header and shift the data down by one row.
+            A boolean value that indicates whether the data being imported has
+            column labels. If the source does not contain headers (i.e., when
+            this property set to `false`<!-- -->), Excel will automatically
+            generate a header and shift the data down by one row.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />
         description: |-
 
 
@@ -477,12 +514,13 @@ methods:
             workbook.addTable(dataRange.getAddress(), true);
           }
           ```
-  - name: 'addTableStyle(name, makeUniqueName)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addTableStyle:member(1)'
+  - name: addTableStyle(name, makeUniqueName)
+    uid: ExcelScript!ExcelScript.Workbook#addTableStyle:member(1)
     package: ExcelScript!
-    fullName: 'addTableStyle(name, makeUniqueName)'
+    fullName: addTableStyle(name, makeUniqueName)
     summary: Creates a blank `TableStyle` with the specified name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -490,23 +528,24 @@ methods:
       parameters:
         - id: name
           description: >-
-            The unique name for the new table style. Will throw an `InvalidArgument` error if the name is already in
-            use.
+            The unique name for the new table style. Will throw an
+            `InvalidArgument` error if the name is already in use.
           type: string
         - id: makeUniqueName
           description: >-
-            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will append numbers to the name in order to make
-            it unique, if needed.
+            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will
+            append numbers to the name in order to make it unique, if needed.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TableStyle:interface" />
         description: ''
-  - name: 'addTimelineStyle(name, makeUniqueName)'
-    uid: 'ExcelScript!ExcelScript.Workbook#addTimelineStyle:member(1)'
+  - name: addTimelineStyle(name, makeUniqueName)
+    uid: ExcelScript!ExcelScript.Workbook#addTimelineStyle:member(1)
     package: ExcelScript!
-    fullName: 'addTimelineStyle(name, makeUniqueName)'
+    fullName: addTimelineStyle(name, makeUniqueName)
     summary: Creates a blank `TimelineStyle` with the specified name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -514,25 +553,27 @@ methods:
       parameters:
         - id: name
           description: >-
-            The unique name for the new timeline style. Will throw an `InvalidArgument` error if the name is already in
-            use.
+            The unique name for the new timeline style. Will throw an
+            `InvalidArgument` error if the name is already in use.
           type: string
         - id: makeUniqueName
           description: >-
-            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will append numbers to the name in order to make
-            it unique, if needed.
+            Optional. Defaults to `false`<!-- -->. If `true`<!-- -->, will
+            append numbers to the name in order to make it unique, if needed.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />
         description: ''
   - name: addWorksheet(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#addWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#addWorksheet:member(1)
     package: ExcelScript!
     fullName: addWorksheet(name)
     summary: >-
-      Adds a new worksheet to the workbook. The worksheet will be added at the end of existing worksheets. If you wish
-      to activate the newly added worksheet, call `.activate()` on it.
+      Adds a new worksheet to the workbook. The worksheet will be added at the
+      end of existing worksheets. If you wish to activate the newly added
+      worksheet, call `.activate()` on it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -540,11 +581,12 @@ methods:
       parameters:
         - id: name
           description: >-
-            Optional. The name of the worksheet to be added. If specified, the name should be unique. If not specified,
-            Excel determines the name of the new worksheet.
+            Optional. The name of the worksheet to be added. If specified, the
+            name should be unique. If not specified, Excel determines the name
+            of the new worksheet.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: |-
 
 
@@ -566,13 +608,15 @@ methods:
           }
           ```
   - name: breakAllLinksToLinkedWorkbooks()
-    uid: 'ExcelScript!ExcelScript.Workbook#breakAllLinksToLinkedWorkbooks:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#breakAllLinksToLinkedWorkbooks:member(1)
     package: ExcelScript!
     fullName: breakAllLinksToLinkedWorkbooks()
     summary: >-
-      Breaks all the links to the linked workbooks. Once the links are broken, any formulas referencing workbook links
-      are removed entirely and replaced with the most recently retrieved values.
+      Breaks all the links to the linked workbooks. Once the links are broken,
+      any formulas referencing workbook links are removed entirely and replaced
+      with the most recently retrieved values.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -581,17 +625,18 @@ methods:
         type: void
         description: ''
   - name: getActiveCell()
-    uid: 'ExcelScript!ExcelScript.Workbook#getActiveCell:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getActiveCell:member(1)
     package: ExcelScript!
     fullName: getActiveCell()
     summary: Gets the currently active cell from the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getActiveCell(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -609,67 +654,72 @@ methods:
           }
           ```
   - name: getActiveChart()
-    uid: 'ExcelScript!ExcelScript.Workbook#getActiveChart:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getActiveChart:member(1)
     package: ExcelScript!
     fullName: getActiveChart()
     summary: >-
-      Gets the currently active chart in the workbook. If there is no active chart, then this method returns
-      `undefined`<!-- -->.
+      Gets the currently active chart in the workbook. If there is no active
+      chart, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getActiveChart(): Chart;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Chart:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Chart:interface" />
         description: ''
   - name: getActiveSlicer()
-    uid: 'ExcelScript!ExcelScript.Workbook#getActiveSlicer:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getActiveSlicer:member(1)
     package: ExcelScript!
     fullName: getActiveSlicer()
     summary: >-
-      Gets the currently active slicer in the workbook. If there is no active slicer, then this method returns
-      `undefined`<!-- -->.
+      Gets the currently active slicer in the workbook. If there is no active
+      slicer, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getActiveSlicer(): Slicer;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" />
         description: ''
   - name: getActiveWorksheet()
-    uid: 'ExcelScript!ExcelScript.Workbook#getActiveWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getActiveWorksheet:member(1)
     package: ExcelScript!
     fullName: getActiveWorksheet()
     summary: Gets the currently active worksheet in the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getActiveWorksheet(): Worksheet;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: getApplication()
-    uid: 'ExcelScript!ExcelScript.Workbook#getApplication:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getApplication:member(1)
     package: ExcelScript!
     fullName: getApplication()
     summary: Represents the Excel application instance that contains this workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getApplication(): Application;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Application:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Application:interface" />
         description: ''
   - name: getAutoSave()
-    uid: 'ExcelScript!ExcelScript.Workbook#getAutoSave:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getAutoSave:member(1)
     package: ExcelScript!
     fullName: getAutoSave()
     summary: Specifies if the workbook is in AutoSave mode.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -678,11 +728,14 @@ methods:
         type: boolean
         description: ''
   - name: getBinding(id)
-    uid: 'ExcelScript!ExcelScript.Workbook#getBinding:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getBinding:member(1)
     package: ExcelScript!
     fullName: getBinding(id)
-    summary: 'Gets a binding object by ID. If the binding object does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a binding object by ID. If the binding object does not exist, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -692,27 +745,29 @@ methods:
           description: ID of the binding object to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Binding:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Binding:interface" /> | undefined
         description: ''
   - name: getBindings()
-    uid: 'ExcelScript!ExcelScript.Workbook#getBindings:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getBindings:member(1)
     package: ExcelScript!
     fullName: getBindings()
     summary: Represents a collection of bindings that are part of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getBindings(): Binding[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Binding:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Binding:interface" />[]
         description: ''
   - name: getCalculationEngineVersion()
-    uid: 'ExcelScript!ExcelScript.Workbook#getCalculationEngineVersion:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCalculationEngineVersion:member(1)
     package: ExcelScript!
     fullName: getCalculationEngineVersion()
     summary: Returns a number about the version of Excel Calculation Engine.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -721,13 +776,15 @@ methods:
         type: number
         description: ''
   - name: getChartDataPointTrack()
-    uid: 'ExcelScript!ExcelScript.Workbook#getChartDataPointTrack:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getChartDataPointTrack:member(1)
     package: ExcelScript!
     fullName: getChartDataPointTrack()
     summary: >-
-      True if all charts in the workbook are tracking the actual data points to which they are attached. False if the
-      charts track the index of the data points.
+      True if all charts in the workbook are tracking the actual data points to
+      which they are attached. False if the charts track the index of the data
+      points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -736,13 +793,14 @@ methods:
         type: boolean
         description: ''
   - name: getComment(commentId)
-    uid: 'ExcelScript!ExcelScript.Workbook#getComment:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getComment:member(1)
     package: ExcelScript!
     fullName: getComment(commentId)
     summary: >-
-      Gets a comment from the collection based on its ID. If the comment object does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a comment from the collection based on its ID. If the comment object
+      does not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -752,14 +810,17 @@ methods:
           description: The identifier for the comment.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" /> | undefined
         description: ''
   - name: getCommentByCell(cellAddress)
-    uid: 'ExcelScript!ExcelScript.Workbook#getCommentByCell:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCommentByCell:member(1)
     package: ExcelScript!
     fullName: getCommentByCell(cellAddress)
-    summary: 'Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.'
+    summary: >-
+      Gets the comment from the specified cell. If there is no comment in the
+      cell, an error is thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -767,19 +828,21 @@ methods:
       parameters:
         - id: cellAddress
           description: >-
-            The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must
-            contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided
-            range is larger than one cell.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell which the comment is on. This can be a `Range` object or a
+            string. If it's a string, it must contain the full address,
+            including the sheet name. An `InvalidArgument` error is thrown if
+            the provided range is larger than one cell.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: getCommentByReplyId(replyId)
-    uid: 'ExcelScript!ExcelScript.Workbook#getCommentByReplyId:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCommentByReplyId:member(1)
     package: ExcelScript!
     fullName: getCommentByReplyId(replyId)
     summary: Gets the comment to which the given reply is connected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -789,29 +852,31 @@ methods:
           description: The identifier of comment reply.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: getComments()
-    uid: 'ExcelScript!ExcelScript.Workbook#getComments:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getComments:member(1)
     package: ExcelScript!
     fullName: getComments()
     summary: Represents a collection of comments associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getComments(): Comment[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />[]
         description: ''
   - name: getCustomXmlPart(id)
-    uid: 'ExcelScript!ExcelScript.Workbook#getCustomXmlPart:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCustomXmlPart:member(1)
     package: ExcelScript!
     fullName: getCustomXmlPart(id)
     summary: >-
-      Gets a custom XML part based on its ID. If the `CustomXmlPart` does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a custom XML part based on its ID. If the `CustomXmlPart` does not
+      exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -821,14 +886,19 @@ methods:
           description: ID of the object to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" /> |
+          undefined
         description: ''
   - name: getCustomXmlPartByNamespace(namespaceUri)
-    uid: 'ExcelScript!ExcelScript.Workbook#getCustomXmlPartByNamespace:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCustomXmlPartByNamespace:member(1)
     package: ExcelScript!
     fullName: getCustomXmlPartByNamespace(namespaceUri)
-    summary: Gets a new collection of custom XML parts whose namespaces match the given namespace.
+    summary: >-
+      Gets a new collection of custom XML parts whose namespaces match the given
+      namespace.
     remarks: ''
+
     isPreview: false
     isDeprecated: true
     customDeprecatedMessage: Use `getCustomXmlPartsByNamespace` instead.
@@ -836,118 +906,135 @@ methods:
       content: 'getCustomXmlPartByNamespace(namespaceUri: string): CustomXmlPart[];'
       parameters:
         - id: namespaceUri
-          description: 'This must be a fully qualified schema URI; for example, "http://schemas.contoso.com/review/1.0".'
+          description: >-
+            This must be a fully qualified schema URI; for example,
+            "http://schemas.contoso.com/review/1.0".
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]
         description: ''
   - name: getCustomXmlParts()
-    uid: 'ExcelScript!ExcelScript.Workbook#getCustomXmlParts:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCustomXmlParts:member(1)
     package: ExcelScript!
     fullName: getCustomXmlParts()
     summary: Represents the collection of custom XML parts contained by this workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCustomXmlParts(): CustomXmlPart[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]
         description: ''
   - name: getCustomXmlPartsByNamespace(namespaceUri)
-    uid: 'ExcelScript!ExcelScript.Workbook#getCustomXmlPartsByNamespace:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getCustomXmlPartsByNamespace:member(1)
     package: ExcelScript!
     fullName: getCustomXmlPartsByNamespace(namespaceUri)
-    summary: Gets a new collection of custom XML parts whose namespaces match the given namespace.
+    summary: >-
+      Gets a new collection of custom XML parts whose namespaces match the given
+      namespace.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCustomXmlPartsByNamespace(namespaceUri: string): CustomXmlPart[];'
       parameters:
         - id: namespaceUri
-          description: 'This must be a fully qualified schema URI; for example, "http://schemas.contoso.com/review/1.0".'
+          description: >-
+            This must be a fully qualified schema URI; for example,
+            "http://schemas.contoso.com/review/1.0".
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.CustomXmlPart:interface" />[]
         description: ''
   - name: getDefaultPivotTableStyle()
-    uid: 'ExcelScript!ExcelScript.Workbook#getDefaultPivotTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getDefaultPivotTableStyle:member(1)
     package: ExcelScript!
     fullName: getDefaultPivotTableStyle()
     summary: Gets the default PivotTable style for the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDefaultPivotTableStyle(): PivotTableStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />
         description: ''
   - name: getDefaultSlicerStyle()
-    uid: 'ExcelScript!ExcelScript.Workbook#getDefaultSlicerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getDefaultSlicerStyle:member(1)
     package: ExcelScript!
     fullName: getDefaultSlicerStyle()
     summary: Gets the default `SlicerStyle` for the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDefaultSlicerStyle(): SlicerStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />
         description: ''
   - name: getDefaultTableStyle()
-    uid: 'ExcelScript!ExcelScript.Workbook#getDefaultTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getDefaultTableStyle:member(1)
     package: ExcelScript!
     fullName: getDefaultTableStyle()
     summary: Gets the default table style for the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDefaultTableStyle(): TableStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TableStyle:interface" />
         description: ''
   - name: getDefaultTimelineStyle()
-    uid: 'ExcelScript!ExcelScript.Workbook#getDefaultTimelineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getDefaultTimelineStyle:member(1)
     package: ExcelScript!
     fullName: getDefaultTimelineStyle()
     summary: Gets the default timeline style for the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getDefaultTimelineStyle(): TimelineStyle;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />
         description: ''
   - name: getFirstWorksheet(visibleOnly)
-    uid: 'ExcelScript!ExcelScript.Workbook#getFirstWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getFirstWorksheet:member(1)
     package: ExcelScript!
     fullName: getFirstWorksheet(visibleOnly)
     summary: Gets the first worksheet in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFirstWorksheet(visibleOnly?: boolean): Worksheet;'
       parameters:
         - id: visibleOnly
-          description: 'Optional. If `true`<!-- -->, considers only visible worksheets, skipping over any hidden ones.'
+          description: >-
+            Optional. If `true`<!-- -->, considers only visible worksheets,
+            skipping over any hidden ones.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: getIsDirty()
-    uid: 'ExcelScript!ExcelScript.Workbook#getIsDirty:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getIsDirty:member(1)
     package: ExcelScript!
     fullName: getIsDirty()
     summary: >-
-      Specifies if changes have been made since the workbook was last saved. You can set this property to `true` if you
-      want to close a modified workbook without either saving it or being prompted to save it.
+      Specifies if changes have been made since the workbook was last saved. You
+      can set this property to `true` if you want to close a modified workbook
+      without either saving it or being prompted to save it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -956,30 +1043,34 @@ methods:
         type: boolean
         description: ''
   - name: getLastWorksheet(visibleOnly)
-    uid: 'ExcelScript!ExcelScript.Workbook#getLastWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getLastWorksheet:member(1)
     package: ExcelScript!
     fullName: getLastWorksheet(visibleOnly)
     summary: Gets the last worksheet in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLastWorksheet(visibleOnly?: boolean): Worksheet;'
       parameters:
         - id: visibleOnly
-          description: 'Optional. If `true`<!-- -->, considers only visible worksheets, skipping over any hidden ones.'
+          description: >-
+            Optional. If `true`<!-- -->, considers only visible worksheets,
+            skipping over any hidden ones.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: getLinkedWorkbookByUrl(key)
-    uid: 'ExcelScript!ExcelScript.Workbook#getLinkedWorkbookByUrl:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getLinkedWorkbookByUrl:member(1)
     package: ExcelScript!
     fullName: getLinkedWorkbookByUrl(key)
     summary: >-
-      Gets information about a linked workbook by its URL. If the workbook does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets information about a linked workbook by its URL. If the workbook does
+      not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -989,22 +1080,25 @@ methods:
           description: The URL of the linked workbook.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LinkedWorkbook:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.LinkedWorkbook:interface" /> |
+          undefined
         description: ''
   - name: getLinkedWorkbookRefreshMode()
-    uid: 'ExcelScript!ExcelScript.Workbook#getLinkedWorkbookRefreshMode:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getLinkedWorkbookRefreshMode:member(1)
     package: ExcelScript!
     fullName: getLinkedWorkbookRefreshMode()
     summary: >-
-      Represents the update mode of the workbook links. The mode is same for all of the workbook links present in the
-      workbook.
+      Represents the update mode of the workbook links. The mode is same for all
+      of the workbook links present in the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLinkedWorkbookRefreshMode(): WorkbookLinksRefreshMode;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum" />
         description: |-
 
 
@@ -1026,19 +1120,21 @@ methods:
             }
           ```
   - name: getLinkedWorkbooks()
-    uid: 'ExcelScript!ExcelScript.Workbook#getLinkedWorkbooks:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getLinkedWorkbooks:member(1)
     package: ExcelScript!
     fullName: getLinkedWorkbooks()
     summary: >-
-      Returns a collection of linked workbooks. In formulas, the workbook links can be used to reference data (cell
-      values and names) outside of the current workbook.
+      Returns a collection of linked workbooks. In formulas, the workbook links
+      can be used to reference data (cell values and names) outside of the
+      current workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLinkedWorkbooks(): LinkedWorkbook[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.LinkedWorkbook:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.LinkedWorkbook:interface" />[]
         description: |-
 
 
@@ -1061,11 +1157,12 @@ methods:
           }
           ```
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Workbook#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getName:member(1)
     package: ExcelScript!
     fullName: getName()
     summary: Gets the workbook name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1093,13 +1190,14 @@ methods:
           }
           ```
   - name: getNamedItem(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getNamedItem:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getNamedItem:member(1)
     package: ExcelScript!
     fullName: getNamedItem(name)
     summary: >-
-      Gets a `NamedItem` object using its name. If the object does not exist, then this method returns `undefined`<!--
-      -->.
+      Gets a `NamedItem` object using its name. If the object does not exist,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1109,20 +1207,23 @@ methods:
           description: Nameditem name.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" /> | undefined
         description: ''
   - name: getNames()
-    uid: 'ExcelScript!ExcelScript.Workbook#getNames:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getNames:member(1)
     package: ExcelScript!
     fullName: getNames()
-    summary: Represents a collection of workbook-scoped named items (named ranges and constants).
+    summary: >-
+      Represents a collection of workbook-scoped named items (named ranges and
+      constants).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNames(): NamedItem[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />[]
         description: |-
 
 
@@ -1149,11 +1250,14 @@ methods:
           }
           ```
   - name: getPivotTable(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getPivotTable:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPivotTable:member(1)
     package: ExcelScript!
     fullName: getPivotTable(name)
-    summary: 'Gets a PivotTable by name. If the PivotTable does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotTable by name. If the PivotTable does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1163,29 +1267,33 @@ methods:
           description: Name of the PivotTable to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> |
+          undefined
         description: ''
   - name: getPivotTables()
-    uid: 'ExcelScript!ExcelScript.Workbook#getPivotTables:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPivotTables:member(1)
     package: ExcelScript!
     fullName: getPivotTables()
     summary: Represents a collection of PivotTables associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPivotTables(): PivotTable[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]
         description: ''
   - name: getPivotTableStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getPivotTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPivotTableStyle:member(1)
     package: ExcelScript!
     fullName: getPivotTableStyle(name)
     summary: >-
-      Gets a `PivotTableStyle` by name. If the `PivotTableStyle` does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a `PivotTableStyle` by name. If the `PivotTableStyle` does not exist,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1195,27 +1303,33 @@ methods:
           description: Name of the PivotTable style to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" /> |
+          undefined
         description: ''
   - name: getPivotTableStyles()
-    uid: 'ExcelScript!ExcelScript.Workbook#getPivotTableStyles:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPivotTableStyles:member(1)
     package: ExcelScript!
     fullName: getPivotTableStyles()
     summary: Represents a collection of PivotTableStyles associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPivotTableStyles(): PivotTableStyle[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" />[]
         description: ''
   - name: getPredefinedCellStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getPredefinedCellStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPredefinedCellStyle:member(1)
     package: ExcelScript!
     fullName: getPredefinedCellStyle(name)
-    summary: 'Gets a style by name. If the style object does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a style by name. If the style object does not exist, then this method
+      returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1225,27 +1339,31 @@ methods:
           description: Name of the style to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PredefinedCellStyle:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PredefinedCellStyle:interface" /> |
+          undefined
         description: ''
   - name: getPredefinedCellStyles()
-    uid: 'ExcelScript!ExcelScript.Workbook#getPredefinedCellStyles:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPredefinedCellStyles:member(1)
     package: ExcelScript!
     fullName: getPredefinedCellStyles()
     summary: Represents a collection of styles associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPredefinedCellStyles(): PredefinedCellStyle[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PredefinedCellStyle:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PredefinedCellStyle:interface" />[]
         description: ''
   - name: getPreviouslySaved()
-    uid: 'ExcelScript!ExcelScript.Workbook#getPreviouslySaved:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getPreviouslySaved:member(1)
     package: ExcelScript!
     fullName: getPreviouslySaved()
     summary: Specifies if the workbook has ever been saved locally or online.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1254,30 +1372,32 @@ methods:
         type: boolean
         description: ''
   - name: getProperties()
-    uid: 'ExcelScript!ExcelScript.Workbook#getProperties:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getProperties:member(1)
     package: ExcelScript!
     fullName: getProperties()
     summary: Gets the workbook properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getProperties(): DocumentProperties;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.DocumentProperties:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.DocumentProperties:interface" />
         description: ''
   - name: getProtection()
-    uid: 'ExcelScript!ExcelScript.Workbook#getProtection:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getProtection:member(1)
     package: ExcelScript!
     fullName: getProtection()
     summary: Returns the protection object for a workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getProtection(): WorkbookProtection;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorkbookProtection:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorkbookProtection:interface" />
         description: |-
 
 
@@ -1302,24 +1422,26 @@ methods:
           }
           ```
   - name: getQueries()
-    uid: 'ExcelScript!ExcelScript.Workbook#getQueries:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getQueries:member(1)
     package: ExcelScript!
     fullName: getQueries()
     summary: Returns a collection of Power Query queries that are part of the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getQueries(): Query[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Query:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Query:interface" />[]
         description: ''
   - name: getQuery(key)
-    uid: 'ExcelScript!ExcelScript.Workbook#getQuery:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getQuery:member(1)
     package: ExcelScript!
     fullName: getQuery(key)
     summary: Gets a query from the collection based on its name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1329,14 +1451,15 @@ methods:
           description: The name of the query case-insensitive.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Query:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Query:interface" />
         description: ''
   - name: getReadOnly()
-    uid: 'ExcelScript!ExcelScript.Workbook#getReadOnly:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getReadOnly:member(1)
     package: ExcelScript!
     fullName: getReadOnly()
     summary: Returns `true` if the workbook is open in read-only mode.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1345,41 +1468,47 @@ methods:
         type: boolean
         description: ''
   - name: getSelectedRange()
-    uid: 'ExcelScript!ExcelScript.Workbook#getSelectedRange:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSelectedRange:member(1)
     package: ExcelScript!
     fullName: getSelectedRange()
     summary: >-
-      Gets the currently selected single range from the workbook. If there are multiple ranges selected, this method
-      will throw an error.
+      Gets the currently selected single range from the workbook. If there are
+      multiple ranges selected, this method will throw an error.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSelectedRange(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getSelectedRanges()
-    uid: 'ExcelScript!ExcelScript.Workbook#getSelectedRanges:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSelectedRanges:member(1)
     package: ExcelScript!
     fullName: getSelectedRanges()
     summary: >-
-      Gets the currently selected one or more ranges from the workbook. Unlike `getSelectedRange()`<!-- -->, this method
-      returns a `RangeAreas` object that represents all the selected ranges.
+      Gets the currently selected one or more ranges from the workbook. Unlike
+      `getSelectedRange()`<!-- -->, this method returns a `RangeAreas` object
+      that represents all the selected ranges.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSelectedRanges(): RangeAreas;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getSlicer(key)
-    uid: 'ExcelScript!ExcelScript.Workbook#getSlicer:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSlicer:member(1)
     package: ExcelScript!
     fullName: getSlicer(key)
-    summary: 'Gets a slicer using its name or ID. If the slicer doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a slicer using its name or ID. If the slicer doesn't exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1389,27 +1518,31 @@ methods:
           description: Name or ID of the slicer to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" /> | undefined
         description: ''
   - name: getSlicers()
-    uid: 'ExcelScript!ExcelScript.Workbook#getSlicers:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSlicers:member(1)
     package: ExcelScript!
     fullName: getSlicers()
     summary: Represents a collection of slicers associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSlicers(): Slicer[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" />[]
         description: ''
   - name: getSlicerStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getSlicerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSlicerStyle:member(1)
     package: ExcelScript!
     fullName: getSlicerStyle(name)
-    summary: 'Gets a `SlicerStyle` by name. If the slicer style doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a `SlicerStyle` by name. If the slicer style doesn't exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1419,27 +1552,33 @@ methods:
           description: Name of the slicer style to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" /> |
+          undefined
         description: ''
   - name: getSlicerStyles()
-    uid: 'ExcelScript!ExcelScript.Workbook#getSlicerStyles:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getSlicerStyles:member(1)
     package: ExcelScript!
     fullName: getSlicerStyles()
     summary: Represents a collection of SlicerStyles associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSlicerStyles(): SlicerStyle[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" />[]
         description: ''
   - name: getTable(key)
-    uid: 'ExcelScript!ExcelScript.Workbook#getTable:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTable:member(1)
     package: ExcelScript!
     fullName: getTable(key)
-    summary: 'Gets a table by name or ID. If the table doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a table by name or ID. If the table doesn't exist, then this method
+      returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1449,27 +1588,31 @@ methods:
           description: Name or ID of the table to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" /> | undefined
         description: ''
   - name: getTables()
-    uid: 'ExcelScript!ExcelScript.Workbook#getTables:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTables:member(1)
     package: ExcelScript!
     fullName: getTables()
     summary: Represents a collection of tables associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTables(): Table[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />[]
         description: ''
   - name: getTableStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTableStyle:member(1)
     package: ExcelScript!
     fullName: getTableStyle(name)
-    summary: 'Gets a `TableStyle` by name. If the table style does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a `TableStyle` by name. If the table style does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1479,27 +1622,33 @@ methods:
           description: Name of the table style to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TableStyle:interface" /> |
+          undefined
         description: ''
   - name: getTableStyles()
-    uid: 'ExcelScript!ExcelScript.Workbook#getTableStyles:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTableStyles:member(1)
     package: ExcelScript!
     fullName: getTableStyles()
     summary: Represents a collection of TableStyles associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTableStyles(): TableStyle[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.TableStyle:interface" />[]
         description: ''
   - name: getTimelineStyle(name)
-    uid: 'ExcelScript!ExcelScript.Workbook#getTimelineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTimelineStyle:member(1)
     package: ExcelScript!
     fullName: getTimelineStyle(name)
-    summary: 'Gets a `TimelineStyle` by name. If the timeline style doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a `TimelineStyle` by name. If the timeline style doesn't exist, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1509,29 +1658,34 @@ methods:
           description: Name of the timeline style to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" /> |
+          undefined
         description: ''
   - name: getTimelineStyles()
-    uid: 'ExcelScript!ExcelScript.Workbook#getTimelineStyles:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getTimelineStyles:member(1)
     package: ExcelScript!
     fullName: getTimelineStyles()
     summary: Represents a collection of TimelineStyles associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTimelineStyles(): TimelineStyle[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" />[]
         description: ''
   - name: getUsePrecisionAsDisplayed()
-    uid: 'ExcelScript!ExcelScript.Workbook#getUsePrecisionAsDisplayed:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getUsePrecisionAsDisplayed:member(1)
     package: ExcelScript!
     fullName: getUsePrecisionAsDisplayed()
     summary: >-
-      True if calculations in this workbook will be done using only the precision of the numbers as they're displayed.
-      Data will permanently lose accuracy when switching this property from `false` to `true`<!-- -->.
+      True if calculations in this workbook will be done using only the
+      precision of the numbers as they're displayed. Data will permanently lose
+      accuracy when switching this property from `false` to `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1540,13 +1694,14 @@ methods:
         type: boolean
         description: ''
   - name: getWorksheet(key)
-    uid: 'ExcelScript!ExcelScript.Workbook#getWorksheet:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getWorksheet:member(1)
     package: ExcelScript!
     fullName: getWorksheet(key)
     summary: >-
-      Gets a worksheet object using its name or ID. If the worksheet does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a worksheet object using its name or ID. If the worksheet does not
+      exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1556,7 +1711,7 @@ methods:
           description: The name or ID of the worksheet.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" /> | undefined
         description: |-
 
 
@@ -1578,17 +1733,18 @@ methods:
           }
           ```
   - name: getWorksheets()
-    uid: 'ExcelScript!ExcelScript.Workbook#getWorksheets:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#getWorksheets:member(1)
     package: ExcelScript!
     fullName: getWorksheets()
     summary: Represents a collection of worksheets associated with the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getWorksheets(): Worksheet[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />[]
         description: |-
 
 
@@ -1611,11 +1767,12 @@ methods:
           }
           ```
   - name: refreshAllDataConnections()
-    uid: 'ExcelScript!ExcelScript.Workbook#refreshAllDataConnections:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#refreshAllDataConnections:member(1)
     package: ExcelScript!
     fullName: refreshAllDataConnections()
     summary: Refreshes all the Data Connections.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1624,11 +1781,13 @@ methods:
         type: void
         description: ''
   - name: refreshAllLinksToLinkedWorkbooks()
-    uid: 'ExcelScript!ExcelScript.Workbook#refreshAllLinksToLinkedWorkbooks:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.Workbook#refreshAllLinksToLinkedWorkbooks:member(1)
     package: ExcelScript!
     fullName: refreshAllLinksToLinkedWorkbooks()
     summary: Makes a request to refresh all the workbook links.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1637,11 +1796,12 @@ methods:
         type: void
         description: ''
   - name: refreshAllPivotTables()
-    uid: 'ExcelScript!ExcelScript.Workbook#refreshAllPivotTables:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#refreshAllPivotTables:member(1)
     package: ExcelScript!
     fullName: refreshAllPivotTables()
     summary: Refreshes all the pivot tables in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1650,13 +1810,15 @@ methods:
         type: void
         description: ''
   - name: setChartDataPointTrack(chartDataPointTrack)
-    uid: 'ExcelScript!ExcelScript.Workbook#setChartDataPointTrack:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setChartDataPointTrack:member(1)
     package: ExcelScript!
     fullName: setChartDataPointTrack(chartDataPointTrack)
     summary: >-
-      True if all charts in the workbook are tracking the actual data points to which they are attached. False if the
-      charts track the index of the data points.
+      True if all charts in the workbook are tracking the actual data points to
+      which they are attached. False if the charts track the index of the data
+      points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1669,11 +1831,12 @@ methods:
         type: void
         description: ''
   - name: setDefaultPivotTableStyle(newDefaultStyle)
-    uid: 'ExcelScript!ExcelScript.Workbook#setDefaultPivotTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setDefaultPivotTableStyle:member(1)
     package: ExcelScript!
     fullName: setDefaultPivotTableStyle(newDefaultStyle)
     summary: Sets the default PivotTable style for use in the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1683,70 +1846,89 @@ methods:
                 ): void;
       parameters:
         - id: newDefaultStyle
-          description: 'The `PivotTableStyle` object, or name of the `PivotTableStyle` object, that should be the new default.'
-          type: '<xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" /> | string'
+          description: >-
+            The `PivotTableStyle` object, or name of the `PivotTableStyle`
+            object, that should be the new default.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.PivotTableStyle:interface" /> |
+            string
       return:
         type: void
         description: ''
   - name: setDefaultSlicerStyle(newDefaultStyle)
-    uid: 'ExcelScript!ExcelScript.Workbook#setDefaultSlicerStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setDefaultSlicerStyle:member(1)
     package: ExcelScript!
     fullName: setDefaultSlicerStyle(newDefaultStyle)
     summary: Sets the default slicer style for use in the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setDefaultSlicerStyle(newDefaultStyle: SlicerStyle | string): void;'
       parameters:
         - id: newDefaultStyle
-          description: 'The `SlicerStyle` object, or name of the `SlicerStyle` object, that should be the new default.'
-          type: '<xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" /> | string'
+          description: >-
+            The `SlicerStyle` object, or name of the `SlicerStyle` object, that
+            should be the new default.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.SlicerStyle:interface" /> |
+            string
       return:
         type: void
         description: ''
   - name: setDefaultTableStyle(newDefaultStyle)
-    uid: 'ExcelScript!ExcelScript.Workbook#setDefaultTableStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setDefaultTableStyle:member(1)
     package: ExcelScript!
     fullName: setDefaultTableStyle(newDefaultStyle)
     summary: Sets the default table style for use in the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setDefaultTableStyle(newDefaultStyle: TableStyle | string): void;'
       parameters:
         - id: newDefaultStyle
-          description: 'The `TableStyle` object, or name of the `TableStyle` object, that should be the new default.'
-          type: '<xref uid="ExcelScript!ExcelScript.TableStyle:interface" /> | string'
+          description: >-
+            The `TableStyle` object, or name of the `TableStyle` object, that
+            should be the new default.
+          type: <xref uid="ExcelScript!ExcelScript.TableStyle:interface" /> | string
       return:
         type: void
         description: ''
   - name: setDefaultTimelineStyle(newDefaultStyle)
-    uid: 'ExcelScript!ExcelScript.Workbook#setDefaultTimelineStyle:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setDefaultTimelineStyle:member(1)
     package: ExcelScript!
     fullName: setDefaultTimelineStyle(newDefaultStyle)
     summary: Sets the default timeline style for use in the parent object's scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'setDefaultTimelineStyle(newDefaultStyle: TimelineStyle | string): void;'
       parameters:
         - id: newDefaultStyle
-          description: 'The `TimelineStyle` object, or name of the `TimelineStyle` object, that should be the new default.'
-          type: '<xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" /> | string'
+          description: >-
+            The `TimelineStyle` object, or name of the `TimelineStyle` object,
+            that should be the new default.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.TimelineStyle:interface" /> |
+            string
       return:
         type: void
         description: ''
   - name: setIsDirty(isDirty)
-    uid: 'ExcelScript!ExcelScript.Workbook#setIsDirty:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setIsDirty:member(1)
     package: ExcelScript!
     fullName: setIsDirty(isDirty)
     summary: >-
-      Specifies if changes have been made since the workbook was last saved. You can set this property to `true` if you
-      want to close a modified workbook without either saving it or being prompted to save it.
+      Specifies if changes have been made since the workbook was last saved. You
+      can set this property to `true` if you want to close a modified workbook
+      without either saving it or being prompted to save it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1759,13 +1941,14 @@ methods:
         type: void
         description: ''
   - name: setLinkedWorkbookRefreshMode(linkedWorkbookRefreshMode)
-    uid: 'ExcelScript!ExcelScript.Workbook#setLinkedWorkbookRefreshMode:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setLinkedWorkbookRefreshMode:member(1)
     package: ExcelScript!
     fullName: setLinkedWorkbookRefreshMode(linkedWorkbookRefreshMode)
     summary: >-
-      Represents the update mode of the workbook links. The mode is same for all of the workbook links present in the
-      workbook.
+      Represents the update mode of the workbook links. The mode is same for all
+      of the workbook links present in the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1776,18 +1959,20 @@ methods:
       parameters:
         - id: linkedWorkbookRefreshMode
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum" />
       return:
         type: void
         description: ''
   - name: setUsePrecisionAsDisplayed(usePrecisionAsDisplayed)
-    uid: 'ExcelScript!ExcelScript.Workbook#setUsePrecisionAsDisplayed:member(1)'
+    uid: ExcelScript!ExcelScript.Workbook#setUsePrecisionAsDisplayed:member(1)
     package: ExcelScript!
     fullName: setUsePrecisionAsDisplayed(usePrecisionAsDisplayed)
     summary: >-
-      True if calculations in this workbook will be done using only the precision of the numbers as they're displayed.
-      Data will permanently lose accuracy when switching this property from `false` to `true`<!-- -->.
+      True if calculations in this workbook will be done using only the
+      precision of the numbers as they're displayed. Data will permanently lose
+      accuracy when switching this property from `false` to `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbooklinksrefreshmode.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbooklinksrefreshmode.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSEnum
 name: ExcelScript.WorkbookLinksRefreshMode
-uid: 'ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum'
+uid: ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum
 package: ExcelScript!
 fullName: ExcelScript.WorkbookLinksRefreshMode
 summary: Represents the refresh mode of the workbook links.
@@ -25,14 +25,17 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: automatic
-    uid: 'ExcelScript!ExcelScript.WorkbookLinksRefreshMode.automatic:member'
+    uid: ExcelScript!ExcelScript.WorkbookLinksRefreshMode.automatic:member
     package: ExcelScript!
-    summary: The workbook links are updated at a set interval determined by the Excel application.
+    summary: >-
+      The workbook links are updated at a set interval determined by the Excel
+      application.
   - name: manual
-    uid: 'ExcelScript!ExcelScript.WorkbookLinksRefreshMode.manual:member'
+    uid: ExcelScript!ExcelScript.WorkbookLinksRefreshMode.manual:member
     package: ExcelScript!
     summary: The workbook links are updated manually.

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbookprotection.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.WorkbookProtection
-uid: 'ExcelScript!ExcelScript.WorkbookProtection:interface'
+uid: ExcelScript!ExcelScript.WorkbookProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.WorkbookProtection
 summary: Represents the protection of a workbook object.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getProtected()
-    uid: 'ExcelScript!ExcelScript.WorkbookProtection#getProtected:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookProtection#getProtected:member(1)
     package: ExcelScript!
     fullName: getProtected()
     summary: Specifies if the workbook is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -42,11 +44,12 @@ methods:
           }
           ```
   - name: protect(password)
-    uid: 'ExcelScript!ExcelScript.WorkbookProtection#protect:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookProtection#protect:member(1)
     package: ExcelScript!
     fullName: protect(password)
     summary: Protects the workbook. Fails if the workbook has been protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -77,11 +80,12 @@ methods:
           }
           ```
   - name: unprotect(password)
-    uid: 'ExcelScript!ExcelScript.WorkbookProtection#unprotect:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookProtection#unprotect:member(1)
     package: ExcelScript!
     fullName: unprotect(password)
     summary: Unprotects the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.workbookrangeareas.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.workbookrangeareas.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.WorkbookRangeAreas
-uid: 'ExcelScript!ExcelScript.WorkbookRangeAreas:interface'
+uid: ExcelScript!ExcelScript.WorkbookRangeAreas:interface
 package: ExcelScript!
 fullName: ExcelScript.WorkbookRangeAreas
-summary: Represents a collection of one or more rectangular ranges in multiple worksheets.
+summary: >-
+  Represents a collection of one or more rectangular ranges in multiple
+  worksheets.
 remarks: |-
 
 
@@ -28,48 +30,54 @@ remarks: |-
     });
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: getAddresses()
-    uid: 'ExcelScript!ExcelScript.WorkbookRangeAreas#getAddresses:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookRangeAreas#getAddresses:member(1)
     package: ExcelScript!
     fullName: getAddresses()
     summary: >-
-      Returns an array of addresses in A1-style. Address values contain the worksheet name for each rectangular block of
-      cells (e.g., "Sheet1!A1:B4, Sheet1!D1:D4"). Read-only.
+      Returns an array of addresses in A1-style. Address values contain the
+      worksheet name for each rectangular block of cells (e.g., "Sheet1!A1:B4,
+      Sheet1!D1:D4"). Read-only.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAddresses(): string[];'
       return:
-        type: 'string[]'
+        type: string[]
         description: ''
   - name: getAreas()
-    uid: 'ExcelScript!ExcelScript.WorkbookRangeAreas#getAreas:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookRangeAreas#getAreas:member(1)
     package: ExcelScript!
     fullName: getAreas()
     summary: >-
-      Returns the `RangeAreasCollection` object. Each `RangeAreas` in the collection represent one or more rectangle
-      ranges in one worksheet.
+      Returns the `RangeAreasCollection` object. Each `RangeAreas` in the
+      collection represent one or more rectangle ranges in one worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAreas(): RangeAreas[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />[]
         description: ''
   - name: getRangeAreasBySheet(key)
-    uid: 'ExcelScript!ExcelScript.WorkbookRangeAreas#getRangeAreasBySheet:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookRangeAreas#getRangeAreasBySheet:member(1)
     package: ExcelScript!
     fullName: getRangeAreasBySheet(key)
     summary: >-
-      Returns the `RangeAreas` object based on worksheet name or ID in the collection. If the worksheet does not exist,
-      then this method returns `undefined`<!-- -->.
+      Returns the `RangeAreas` object based on worksheet name or ID in the
+      collection. If the worksheet does not exist, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -79,18 +87,19 @@ methods:
           description: The name or ID of the worksheet.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getRanges()
-    uid: 'ExcelScript!ExcelScript.WorkbookRangeAreas#getRanges:member(1)'
+    uid: ExcelScript!ExcelScript.WorkbookRangeAreas#getRanges:member(1)
     package: ExcelScript!
     fullName: getRanges()
     summary: Returns ranges that comprise this object in a `RangeCollection` object.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getRanges(): Range[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />[]
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheet.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSType
 name: ExcelScript.Worksheet
-uid: 'ExcelScript!ExcelScript.Worksheet:interface'
+uid: ExcelScript!ExcelScript.Worksheet:interface
 package: ExcelScript!
 fullName: ExcelScript.Worksheet
-summary: 'An Excel worksheet is a grid of cells. It can contain data, tables, charts, etc.'
+summary: >-
+  An Excel worksheet is a grid of cells. It can contain data, tables, charts,
+  etc.
 remarks: |-
 
 
@@ -18,16 +20,18 @@ remarks: |-
     newSheet.setTabColor("purple");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: activate()
-    uid: 'ExcelScript!ExcelScript.Worksheet#activate:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#activate:member(1)
     package: ExcelScript!
     fullName: activate()
     summary: Activate the worksheet in the Excel UI.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -54,12 +58,13 @@ methods:
             }
           }
           ```
-  - name: 'addChart(type, sourceData, seriesBy)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addChart:member(1)'
+  - name: addChart(type, sourceData, seriesBy)
+    uid: ExcelScript!ExcelScript.Worksheet#addChart:member(1)
     package: ExcelScript!
-    fullName: 'addChart(type, sourceData, seriesBy)'
+    fullName: addChart(type, sourceData, seriesBy)
     summary: Creates a new chart.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -71,18 +76,20 @@ methods:
                 ): Chart;
       parameters:
         - id: type
-          description: Represents the type of a chart. See `ExcelScript.ChartType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartType:enum" />'
+          description: >-
+            Represents the type of a chart. See `ExcelScript.ChartType` for
+            details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartType:enum" />
         - id: sourceData
           description: The `Range` object corresponding to the source data.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         - id: seriesBy
           description: >-
-            Optional. Specifies the way columns or rows are used as data series on the chart. See
-            `ExcelScript.ChartSeriesBy` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ChartSeriesBy:enum" />'
+            Optional. Specifies the way columns or rows are used as data series
+            on the chart. See `ExcelScript.ChartSeriesBy` for details.
+          type: <xref uid="ExcelScript!ExcelScript.ChartSeriesBy:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Chart:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Chart:interface" />
         description: |-
 
 
@@ -106,14 +113,16 @@ methods:
             chart.setName("ColumnChart");
           }
           ```
-  - name: 'addComment(cellAddress, content, contentType)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addComment:member(1)'
+  - name: addComment(cellAddress, content, contentType)
+    uid: ExcelScript!ExcelScript.Worksheet#addComment:member(1)
     package: ExcelScript!
-    fullName: 'addComment(cellAddress, content, contentType)'
+    fullName: addComment(cellAddress, content, contentType)
     summary: >-
-      Creates a new comment with the given content on the given cell. An `InvalidArgument` error is thrown if the
-      provided range is larger than one cell.
+      Creates a new comment with the given content on the given cell. An
+      `InvalidArgument` error is thrown if the provided range is larger than one
+      cell.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -126,39 +135,49 @@ methods:
       parameters:
         - id: cellAddress
           description: >-
-            The cell to which the comment is added. This can be a `Range` object or a string. If it's a string, it must
-            contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided
-            range is larger than one cell.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell to which the comment is added. This can be a `Range` object
+            or a string. If it's a string, it must contain the full address,
+            including the sheet name. An `InvalidArgument` error is thrown if
+            the provided range is larger than one cell.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: content
           description: >-
-            The comment's content. This can be either a string or `CommentRichContent` object. Strings are used for
-            plain text. `CommentRichContent` objects allow for other comment features, such as mentions.
-          type: '<xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" /> | string'
+            The comment's content. This can be either a string or
+            `CommentRichContent` object. Strings are used for plain text.
+            `CommentRichContent` objects allow for other comment features, such
+            as mentions.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.CommentRichContent:interface" />
+            | string
         - id: contentType
           description: >-
-            Optional. The type of content contained within the comment. The default value is enum
-            `ContentType.Plain`<!-- -->.
-          type: '<xref uid="ExcelScript!ExcelScript.ContentType:enum" />'
+            Optional. The type of content contained within the comment. The
+            default value is enum `ContentType.Plain`<!-- -->.
+          type: <xref uid="ExcelScript!ExcelScript.ContentType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: addGeometricShape(geometricShapeType)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addGeometricShape:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addGeometricShape:member(1)
     package: ExcelScript!
     fullName: addGeometricShape(geometricShapeType)
-    summary: Adds a geometric shape to the worksheet. Returns a `Shape` object that represents the new shape.
+    summary: >-
+      Adds a geometric shape to the worksheet. Returns a `Shape` object that
+      represents the new shape.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'addGeometricShape(geometricShapeType: GeometricShapeType): Shape;'
       parameters:
         - id: geometricShapeType
-          description: Represents the type of the geometric shape. See `ExcelScript.GeometricShapeType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />'
+          description: >-
+            Represents the type of the geometric shape. See
+            `ExcelScript.GeometricShapeType` for details.
+          type: <xref uid="ExcelScript!ExcelScript.GeometricShapeType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: |-
 
 
@@ -183,13 +202,14 @@ methods:
           }
           ```
   - name: addGroup(values)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addGroup:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addGroup:member(1)
     package: ExcelScript!
     fullName: addGroup(values)
     summary: >-
-      Groups a subset of shapes in this collection's worksheet. Returns a `Shape` object that represents the new group
-      of shapes.
+      Groups a subset of shapes in this collection's worksheet. Returns a
+      `Shape` object that represents the new group of shapes.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -197,16 +217,19 @@ methods:
       parameters:
         - id: values
           description: An array of shape IDs or shape objects.
-          type: 'Array&lt;string | <xref uid="ExcelScript!ExcelScript.Shape:interface" />&gt;'
+          type: >-
+            Array&lt;string | <xref
+            uid="ExcelScript!ExcelScript.Shape:interface" />&gt;
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: addHorizontalPageBreak(pageBreakRange)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addHorizontalPageBreak:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addHorizontalPageBreak:member(1)
     package: ExcelScript!
     fullName: addHorizontalPageBreak(pageBreakRange)
     summary: Adds a page break before the top-left cell of the range specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -214,28 +237,31 @@ methods:
       parameters:
         - id: pageBreakRange
           description: The range immediately after the page break to be added.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageBreak:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PageBreak:interface" />
         description: ''
   - name: addImage(base64ImageString)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addImage:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addImage:member(1)
     package: ExcelScript!
     fullName: addImage(base64ImageString)
     summary: >-
-      Creates an image from a Base64-encoded string and adds it to the worksheet. Returns the `Shape` object that
-      represents the new image.
+      Creates an image from a Base64-encoded string and adds it to the
+      worksheet. Returns the `Shape` object that represents the new image.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'addImage(base64ImageString: string): Shape;'
       parameters:
         - id: base64ImageString
-          description: A Base64-encoded string representing an image in either JPEG or PNG format.
+          description: >-
+            A Base64-encoded string representing an image in either JPEG or PNG
+            format.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: |-
 
 
@@ -281,12 +307,15 @@ methods:
             return base64;
           }
           ```
-  - name: 'addLine(startLeft, startTop, endLeft, endTop, connectorType)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addLine:member(1)'
+  - name: addLine(startLeft, startTop, endLeft, endTop, connectorType)
+    uid: ExcelScript!ExcelScript.Worksheet#addLine:member(1)
     package: ExcelScript!
-    fullName: 'addLine(startLeft, startTop, endLeft, endTop, connectorType)'
-    summary: Adds a line to worksheet. Returns a `Shape` object that represents the new line.
+    fullName: addLine(startLeft, startTop, endLeft, endTop, connectorType)
+    summary: >-
+      Adds a line to worksheet. Returns a `Shape` object that represents the new
+      line.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -300,29 +329,40 @@ methods:
                 ): Shape;
       parameters:
         - id: startLeft
-          description: 'The distance, in points, from the start of the line to the left side of the worksheet.'
+          description: >-
+            The distance, in points, from the start of the line to the left side
+            of the worksheet.
           type: number
         - id: startTop
-          description: 'The distance, in points, from the start of the line to the top of the worksheet.'
+          description: >-
+            The distance, in points, from the start of the line to the top of
+            the worksheet.
           type: number
         - id: endLeft
-          description: 'The distance, in points, from the end of the line to the left of the worksheet.'
+          description: >-
+            The distance, in points, from the end of the line to the left of the
+            worksheet.
           type: number
         - id: endTop
-          description: 'The distance, in points, from the end of the line to the top of the worksheet.'
+          description: >-
+            The distance, in points, from the end of the line to the top of the
+            worksheet.
           type: number
         - id: connectorType
-          description: Represents the connector type. See `ExcelScript.ConnectorType` for details.
-          type: '<xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />'
+          description: >-
+            Represents the connector type. See `ExcelScript.ConnectorType` for
+            details.
+          type: <xref uid="ExcelScript!ExcelScript.ConnectorType:enum" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
-  - name: 'addNamedItem(name, reference, comment)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addNamedItem:member(1)'
+  - name: addNamedItem(name, reference, comment)
+    uid: ExcelScript!ExcelScript.Worksheet#addNamedItem:member(1)
     package: ExcelScript!
-    fullName: 'addNamedItem(name, reference, comment)'
+    fullName: addNamedItem(name, reference, comment)
     summary: Adds a new name to the collection of the given scope.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -338,19 +378,22 @@ methods:
           type: string
         - id: reference
           description: The formula or the range that the name will refer to.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: comment
           description: Optional. The comment associated with the named item.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />
         description: ''
-  - name: 'addNamedItemFormulaLocal(name, formula, comment)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addNamedItemFormulaLocal:member(1)'
+  - name: addNamedItemFormulaLocal(name, formula, comment)
+    uid: ExcelScript!ExcelScript.Worksheet#addNamedItemFormulaLocal:member(1)
     package: ExcelScript!
-    fullName: 'addNamedItemFormulaLocal(name, formula, comment)'
-    summary: Adds a new name to the collection of the given scope using the user's locale for the formula.
+    fullName: addNamedItemFormulaLocal(name, formula, comment)
+    summary: >-
+      Adds a new name to the collection of the given scope using the user's
+      locale for the formula.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -371,14 +414,15 @@ methods:
           description: Optional. The comment associated with the named item.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />
         description: ''
   - name: addNamedSheetView(name)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addNamedSheetView:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addNamedSheetView:member(1)
     package: ExcelScript!
     fullName: addNamedSheetView(name)
     summary: Creates a new sheet view with the given name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -386,18 +430,22 @@ methods:
       parameters:
         - id: name
           description: >-
-            The name of the sheet view to be created. Throws an error when the provided name already exists, is empty,
-            or is a name reserved by the worksheet.
+            The name of the sheet view to be created. Throws an error when the
+            provided name already exists, is empty, or is a name reserved by the
+            worksheet.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />
         description: ''
-  - name: 'addPivotTable(name, source, destination)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addPivotTable:member(1)'
+  - name: addPivotTable(name, source, destination)
+    uid: ExcelScript!ExcelScript.Worksheet#addPivotTable:member(1)
     package: ExcelScript!
-    fullName: 'addPivotTable(name, source, destination)'
-    summary: Add a PivotTable based on the specified source data and insert it at the top-left cell of the destination range.
+    fullName: addPivotTable(name, source, destination)
+    summary: >-
+      Add a PivotTable based on the specified source data and insert it at the
+      top-left cell of the destination range.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -413,18 +461,19 @@ methods:
           type: string
         - id: source
           description: >-
-            The source data for the new PivotTable, this can either be a range (or string address including the
-            worksheet name) or a table.
+            The source data for the new PivotTable, this can either be a range
+            (or string address including the worksheet name) or a table.
           type: >-
-            <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string | <xref
-            uid="ExcelScript!ExcelScript.Table:interface" />
+            <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string |
+            <xref uid="ExcelScript!ExcelScript.Table:interface" />
         - id: destination
           description: >-
-            The cell in the upper-left corner of the PivotTable report's destination range (the range on the worksheet
-            where the resulting report will be placed).
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell in the upper-left corner of the PivotTable report's
+            destination range (the range on the worksheet where the resulting
+            report will be placed).
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />
         description: |-
 
 
@@ -452,12 +501,13 @@ methods:
             newSheet.activate();
           }
           ```
-  - name: 'addSlicer(slicerSource, sourceField, slicerDestination)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addSlicer:member(1)'
+  - name: addSlicer(slicerSource, sourceField, slicerDestination)
+    uid: ExcelScript!ExcelScript.Worksheet#addSlicer:member(1)
     package: ExcelScript!
-    fullName: 'addSlicer(slicerSource, sourceField, slicerDestination)'
+    fullName: addSlicer(slicerSource, sourceField, slicerDestination)
     summary: Adds a new slicer to the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -470,27 +520,33 @@ methods:
       parameters:
         - id: slicerSource
           description: >-
-            The data source that the new slicer will be based on. It can be a `PivotTable` object, a `Table` object, or
-            a string. When a PivotTable object is passed, the data source is the source of the `PivotTable` object. When
-            a `Table` object is passed, the data source is the `Table` object. When a string is passed, it is
+            The data source that the new slicer will be based on. It can be a
+            `PivotTable` object, a `Table` object, or a string. When a
+            PivotTable object is passed, the data source is the source of the
+            `PivotTable` object. When a `Table` object is passed, the data
+            source is the `Table` object. When a string is passed, it is
             interpreted as the name or ID of a PivotTable or table.
           type: >-
-            string | <xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> | <xref
-            uid="ExcelScript!ExcelScript.Table:interface" />
+            string | <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />
+            | <xref uid="ExcelScript!ExcelScript.Table:interface" />
         - id: sourceField
           description: >-
-            The field in the data source to filter by. It can be a `PivotField` object, a `TableColumn` object, the ID
-            of a `PivotField` or the name or ID of a `TableColumn`<!-- -->.
+            The field in the data source to filter by. It can be a `PivotField`
+            object, a `TableColumn` object, the ID of a `PivotField` or the name
+            or ID of a `TableColumn`<!-- -->.
           type: >-
-            string | <xref uid="ExcelScript!ExcelScript.PivotField:interface" /> | number | <xref
-            uid="ExcelScript!ExcelScript.TableColumn:interface" />
+            string | <xref uid="ExcelScript!ExcelScript.PivotField:interface" />
+            | number | <xref uid="ExcelScript!ExcelScript.TableColumn:interface"
+            />
         - id: slicerDestination
           description: >-
-            Optional. The worksheet in which the new slicer will be created. It can be a `Worksheet` object or the name
-            or ID of a worksheet. This parameter can be omitted if the slicer collection is retrieved from a worksheet.
-          type: 'string | <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+            Optional. The worksheet in which the new slicer will be created. It
+            can be a `Worksheet` object or the name or ID of a worksheet. This
+            parameter can be omitted if the slicer collection is retrieved from
+            a worksheet.
+          type: string | <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" />
         description: |-
 
 
@@ -519,15 +575,17 @@ methods:
             slicer.setLeft(400);
           }
           ```
-  - name: 'addTable(address, hasHeaders)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addTable:member(1)'
+  - name: addTable(address, hasHeaders)
+    uid: ExcelScript!ExcelScript.Worksheet#addTable:member(1)
     package: ExcelScript!
-    fullName: 'addTable(address, hasHeaders)'
+    fullName: addTable(address, hasHeaders)
     summary: >-
-      Creates a new table. The range object or source address determines the worksheet under which the table will be
-      added. If the table cannot be added (e.g., because the address is invalid, or the table would overlap with another
-      table), an error will be thrown.
+      Creates a new table. The range object or source address determines the
+      worksheet under which the table will be added. If the table cannot be
+      added (e.g., because the address is invalid, or the table would overlap
+      with another table), an error will be thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -535,17 +593,19 @@ methods:
       parameters:
         - id: address
           description: >-
-            A `Range` object, or a string address or name of the range representing the data source. If the address does
-            not contain a sheet name, the currently-active sheet is used.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            A `Range` object, or a string address or name of the range
+            representing the data source. If the address does not contain a
+            sheet name, the currently-active sheet is used.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
         - id: hasHeaders
           description: >-
-            A boolean value that indicates whether the data being imported has column labels. If the source does not
-            contain headers (i.e., when this property set to `false`<!-- -->), Excel will automatically generate a
-            header and shift the data down by one row.
+            A boolean value that indicates whether the data being imported has
+            column labels. If the source does not contain headers (i.e., when
+            this property set to `false`<!-- -->), Excel will automatically
+            generate a header and shift the data down by one row.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />
         description: |-
 
 
@@ -568,13 +628,14 @@ methods:
           }
           ```
   - name: addTextBox(text)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addTextBox:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addTextBox:member(1)
     package: ExcelScript!
     fullName: addTextBox(text)
     summary: >-
-      Adds a text box to the worksheet with the provided text as the content. Returns a `Shape` object that represents
-      the new text box.
+      Adds a text box to the worksheet with the provided text as the content.
+      Returns a `Shape` object that represents the new text box.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -584,14 +645,15 @@ methods:
           description: Represents the text that will be shown in the created text box.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />
         description: ''
   - name: addVerticalPageBreak(pageBreakRange)
-    uid: 'ExcelScript!ExcelScript.Worksheet#addVerticalPageBreak:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#addVerticalPageBreak:member(1)
     package: ExcelScript!
     fullName: addVerticalPageBreak(pageBreakRange)
     summary: Adds a page break before the top-left cell of the range specified.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -599,18 +661,19 @@ methods:
       parameters:
         - id: pageBreakRange
           description: The range immediately after the page break to be added.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageBreak:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PageBreak:interface" />
         description: ''
-  - name: 'addWorksheetCustomProperty(key, value)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#addWorksheetCustomProperty:member(1)'
+  - name: addWorksheetCustomProperty(key, value)
+    uid: ExcelScript!ExcelScript.Worksheet#addWorksheetCustomProperty:member(1)
     package: ExcelScript!
-    fullName: 'addWorksheetCustomProperty(key, value)'
+    fullName: addWorksheetCustomProperty(key, value)
     summary: >-
-      Adds a new custom property that maps to the provided key. This overwrites existing custom properties with that
-      key.
+      Adds a new custom property that maps to the provided key. This overwrites
+      existing custom properties with that key.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -622,38 +685,43 @@ methods:
       parameters:
         - id: key
           description: >-
-            The key that identifies the custom property object. It is case-insensitive.The key is limited to 255
-            characters (larger values will cause an `InvalidArgument` error to be thrown.)
+            The key that identifies the custom property object. It is
+            case-insensitive.The key is limited to 255 characters (larger values
+            will cause an `InvalidArgument` error to be thrown.)
           type: string
         - id: value
           description: The value of this custom property.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface" />'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface"
+          />
         description: ''
   - name: calculate(markAllDirty)
-    uid: 'ExcelScript!ExcelScript.Worksheet#calculate:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#calculate:member(1)
     package: ExcelScript!
     fullName: calculate(markAllDirty)
     summary: Calculates all cells on a worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'calculate(markAllDirty: boolean): void;'
       parameters:
         - id: markAllDirty
-          description: 'True, to mark all as dirty.'
+          description: True, to mark all as dirty.
           type: boolean
       return:
         type: void
         description: ''
-  - name: 'copy(positionType, relativeTo)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#copy:member(1)'
+  - name: copy(positionType, relativeTo)
+    uid: ExcelScript!ExcelScript.Worksheet#copy:member(1)
     package: ExcelScript!
-    fullName: 'copy(positionType, relativeTo)'
+    fullName: copy(positionType, relativeTo)
     summary: Copies a worksheet and places it at the specified position.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -665,16 +733,18 @@ methods:
       parameters:
         - id: positionType
           description: >-
-            The location in the workbook to place the newly created worksheet. The default value is "None", which
-            inserts the worksheet at the beginning of the worksheet.
-          type: '<xref uid="ExcelScript!ExcelScript.WorksheetPositionType:enum" />'
+            The location in the workbook to place the newly created worksheet.
+            The default value is "None", which inserts the worksheet at the
+            beginning of the worksheet.
+          type: <xref uid="ExcelScript!ExcelScript.WorksheetPositionType:enum" />
         - id: relativeTo
           description: >-
-            The existing worksheet which determines the newly created worksheet's position. This is only needed if
-            `positionType` is "Before" or "After".
-          type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+            The existing worksheet which determines the newly created
+            worksheet's position. This is only needed if `positionType` is
+            "Before" or "After".
+          type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: |-
 
 
@@ -701,14 +771,16 @@ methods:
           }
           ```
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.Worksheet#delete:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: >-
-      Deletes the worksheet from the workbook. Note that if the worksheet's visibility is set to "VeryHidden", the
-      delete operation will fail with an `InvalidOperation` exception. You should first change its visibility to hidden
-      or visible before deleting it.
+      Deletes the worksheet from the workbook. Note that if the worksheet's
+      visibility is set to "VeryHidden", the delete operation will fail with an
+      `InvalidOperation` exception. You should first change its visibility to
+      hidden or visible before deleting it.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -733,27 +805,31 @@ methods:
           }
           ```
   - name: enterTemporaryNamedSheetView()
-    uid: 'ExcelScript!ExcelScript.Worksheet#enterTemporaryNamedSheetView:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#enterTemporaryNamedSheetView:member(1)
     package: ExcelScript!
     fullName: enterTemporaryNamedSheetView()
     summary: >-
-      Creates and activates a new temporary sheet view. Temporary views are removed when closing the application,
-      exiting the temporary view with the exit method, or switching to another sheet view. The temporary sheet view can
-      also be accessed with the empty string (""), if the temporary view exists.
+      Creates and activates a new temporary sheet view. Temporary views are
+      removed when closing the application, exiting the temporary view with the
+      exit method, or switching to another sheet view. The temporary sheet view
+      can also be accessed with the empty string (""), if the temporary view
+      exists.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'enterTemporaryNamedSheetView(): NamedSheetView;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />
         description: ''
   - name: exitActiveNamedSheetView()
-    uid: 'ExcelScript!ExcelScript.Worksheet#exitActiveNamedSheetView:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#exitActiveNamedSheetView:member(1)
     package: ExcelScript!
     fullName: exitActiveNamedSheetView()
     summary: Exits the currently active sheet view.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -761,14 +837,16 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'findAll(text, criteria)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#findAll:member(1)'
+  - name: findAll(text, criteria)
+    uid: ExcelScript!ExcelScript.Worksheet#findAll:member(1)
     package: ExcelScript!
-    fullName: 'findAll(text, criteria)'
+    fullName: findAll(text, criteria)
     summary: >-
-      Finds all occurrences of the given string based on the criteria specified and returns them as a `RangeAreas`
-      object, comprising one or more rectangular ranges.
+      Finds all occurrences of the given string based on the criteria specified
+      and returns them as a `RangeAreas` object, comprising one or more
+      rectangular ranges.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -779,11 +857,13 @@ methods:
           type: string
         - id: criteria
           description: >-
-            Additional search criteria, including whether the search needs to match the entire cell or be
-            case-sensitive.
-          type: '<xref uid="ExcelScript!ExcelScript.WorksheetSearchCriteria:interface" />'
+            Additional search criteria, including whether the search needs to
+            match the entire cell or be case-sensitive.
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.WorksheetSearchCriteria:interface" />
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: |-
 
 
@@ -805,30 +885,32 @@ methods:
           }
           ```
   - name: getActiveNamedSheetView()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getActiveNamedSheetView:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getActiveNamedSheetView:member(1)
     package: ExcelScript!
     fullName: getActiveNamedSheetView()
     summary: Gets the worksheet's currently active sheet view.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getActiveNamedSheetView(): NamedSheetView;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />
         description: ''
   - name: getAutoFilter()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getAutoFilter:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getAutoFilter:member(1)
     package: ExcelScript!
     fullName: getAutoFilter()
     summary: Represents the `AutoFilter` object of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAutoFilter(): AutoFilter;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.AutoFilter:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.AutoFilter:interface" />
         description: |-
 
 
@@ -852,14 +934,16 @@ methods:
             });
           }
           ```
-  - name: 'getCell(row, column)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#getCell:member(1)'
+  - name: getCell(row, column)
+    uid: ExcelScript!ExcelScript.Worksheet#getCell:member(1)
     package: ExcelScript!
-    fullName: 'getCell(row, column)'
+    fullName: getCell(row, column)
     summary: >-
-      Gets the `Range` object containing the single cell based on row and column numbers. The cell can be outside the
-      bounds of its parent range, so long as it stays within the worksheet grid.
+      Gets the `Range` object containing the single cell based on row and column
+      numbers. The cell can be outside the bounds of its parent range, so long
+      as it stays within the worksheet grid.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -872,16 +956,18 @@ methods:
           description: The column number of the cell to be retrieved. Zero-indexed.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getChart(name)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getChart:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getChart:member(1)
     package: ExcelScript!
     fullName: getChart(name)
     summary: >-
-      Gets a chart using its name. If there are multiple charts with the same name, the first one will be returned. If
-      the chart doesn't exist, then this method returns `undefined`<!-- -->.
+      Gets a chart using its name. If there are multiple charts with the same
+      name, the first one will be returned. If the chart doesn't exist, then
+      this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -891,7 +977,7 @@ methods:
           description: Name of the chart to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Chart:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Chart:interface" /> | undefined
         description: |-
 
 
@@ -913,26 +999,28 @@ methods:
           }
           ```
   - name: getCharts()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getCharts:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getCharts:member(1)
     package: ExcelScript!
     fullName: getCharts()
     summary: Returns a collection of charts that are part of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCharts(): Chart[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Chart:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Chart:interface" />[]
         description: ''
   - name: getComment(commentId)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getComment:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getComment:member(1)
     package: ExcelScript!
     fullName: getComment(commentId)
     summary: >-
-      Gets a comment from the collection based on its ID. If the comment object does not exist, then this method returns
-      `undefined`<!-- -->.
+      Gets a comment from the collection based on its ID. If the comment object
+      does not exist, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -942,14 +1030,17 @@ methods:
           description: The identifier for the comment.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" /> | undefined
         description: ''
   - name: getCommentByCell(cellAddress)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getCommentByCell:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getCommentByCell:member(1)
     package: ExcelScript!
     fullName: getCommentByCell(cellAddress)
-    summary: 'Gets the comment from the specified cell. If there is no comment in the cell, an error is thrown.'
+    summary: >-
+      Gets the comment from the specified cell. If there is no comment in the
+      cell, an error is thrown.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -957,19 +1048,21 @@ methods:
       parameters:
         - id: cellAddress
           description: >-
-            The cell which the comment is on. This can be a `Range` object or a string. If it's a string, it must
-            contain the full address, including the sheet name. An `InvalidArgument` error is thrown if the provided
-            range is larger than one cell.
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+            The cell which the comment is on. This can be a `Range` object or a
+            string. If it's a string, it must contain the full address,
+            including the sheet name. An `InvalidArgument` error is thrown if
+            the provided range is larger than one cell.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: getCommentByReplyId(replyId)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getCommentByReplyId:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getCommentByReplyId:member(1)
     package: ExcelScript!
     fullName: getCommentByReplyId(replyId)
     summary: Gets the comment to which the given reply is connected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -979,42 +1072,48 @@ methods:
           description: The identifier of comment reply.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />
         description: ''
   - name: getComments()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getComments:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getComments:member(1)
     package: ExcelScript!
     fullName: getComments()
     summary: Returns a collection of all the Comments objects on the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getComments(): Comment[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Comment:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Comment:interface" />[]
         description: ''
   - name: getCustomProperties()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getCustomProperties:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getCustomProperties:member(1)
     package: ExcelScript!
     fullName: getCustomProperties()
     summary: Gets a collection of worksheet-level custom properties.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getCustomProperties(): WorksheetCustomProperty[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface" />[]'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface"
+          />[]
         description: ''
   - name: getEnableCalculation()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getEnableCalculation:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getEnableCalculation:member(1)
     package: ExcelScript!
     fullName: getEnableCalculation()
     summary: >-
-      Determines if Excel should recalculate the worksheet when necessary. True if Excel recalculates the worksheet when
-      necessary. False if Excel doesn't recalculate the sheet.
+      Determines if Excel should recalculate the worksheet when necessary. True
+      if Excel recalculates the worksheet when necessary. False if Excel doesn't
+      recalculate the sheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1023,39 +1122,47 @@ methods:
         type: boolean
         description: ''
   - name: getFreezePanes()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getFreezePanes:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getFreezePanes:member(1)
     package: ExcelScript!
     fullName: getFreezePanes()
-    summary: Gets an object that can be used to manipulate frozen panes on the worksheet.
+    summary: >-
+      Gets an object that can be used to manipulate frozen panes on the
+      worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getFreezePanes(): WorksheetFreezePanes;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetFreezePanes:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorksheetFreezePanes:interface" />
         description: ''
   - name: getHorizontalPageBreaks()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getHorizontalPageBreaks:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getHorizontalPageBreaks:member(1)
     package: ExcelScript!
     fullName: getHorizontalPageBreaks()
-    summary: Gets the horizontal page break collection for the worksheet. This collection only contains manual page breaks.
+    summary: >-
+      Gets the horizontal page break collection for the worksheet. This
+      collection only contains manual page breaks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getHorizontalPageBreaks(): PageBreak[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageBreak:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PageBreak:interface" />[]
         description: ''
   - name: getId()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getId:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getId:member(1)
     package: ExcelScript!
     fullName: getId()
     summary: >-
-      Returns a value that uniquely identifies the worksheet in a given workbook. The value of the identifier remains
-      the same even when the worksheet is renamed or moved.
+      Returns a value that uniquely identifies the worksheet in a given
+      workbook. The value of the identifier remains the same even when the
+      worksheet is renamed or moved.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1064,11 +1171,14 @@ methods:
         type: string
         description: ''
   - name: getName()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getName:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getName:member(1)
     package: ExcelScript!
     fullName: getName()
-    summary: The display name of the worksheet. The name must be fewer than 32 characters.
+    summary: >-
+      The display name of the worksheet. The name must be fewer than 32
+      characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1099,13 +1209,14 @@ methods:
           }
           ```
   - name: getNamedItem(name)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getNamedItem:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getNamedItem:member(1)
     package: ExcelScript!
     fullName: getNamedItem(name)
     summary: >-
-      Gets a `NamedItem` object using its name. If the object does not exist, then this method returns `undefined`<!--
-      -->.
+      Gets a `NamedItem` object using its name. If the object does not exist,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1115,16 +1226,18 @@ methods:
           description: Nameditem name.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" /> | undefined
         description: ''
   - name: getNamedSheetView(key)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getNamedSheetView:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getNamedSheetView:member(1)
     package: ExcelScript!
     fullName: getNamedSheetView(key)
     summary: >-
-      Gets a sheet view using its name. If the sheet view object does not exist, then this method returns an object with
-      its `isNullObject` property set to `true`<!-- -->.
+      Gets a sheet view using its name. If the sheet view object does not exist,
+      then this method returns an object with its `isNullObject` property set to
+      `true`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1132,69 +1245,77 @@ methods:
       parameters:
         - id: key
           description: >-
-            The case-sensitive name of the sheet view. Use the empty string ("") to get the temporary sheet view, if the
-            temporary view exists.
+            The case-sensitive name of the sheet view. Use the empty string ("")
+            to get the temporary sheet view, if the temporary view exists.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" /> |
+          undefined
         description: ''
   - name: getNamedSheetViews()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getNamedSheetViews:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getNamedSheetViews:member(1)
     package: ExcelScript!
     fullName: getNamedSheetViews()
     summary: Returns a collection of sheet views that are present in the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNamedSheetViews(): NamedSheetView[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.NamedSheetView:interface" />[]
         description: ''
   - name: getNames()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getNames:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getNames:member(1)
     package: ExcelScript!
     fullName: getNames()
     summary: Collection of names scoped to the current worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNames(): NamedItem[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.NamedItem:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.NamedItem:interface" />[]
         description: ''
   - name: getNext(visibleOnly)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getNext:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getNext:member(1)
     package: ExcelScript!
     fullName: getNext(visibleOnly)
     summary: >-
-      Gets the worksheet that follows this one. If there are no worksheets following this one, then this method returns
-      `undefined`<!-- -->.
+      Gets the worksheet that follows this one. If there are no worksheets
+      following this one, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getNext(visibleOnly?: boolean): Worksheet;'
       parameters:
         - id: visibleOnly
-          description: 'Optional. If `true`<!-- -->, considers only visible worksheets, skipping over any hidden ones.'
+          description: >-
+            Optional. If `true`<!-- -->, considers only visible worksheets,
+            skipping over any hidden ones.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: getPageLayout()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getPageLayout:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getPageLayout:member(1)
     package: ExcelScript!
     fullName: getPageLayout()
     summary: Gets the `PageLayout` object of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPageLayout(): PageLayout;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageLayout:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.PageLayout:interface" />
         description: |-
 
 
@@ -1215,11 +1336,14 @@ methods:
           }
           ```
   - name: getPivotTable(name)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getPivotTable:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getPivotTable:member(1)
     package: ExcelScript!
     fullName: getPivotTable(name)
-    summary: 'Gets a PivotTable by name. If the PivotTable does not exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a PivotTable by name. If the PivotTable does not exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1229,27 +1353,31 @@ methods:
           description: Name of the PivotTable to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.PivotTable:interface" /> |
+          undefined
         description: ''
   - name: getPivotTables()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getPivotTables:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getPivotTables:member(1)
     package: ExcelScript!
     fullName: getPivotTables()
     summary: Collection of PivotTables that are part of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPivotTables(): PivotTable[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PivotTable:interface" />[]
         description: ''
   - name: getPosition()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getPosition:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getPosition:member(1)
     package: ExcelScript!
     fullName: getPosition()
     summary: The zero-based position of the worksheet within the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1258,36 +1386,40 @@ methods:
         type: number
         description: ''
   - name: getPrevious(visibleOnly)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getPrevious:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getPrevious:member(1)
     package: ExcelScript!
     fullName: getPrevious(visibleOnly)
     summary: >-
-      Gets the worksheet that precedes this one. If there are no previous worksheets, then this method returns
-      `undefined`<!-- -->.
+      Gets the worksheet that precedes this one. If there are no previous
+      worksheets, then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getPrevious(visibleOnly?: boolean): Worksheet;'
       parameters:
         - id: visibleOnly
-          description: 'Optional. If `true`<!-- -->, considers only visible worksheets, skipping over any hidden ones.'
+          description: >-
+            Optional. If `true`<!-- -->, considers only visible worksheets,
+            skipping over any hidden ones.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Worksheet:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Worksheet:interface" />
         description: ''
   - name: getProtection()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getProtection:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getProtection:member(1)
     package: ExcelScript!
     fullName: getProtection()
     summary: Returns the sheet protection object for a worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getProtection(): WorksheetProtection;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtection:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.WorksheetProtection:interface" />
         description: |-
 
 
@@ -1312,11 +1444,14 @@ methods:
           }
           ```
   - name: getRange(address)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getRange:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getRange:member(1)
     package: ExcelScript!
     fullName: getRange(address)
-    summary: 'Gets the `Range` object, representing a single rectangular block of cells, specified by the address or name.'
+    summary: >-
+      Gets the `Range` object, representing a single rectangular block of cells,
+      specified by the address or name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1324,12 +1459,14 @@ methods:
       parameters:
         - id: address
           description: >-
-            Optional. The string representing the address or name of the range. For example, "A1:B2". If not specified,
-            the entire worksheet range is returned. The `address` has a limit of 8192 characters. If the address exceeds
-            the character limit, this method returns an `InvalidArgument` error.
+            Optional. The string representing the address or name of the range.
+            For example, "A1:B2". If not specified, the entire worksheet range
+            is returned. The `address` has a limit of 8192 characters. If the
+            address exceeds the character limit, this method returns an
+            `InvalidArgument` error.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: |-
 
 
@@ -1350,14 +1487,15 @@ methods:
             console.log(range.getValue());
           }
           ```
-  - name: 'getRangeByIndexes(startRow, startColumn, rowCount, columnCount)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#getRangeByIndexes:member(1)'
+  - name: getRangeByIndexes(startRow, startColumn, rowCount, columnCount)
+    uid: ExcelScript!ExcelScript.Worksheet#getRangeByIndexes:member(1)
     package: ExcelScript!
-    fullName: 'getRangeByIndexes(startRow, startColumn, rowCount, columnCount)'
+    fullName: getRangeByIndexes(startRow, startColumn, rowCount, columnCount)
     summary: >-
-      Gets the `Range` object beginning at a particular row index and column index, and spanning a certain number of
-      rows and columns.
+      Gets the `Range` object beginning at a particular row index and column
+      index, and spanning a certain number of rows and columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1382,16 +1520,17 @@ methods:
           description: Number of columns to include in the range.
           type: number
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getRanges(address)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getRanges:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getRanges:member(1)
     package: ExcelScript!
     fullName: getRanges(address)
     summary: >-
-      Gets the `RangeAreas` object, representing one or more blocks of rectangular ranges, specified by the address or
-      name.
+      Gets the `RangeAreas` object, representing one or more blocks of
+      rectangular ranges, specified by the address or name.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1399,21 +1538,23 @@ methods:
       parameters:
         - id: address
           description: >-
-            Optional. A string containing the comma-separated or semicolon-separated addresses or names of the
-            individual ranges. For example, "A1:B2, A5:B5" or "A1:B2; A5:B5". If not specified, a `RangeAreas` object
-            for the entire worksheet is returned.
+            Optional. A string containing the comma-separated or
+            semicolon-separated addresses or names of the individual ranges. For
+            example, "A1:B2, A5:B5" or "A1:B2; A5:B5". If not specified, a
+            `RangeAreas` object for the entire worksheet is returned.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.RangeAreas:interface" />
         description: ''
   - name: getShape(key)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getShape:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getShape:member(1)
     package: ExcelScript!
     fullName: getShape(key)
     summary: >-
-      Gets a shape using its name or ID. If the shape object does not exist, then this method returns `undefined`<!--
-      -->.
+      Gets a shape using its name or ID. If the shape object does not exist,
+      then this method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1423,27 +1564,31 @@ methods:
           description: The name or ID of the shape to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" /> | undefined
         description: ''
   - name: getShapes()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getShapes:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getShapes:member(1)
     package: ExcelScript!
     fullName: getShapes()
     summary: Returns the collection of all the Shape objects on the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getShapes(): Shape[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Shape:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Shape:interface" />[]
         description: ''
   - name: getShowDataTypeIcons()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getShowDataTypeIcons:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getShowDataTypeIcons:member(1)
     package: ExcelScript!
     fullName: getShowDataTypeIcons()
-    summary: 'Specifies if data type icons are visible on the worksheet. By default, data type icons are visible.'
+    summary: >-
+      Specifies if data type icons are visible on the worksheet. By default,
+      data type icons are visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1452,11 +1597,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowGridlines()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getShowGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getShowGridlines:member(1)
     package: ExcelScript!
     fullName: getShowGridlines()
     summary: Specifies if gridlines are visible to the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1465,11 +1611,12 @@ methods:
         type: boolean
         description: ''
   - name: getShowHeadings()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getShowHeadings:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getShowHeadings:member(1)
     package: ExcelScript!
     fullName: getShowHeadings()
     summary: Specifies if headings are visible to the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1478,11 +1625,14 @@ methods:
         type: boolean
         description: ''
   - name: getSlicer(key)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getSlicer:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getSlicer:member(1)
     package: ExcelScript!
     fullName: getSlicer(key)
-    summary: 'Gets a slicer using its name or ID. If the slicer doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a slicer using its name or ID. If the slicer doesn't exist, then this
+      method returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1492,27 +1642,31 @@ methods:
           description: Name or ID of the slicer to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" /> | undefined
         description: ''
   - name: getSlicers()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getSlicers:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getSlicers:member(1)
     package: ExcelScript!
     fullName: getSlicers()
     summary: Returns a collection of slicers that are part of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSlicers(): Slicer[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Slicer:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Slicer:interface" />[]
         description: ''
   - name: getStandardHeight()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getStandardHeight:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getStandardHeight:member(1)
     package: ExcelScript!
     fullName: getStandardHeight()
-    summary: 'Returns the standard (default) height of all the rows in the worksheet, in points.'
+    summary: >-
+      Returns the standard (default) height of all the rows in the worksheet, in
+      points.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1521,14 +1675,16 @@ methods:
         type: number
         description: ''
   - name: getStandardWidth()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getStandardWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getStandardWidth:member(1)
     package: ExcelScript!
     fullName: getStandardWidth()
     summary: >-
-      Specifies the standard (default) width of all the columns in the worksheet. One unit of column width is equal to
-      the width of one character in the Normal style. For proportional fonts, the width of the character 0 (zero) is
-      used.
+      Specifies the standard (default) width of all the columns in the
+      worksheet. One unit of column width is equal to the width of one character
+      in the Normal style. For proportional fonts, the width of the character 0
+      (zero) is used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1537,15 +1693,18 @@ methods:
         type: number
         description: ''
   - name: getTabColor()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getTabColor:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getTabColor:member(1)
     package: ExcelScript!
     fullName: getTabColor()
     summary: >-
-      The tab color of the worksheet. When retrieving the tab color, if the worksheet is invisible, the value will be
-      `null`<!-- -->. If the worksheet is visible but the tab color is set to auto, an empty string will be returned.
-      Otherwise, the property will be set to a color, in the form \#RRGGBB (e.g., "FFA500"). When setting the color, use
-      an empty-string to set an "auto" color, or a real color otherwise.
+      The tab color of the worksheet. When retrieving the tab color, if the
+      worksheet is invisible, the value will be `null`<!-- -->. If the worksheet
+      is visible but the tab color is set to auto, an empty string will be
+      returned. Otherwise, the property will be set to a color, in the form
+      \#RRGGBB (e.g., "FFA500"). When setting the color, use an empty-string to
+      set an "auto" color, or a real color otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1554,14 +1713,16 @@ methods:
         type: string
         description: ''
   - name: getTabId()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getTabId:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getTabId:member(1)
     package: ExcelScript!
     fullName: getTabId()
     summary: >-
-      Returns a value representing this worksheet that can be read by Open Office XML. This is an integer value, which
-      is different from `worksheet.id` (which returns a globally unique identifier) and `worksheet.name` (which returns
-      a value such as "Sheet1").
+      Returns a value representing this worksheet that can be read by Open
+      Office XML. This is an integer value, which is different from
+      `worksheet.id` (which returns a globally unique identifier) and
+      `worksheet.name` (which returns a value such as "Sheet1").
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1570,11 +1731,14 @@ methods:
         type: number
         description: ''
   - name: getTable(key)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getTable:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getTable:member(1)
     package: ExcelScript!
     fullName: getTable(key)
-    summary: 'Gets a table by name or ID. If the table doesn''t exist, then this method returns `undefined`<!-- -->.'
+    summary: >-
+      Gets a table by name or ID. If the table doesn't exist, then this method
+      returns `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1584,27 +1748,29 @@ methods:
           description: Name or ID of the table to be retrieved.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" /> | undefined'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" /> | undefined
         description: ''
   - name: getTables()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getTables:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getTables:member(1)
     package: ExcelScript!
     fullName: getTables()
     summary: Collection of tables that are part of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getTables(): Table[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Table:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.Table:interface" />[]
         description: ''
   - name: getUsedRange(valuesOnly)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getUsedRange:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getUsedRange:member(1)
     package: ExcelScript!
     fullName: getUsedRange(valuesOnly)
     summary: ''
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1614,42 +1780,48 @@ methods:
           description: Optional. Considers only cells with values as used cells.
           type: boolean
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: getVerticalPageBreaks()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getVerticalPageBreaks:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getVerticalPageBreaks:member(1)
     package: ExcelScript!
     fullName: getVerticalPageBreaks()
-    summary: Gets the vertical page break collection for the worksheet. This collection only contains manual page breaks.
+    summary: >-
+      Gets the vertical page break collection for the worksheet. This collection
+      only contains manual page breaks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVerticalPageBreaks(): PageBreak[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.PageBreak:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.PageBreak:interface" />[]
         description: ''
   - name: getVisibility()
-    uid: 'ExcelScript!ExcelScript.Worksheet#getVisibility:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getVisibility:member(1)
     package: ExcelScript!
     fullName: getVisibility()
     summary: The visibility of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getVisibility(): SheetVisibility;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.SheetVisibility:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.SheetVisibility:enum" />
         description: ''
   - name: getWorksheetCustomProperty(key)
-    uid: 'ExcelScript!ExcelScript.Worksheet#getWorksheetCustomProperty:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#getWorksheetCustomProperty:member(1)
     package: ExcelScript!
     fullName: getWorksheetCustomProperty(key)
     summary: >-
-      Gets a custom property object by its key, which is case-insensitive. If the custom property doesn't exist, then
-      this method returns `undefined`<!-- -->.
+      Gets a custom property object by its key, which is case-insensitive. If
+      the custom property doesn't exist, then this method returns
+      `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1659,17 +1831,22 @@ methods:
                 ): WorksheetCustomProperty | undefined;
       parameters:
         - id: key
-          description: The key that identifies the custom property object. It is case-insensitive.
+          description: >-
+            The key that identifies the custom property object. It is
+            case-insensitive.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.WorksheetCustomProperty:interface"
+          /> | undefined
         description: ''
   - name: refreshAllPivotTables()
-    uid: 'ExcelScript!ExcelScript.Worksheet#refreshAllPivotTables:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#refreshAllPivotTables:member(1)
     package: ExcelScript!
     fullName: refreshAllPivotTables()
     summary: Refreshes all the pivot tables in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1678,11 +1855,12 @@ methods:
         type: void
         description: ''
   - name: removeAllHorizontalPageBreaks()
-    uid: 'ExcelScript!ExcelScript.Worksheet#removeAllHorizontalPageBreaks:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#removeAllHorizontalPageBreaks:member(1)
     package: ExcelScript!
     fullName: removeAllHorizontalPageBreaks()
     summary: Resets all manual page breaks in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1691,11 +1869,12 @@ methods:
         type: void
         description: ''
   - name: removeAllVerticalPageBreaks()
-    uid: 'ExcelScript!ExcelScript.Worksheet#removeAllVerticalPageBreaks:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#removeAllVerticalPageBreaks:member(1)
     package: ExcelScript!
     fullName: removeAllVerticalPageBreaks()
     summary: Resets all manual page breaks in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1703,12 +1882,15 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'replaceAll(text, replacement, criteria)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#replaceAll:member(1)'
+  - name: replaceAll(text, replacement, criteria)
+    uid: ExcelScript!ExcelScript.Worksheet#replaceAll:member(1)
     package: ExcelScript!
-    fullName: 'replaceAll(text, replacement, criteria)'
-    summary: Finds and replaces the given string based on the criteria specified within the current worksheet.
+    fullName: replaceAll(text, replacement, criteria)
+    summary: >-
+      Finds and replaces the given string based on the criteria specified within
+      the current worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1727,18 +1909,20 @@ methods:
           type: string
         - id: criteria
           description: Additional replacement criteria.
-          type: '<xref uid="ExcelScript!ExcelScript.ReplaceCriteria:interface" />'
+          type: <xref uid="ExcelScript!ExcelScript.ReplaceCriteria:interface" />
       return:
         type: number
         description: ''
   - name: setEnableCalculation(enableCalculation)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setEnableCalculation:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setEnableCalculation:member(1)
     package: ExcelScript!
     fullName: setEnableCalculation(enableCalculation)
     summary: >-
-      Determines if Excel should recalculate the worksheet when necessary. True if Excel recalculates the worksheet when
-      necessary. False if Excel doesn't recalculate the sheet.
+      Determines if Excel should recalculate the worksheet when necessary. True
+      if Excel recalculates the worksheet when necessary. False if Excel doesn't
+      recalculate the sheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1751,11 +1935,14 @@ methods:
         type: void
         description: ''
   - name: setName(name)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setName:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setName:member(1)
     package: ExcelScript!
     fullName: setName(name)
-    summary: The display name of the worksheet. The name must be fewer than 32 characters.
+    summary: >-
+      The display name of the worksheet. The name must be fewer than 32
+      characters.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1784,11 +1971,12 @@ methods:
           }
           ```
   - name: setPosition(position)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setPosition:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setPosition:member(1)
     package: ExcelScript!
     fullName: setPosition(position)
     summary: The zero-based position of the worksheet within the workbook.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1816,11 +2004,14 @@ methods:
           }
           ```
   - name: setShowDataTypeIcons(showDataTypeIcons)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setShowDataTypeIcons:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setShowDataTypeIcons:member(1)
     package: ExcelScript!
     fullName: setShowDataTypeIcons(showDataTypeIcons)
-    summary: 'Specifies if data type icons are visible on the worksheet. By default, data type icons are visible.'
+    summary: >-
+      Specifies if data type icons are visible on the worksheet. By default,
+      data type icons are visible.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1833,11 +2024,12 @@ methods:
         type: void
         description: ''
   - name: setShowGridlines(showGridlines)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setShowGridlines:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setShowGridlines:member(1)
     package: ExcelScript!
     fullName: setShowGridlines(showGridlines)
     summary: Specifies if gridlines are visible to the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1850,11 +2042,12 @@ methods:
         type: void
         description: ''
   - name: setShowHeadings(showHeadings)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setShowHeadings:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setShowHeadings:member(1)
     package: ExcelScript!
     fullName: setShowHeadings(showHeadings)
     summary: Specifies if headings are visible to the user.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1867,14 +2060,16 @@ methods:
         type: void
         description: ''
   - name: setStandardWidth(standardWidth)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setStandardWidth:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setStandardWidth:member(1)
     package: ExcelScript!
     fullName: setStandardWidth(standardWidth)
     summary: >-
-      Specifies the standard (default) width of all the columns in the worksheet. One unit of column width is equal to
-      the width of one character in the Normal style. For proportional fonts, the width of the character 0 (zero) is
-      used.
+      Specifies the standard (default) width of all the columns in the
+      worksheet. One unit of column width is equal to the width of one character
+      in the Normal style. For proportional fonts, the width of the character 0
+      (zero) is used.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1887,15 +2082,18 @@ methods:
         type: void
         description: ''
   - name: setTabColor(tabColor)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setTabColor:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setTabColor:member(1)
     package: ExcelScript!
     fullName: setTabColor(tabColor)
     summary: >-
-      The tab color of the worksheet. When retrieving the tab color, if the worksheet is invisible, the value will be
-      `null`<!-- -->. If the worksheet is visible but the tab color is set to auto, an empty string will be returned.
-      Otherwise, the property will be set to a color, in the form \#RRGGBB (e.g., "FFA500"). When setting the color, use
-      an empty-string to set an "auto" color, or a real color otherwise.
+      The tab color of the worksheet. When retrieving the tab color, if the
+      worksheet is invisible, the value will be `null`<!-- -->. If the worksheet
+      is visible but the tab color is set to auto, an empty string will be
+      returned. Otherwise, the property will be set to a color, in the form
+      \#RRGGBB (e.g., "FFA500"). When setting the color, use an empty-string to
+      set an "auto" color, or a real color otherwise.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1927,11 +2125,12 @@ methods:
           }
           ```
   - name: setVisibility(visibility)
-    uid: 'ExcelScript!ExcelScript.Worksheet#setVisibility:member(1)'
+    uid: ExcelScript!ExcelScript.Worksheet#setVisibility:member(1)
     package: ExcelScript!
     fullName: setVisibility(visibility)
     summary: The visibility of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -1939,7 +2138,7 @@ methods:
       parameters:
         - id: visibility
           description: ''
-          type: '<xref uid="ExcelScript!ExcelScript.SheetVisibility:enum" />'
+          type: <xref uid="ExcelScript!ExcelScript.SheetVisibility:enum" />
       return:
         type: void
         description: |-
@@ -1959,16 +2158,19 @@ methods:
             });
           }
           ```
-  - name: 'showOutlineLevels(rowLevels, columnLevels)'
-    uid: 'ExcelScript!ExcelScript.Worksheet#showOutlineLevels:member(1)'
+  - name: showOutlineLevels(rowLevels, columnLevels)
+    uid: ExcelScript!ExcelScript.Worksheet#showOutlineLevels:member(1)
     package: ExcelScript!
-    fullName: 'showOutlineLevels(rowLevels, columnLevels)'
+    fullName: showOutlineLevels(rowLevels, columnLevels)
     summary: >-
-      Shows row or column groups by their outline levels. Outlines groups and summarizes a list of data in the
-      worksheet. The `rowLevels` and `columnLevels` parameters specify how many levels of the outline will be displayed.
-      The acceptable argument range is between 0 and 8. A value of 0 does not change the current display. A value
-      greater than the current number of levels displays all the levels.
+      Shows row or column groups by their outline levels. Outlines groups and
+      summarizes a list of data in the worksheet. The `rowLevels` and
+      `columnLevels` parameters specify how many levels of the outline will be
+      displayed. The acceptable argument range is between 0 and 8. A value of 0
+      does not change the current display. A value greater than the current
+      number of levels displays all the levels.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetcustomproperty.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetcustomproperty.yml
@@ -1,20 +1,22 @@
 ### YamlMime:TSType
 name: ExcelScript.WorksheetCustomProperty
-uid: 'ExcelScript!ExcelScript.WorksheetCustomProperty:interface'
+uid: ExcelScript!ExcelScript.WorksheetCustomProperty:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetCustomProperty
 summary: Represents a worksheet-level custom property.
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: delete()
-    uid: 'ExcelScript!ExcelScript.WorksheetCustomProperty#delete:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetCustomProperty#delete:member(1)
     package: ExcelScript!
     fullName: delete()
     summary: Deletes the custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -23,13 +25,15 @@ methods:
         type: void
         description: ''
   - name: getKey()
-    uid: 'ExcelScript!ExcelScript.WorksheetCustomProperty#getKey:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetCustomProperty#getKey:member(1)
     package: ExcelScript!
     fullName: getKey()
     summary: >-
-      Gets the key of the custom property. Custom property keys are case-insensitive. The key is limited to 255
-      characters (larger values will cause an `InvalidArgument` error to be thrown.)
+      Gets the key of the custom property. Custom property keys are
+      case-insensitive. The key is limited to 255 characters (larger values will
+      cause an `InvalidArgument` error to be thrown.)
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -38,11 +42,12 @@ methods:
         type: string
         description: ''
   - name: getValue()
-    uid: 'ExcelScript!ExcelScript.WorksheetCustomProperty#getValue:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetCustomProperty#getValue:member(1)
     package: ExcelScript!
     fullName: getValue()
     summary: Specifies the value of the custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -51,11 +56,12 @@ methods:
         type: string
         description: ''
   - name: setValue(value)
-    uid: 'ExcelScript!ExcelScript.WorksheetCustomProperty#setValue:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetCustomProperty#setValue:member(1)
     package: ExcelScript!
     fullName: setValue(value)
     summary: Specifies the value of the custom property.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetfreezepanes.yml
@@ -1,89 +1,100 @@
 ### YamlMime:TSType
 name: ExcelScript.WorksheetFreezePanes
-uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes:interface'
+uid: ExcelScript!ExcelScript.WorksheetFreezePanes:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetFreezePanes
 summary: ''
 remarks: ''
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
   - name: freezeAt(frozenRange)
-    uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes#freezeAt:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetFreezePanes#freezeAt:member(1)
     package: ExcelScript!
     fullName: freezeAt(frozenRange)
     summary: >-
-      Sets the frozen cells in the active worksheet view. The range provided corresponds to cells that will be frozen in
-      the top- and left-most pane.
+      Sets the frozen cells in the active worksheet view. The range provided
+      corresponds to cells that will be frozen in the top- and left-most pane.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'freezeAt(frozenRange: Range | string): void;'
       parameters:
         - id: frozenRange
-          description: 'A range that represents the cells to be frozen, or `null` to remove all frozen panes.'
-          type: '<xref uid="ExcelScript!ExcelScript.Range:interface" /> | string'
+          description: >-
+            A range that represents the cells to be frozen, or `null` to remove
+            all frozen panes.
+          type: <xref uid="ExcelScript!ExcelScript.Range:interface" /> | string
       return:
         type: void
         description: ''
   - name: freezeColumns(count)
-    uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes#freezeColumns:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetFreezePanes#freezeColumns:member(1)
     package: ExcelScript!
     fullName: freezeColumns(count)
     summary: Freeze the first column or columns of the worksheet in place.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'freezeColumns(count?: number): void;'
       parameters:
         - id: count
-          description: 'Optional number of columns to freeze, or zero to unfreeze all columns'
+          description: >-
+            Optional number of columns to freeze, or zero to unfreeze all
+            columns
           type: number
       return:
         type: void
         description: ''
   - name: freezeRows(count)
-    uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes#freezeRows:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetFreezePanes#freezeRows:member(1)
     package: ExcelScript!
     fullName: freezeRows(count)
     summary: Freeze the top row or rows of the worksheet in place.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'freezeRows(count?: number): void;'
       parameters:
         - id: count
-          description: 'Optional number of rows to freeze, or zero to unfreeze all rows'
+          description: Optional number of rows to freeze, or zero to unfreeze all rows
           type: number
       return:
         type: void
         description: ''
   - name: getLocation()
-    uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes#getLocation:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetFreezePanes#getLocation:member(1)
     package: ExcelScript!
     fullName: getLocation()
     summary: >-
-      Gets a range that describes the frozen cells in the active worksheet view. The frozen range corresponds to cells
-      that are frozen in the top- and left-most pane. If there is no frozen pane, then this method returns
+      Gets a range that describes the frozen cells in the active worksheet view.
+      The frozen range corresponds to cells that are frozen in the top- and
+      left-most pane. If there is no frozen pane, then this method returns
       `undefined`<!-- -->.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getLocation(): Range;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.Range:interface" />'
+        type: <xref uid="ExcelScript!ExcelScript.Range:interface" />
         description: ''
   - name: unfreeze()
-    uid: 'ExcelScript!ExcelScript.WorksheetFreezePanes#unfreeze:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetFreezePanes#unfreeze:member(1)
     package: ExcelScript!
     fullName: unfreeze()
     summary: Removes all frozen panes in the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetpositiontype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetpositiontype.yml
@@ -1,9 +1,11 @@
 ### YamlMime:TSEnum
 name: ExcelScript.WorksheetPositionType
-uid: 'ExcelScript!ExcelScript.WorksheetPositionType:enum'
+uid: ExcelScript!ExcelScript.WorksheetPositionType:enum
 package: ExcelScript!
 fullName: ExcelScript.WorksheetPositionType
-summary: The position of a worksheet relative to another worksheet or the entire worksheet collection.
+summary: >-
+  The position of a worksheet relative to another worksheet or the entire
+  worksheet collection.
 remarks: |-
 
 
@@ -29,26 +31,27 @@ remarks: |-
     newSheet.setName(`${date.toDateString()}`);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 fields:
   - name: after
-    uid: 'ExcelScript!ExcelScript.WorksheetPositionType.after:member'
+    uid: ExcelScript!ExcelScript.WorksheetPositionType.after:member
     package: ExcelScript!
     summary: ''
   - name: before
-    uid: 'ExcelScript!ExcelScript.WorksheetPositionType.before:member'
+    uid: ExcelScript!ExcelScript.WorksheetPositionType.before:member
     package: ExcelScript!
     summary: ''
   - name: beginning
-    uid: 'ExcelScript!ExcelScript.WorksheetPositionType.beginning:member'
+    uid: ExcelScript!ExcelScript.WorksheetPositionType.beginning:member
     package: ExcelScript!
     summary: ''
   - name: end
-    uid: 'ExcelScript!ExcelScript.WorksheetPositionType.end:member'
+    uid: ExcelScript!ExcelScript.WorksheetPositionType.end:member
     package: ExcelScript!
     summary: ''
   - name: none
-    uid: 'ExcelScript!ExcelScript.WorksheetPositionType.none:member'
+    uid: ExcelScript!ExcelScript.WorksheetPositionType.none:member
     package: ExcelScript!
     summary: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotection.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.WorksheetProtection
-uid: 'ExcelScript!ExcelScript.WorksheetProtection:interface'
+uid: ExcelScript!ExcelScript.WorksheetProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetProtection
 summary: Represents the protection of a worksheet object.
@@ -31,19 +31,22 @@ remarks: |-
     }
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 methods:
-  - name: 'addAllowEditRange(title, rangeAddress, options)'
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#addAllowEditRange:member(1)'
+  - name: addAllowEditRange(title, rangeAddress, options)
+    uid: ExcelScript!ExcelScript.WorksheetProtection#addAllowEditRange:member(1)
     package: ExcelScript!
-    fullName: 'addAllowEditRange(title, rangeAddress, options)'
+    fullName: addAllowEditRange(title, rangeAddress, options)
     summary: >-
-      Adds an `AllowEditRange` object to the worksheet. Worksheet protection must be disabled or paused for this method
-      to work properly. If worksheet protection is enabled and not paused, then this method throws an `AccessDenied`
-      error and the add operation fails.
+      Adds an `AllowEditRange` object to the worksheet. Worksheet protection
+      must be disabled or paused for this method to work properly. If worksheet
+      protection is enabled and not paused, then this method throws an
+      `AccessDenied` error and the add operation fails.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -61,8 +64,12 @@ methods:
           description: The range address of the `AllowEditRange` object to be added.
           type: string
         - id: options
-          description: 'Additional options to be added to the `AllowEditRange` object, such as the password.'
-          type: '<xref uid="ExcelScript!ExcelScript.AllowEditRangeOptions:interface" />'
+          description: >-
+            Additional options to be added to the `AllowEditRange` object, such
+            as the password.
+          type: >-
+            <xref uid="ExcelScript!ExcelScript.AllowEditRangeOptions:interface"
+            />
       return:
         type: void
         description: |-
@@ -93,14 +100,16 @@ methods:
           }
           ```
   - name: checkPassword(password)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#checkPassword:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#checkPassword:member(1)
     package: ExcelScript!
     fullName: checkPassword(password)
     summary: >-
-      Specifies if the password can be used to unlock worksheet protection. This method doesn't change the worksheet
-      protection state. If a password is entered but no password is required to unlock worksheet protection, this method
-      will return false.
+      Specifies if the password can be used to unlock worksheet protection. This
+      method doesn't change the worksheet protection state. If a password is
+      entered but no password is required to unlock worksheet protection, this
+      method will return false.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -113,11 +122,12 @@ methods:
         type: boolean
         description: ''
   - name: getAllowEditRange(key)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getAllowEditRange:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getAllowEditRange:member(1)
     package: ExcelScript!
     fullName: getAllowEditRange(key)
     summary: Gets the `AllowEditRange` object by its title.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -127,31 +137,37 @@ methods:
           description: The title of the `AllowEditRange`<!-- -->.
           type: string
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.AllowEditRange:interface" /> | undefined'
+        type: >-
+          <xref uid="ExcelScript!ExcelScript.AllowEditRange:interface" /> |
+          undefined
         description: ''
   - name: getAllowEditRanges()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getAllowEditRanges:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getAllowEditRanges:member(1)
     package: ExcelScript!
     fullName: getAllowEditRanges()
     summary: >-
-      Specifies the `AllowEditRangeCollection` object found in this worksheet. This is a collection of `AllowEditRange`
-      objects, which work with worksheet protection properties. When worksheet protection is enabled, an
-      `AllowEditRange` object can be used to allow editing of a specific range, while maintaining protection on the rest
-      of the worksheet.
+      Specifies the `AllowEditRangeCollection` object found in this worksheet.
+      This is a collection of `AllowEditRange` objects, which work with
+      worksheet protection properties. When worksheet protection is enabled, an
+      `AllowEditRange` object can be used to allow editing of a specific range,
+      while maintaining protection on the rest of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getAllowEditRanges(): AllowEditRange[];'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.AllowEditRange:interface" />[]'
+        type: <xref uid="ExcelScript!ExcelScript.AllowEditRange:interface" />[]
         description: ''
   - name: getCanPauseProtection()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getCanPauseProtection:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtection#getCanPauseProtection:member(1)
     package: ExcelScript!
     fullName: getCanPauseProtection()
     summary: Specifies if protection can be paused for this worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -160,11 +176,13 @@ methods:
         type: boolean
         description: ''
   - name: getIsPasswordProtected()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getIsPasswordProtected:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtection#getIsPasswordProtected:member(1)
     package: ExcelScript!
     fullName: getIsPasswordProtected()
     summary: Specifies if the sheet is password protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -173,11 +191,12 @@ methods:
         type: boolean
         description: ''
   - name: getIsPaused()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getIsPaused:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getIsPaused:member(1)
     package: ExcelScript!
     fullName: getIsPaused()
     summary: Specifies if worksheet protection is paused.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -186,24 +205,28 @@ methods:
         type: boolean
         description: ''
   - name: getOptions()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getOptions:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getOptions:member(1)
     package: ExcelScript!
     fullName: getOptions()
     summary: Specifies the protection options for the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getOptions(): WorksheetProtectionOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />
         description: ''
   - name: getProtected()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getProtected:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getProtected:member(1)
     package: ExcelScript!
     fullName: getProtected()
     summary: Specifies if the worksheet is protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -212,30 +235,37 @@ methods:
         type: boolean
         description: ''
   - name: getSavedOptions()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#getSavedOptions:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#getSavedOptions:member(1)
     package: ExcelScript!
     fullName: getSavedOptions()
     summary: >-
-      Specifies the protection options saved in the worksheet. This will return the same `WorksheetProtectionOptions`
-      object regardless of the worksheet protection state.
+      Specifies the protection options saved in the worksheet. This will return
+      the same `WorksheetProtectionOptions` object regardless of the worksheet
+      protection state.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'getSavedOptions(): WorksheetProtectionOptions;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />'
+        type: >-
+          <xref
+          uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />
         description: ''
   - name: pauseProtection(password)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#pauseProtection:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#pauseProtection:member(1)
     package: ExcelScript!
     fullName: pauseProtection(password)
     summary: >-
-      Pauses worksheet protection for the given worksheet object for the user in the current session. This method does
-      nothing if worksheet protection isn't enabled or is already paused. If the password is incorrect, then this method
-      throws an `InvalidArgument` error and fails to pause protection. This method does not change the protection state
-      if worksheet protection is not enabled or already paused.
+      Pauses worksheet protection for the given worksheet object for the user in
+      the current session. This method does nothing if worksheet protection
+      isn't enabled or is already paused. If the password is incorrect, then
+      this method throws an `InvalidArgument` error and fails to pause
+      protection. This method does not change the protection state if worksheet
+      protection is not enabled or already paused.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -248,16 +278,21 @@ methods:
         type: void
         description: ''
   - name: pauseProtectionForAllAllowEditRanges(password)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#pauseProtectionForAllAllowEditRanges:member(1)'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtection#pauseProtectionForAllAllowEditRanges:member(1)
     package: ExcelScript!
     fullName: pauseProtectionForAllAllowEditRanges(password)
     summary: >-
-      Pauses worksheet protection for all `AllowEditRange` objects found in this worksheet that have the given password
-      for the user in the current session. This method does nothing if worksheet protection isn't enabled or is paused.
-      If worksheet protection cannot be paused, this method throws an `UnsupportedOperation` error and fails to pause
-      protection for the range. If the password does not match any `AllowEditRange` objects in the collection, then this
-      method throws a `BadPassword` error and fails to pause protection for any range in the collection.
+      Pauses worksheet protection for all `AllowEditRange` objects found in this
+      worksheet that have the given password for the user in the current
+      session. This method does nothing if worksheet protection isn't enabled or
+      is paused. If worksheet protection cannot be paused, this method throws an
+      `UnsupportedOperation` error and fails to pause protection for the range.
+      If the password does not match any `AllowEditRange` objects in the
+      collection, then this method throws a `BadPassword` error and fails to
+      pause protection for any range in the collection.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -269,12 +304,13 @@ methods:
       return:
         type: void
         description: ''
-  - name: 'protect(options, password)'
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#protect:member(1)'
+  - name: protect(options, password)
+    uid: ExcelScript!ExcelScript.WorksheetProtection#protect:member(1)
     package: ExcelScript!
-    fullName: 'protect(options, password)'
+    fullName: protect(options, password)
     summary: Protects a worksheet. Fails if the worksheet has already been protected.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -282,7 +318,10 @@ methods:
       parameters:
         - id: options
           description: Optional. Sheet protection options.
-          type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />'
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface"
+            />
         - id: password
           description: Optional. Sheet protection password.
           type: string
@@ -312,14 +351,16 @@ methods:
           }
           ```
   - name: resumeProtection()
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#resumeProtection:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#resumeProtection:member(1)
     package: ExcelScript!
     fullName: resumeProtection()
     summary: >-
-      Resumes worksheet protection for the given worksheet object for the user in a given session. Worksheet protection
-      must be paused for this method to work. If worksheet protection is not paused, then this method will not change
-      the protection state of the worksheet.
+      Resumes worksheet protection for the given worksheet object for the user
+      in a given session. Worksheet protection must be paused for this method to
+      work. If worksheet protection is not paused, then this method will not
+      change the protection state of the worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -328,16 +369,20 @@ methods:
         type: void
         description: ''
   - name: setPassword(password)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#setPassword:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#setPassword:member(1)
     package: ExcelScript!
     fullName: setPassword(password)
     summary: >-
-      Changes the password associated with the `WorksheetProtection` object. Setting the password as an empty string
-      ("") or as `null` will remove password protection from the `WorksheetProtection` object. Worksheet protection must
-      be enabled and paused for this method to work properly. If worksheet protection is disabled, this method throws an
-      `InvalidOperation` error and fails to change the password. If worksheet protection is enabled and not paused, this
-      method throws an `AccessDenied` error and fails to change the password.
+      Changes the password associated with the `WorksheetProtection` object.
+      Setting the password as an empty string ("") or as `null` will remove
+      password protection from the `WorksheetProtection` object. Worksheet
+      protection must be enabled and paused for this method to work properly. If
+      worksheet protection is disabled, this method throws an `InvalidOperation`
+      error and fails to change the password. If worksheet protection is enabled
+      and not paused, this method throws an `AccessDenied` error and fails to
+      change the password.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -350,11 +395,12 @@ methods:
         type: void
         description: ''
   - name: unprotect(password)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#unprotect:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#unprotect:member(1)
     package: ExcelScript!
     fullName: unprotect(password)
     summary: Unprotects a worksheet.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -367,22 +413,30 @@ methods:
         type: void
         description: ''
   - name: updateOptions(options)
-    uid: 'ExcelScript!ExcelScript.WorksheetProtection#updateOptions:member(1)'
+    uid: ExcelScript!ExcelScript.WorksheetProtection#updateOptions:member(1)
     package: ExcelScript!
     fullName: updateOptions(options)
     summary: >-
-      Change the worksheet protection options associated with the `WorksheetProtection` object. Worksheet protection
-      must be disabled or paused for this method to work properly. If worksheet protection is enabled and not paused,
-      this method throws an `AccessDenied` error and fails to change the worksheet protection options.
+      Change the worksheet protection options associated with the
+      `WorksheetProtection` object. Worksheet protection must be disabled or
+      paused for this method to work properly. If worksheet protection is
+      enabled and not paused, this method throws an `AccessDenied` error and
+      fails to change the worksheet protection options.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'updateOptions(options: WorksheetProtectionOptions): void;'
       parameters:
         - id: options
-          description: The options interface associated with the `WorksheetProtection` object.
-          type: '<xref uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface" />'
+          description: >-
+            The options interface associated with the `WorksheetProtection`
+            object.
+          type: >-
+            <xref
+            uid="ExcelScript!ExcelScript.WorksheetProtectionOptions:interface"
+            />
       return:
         type: void
         description: ''

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotectionoptions.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetprotectionoptions.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.WorksheetProtectionOptions
-uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions:interface'
+uid: ExcelScript!ExcelScript.WorksheetProtectionOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetProtectionOptions
 summary: Represents the options in sheet protection.
@@ -27,16 +27,20 @@ remarks: |-
     sheetProtection.protect(protectionOptions);
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: allowAutoFilter
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowAutoFilter:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowAutoFilter:member
     package: ExcelScript!
     fullName: allowAutoFilter
-    summary: Represents the worksheet protection option allowing use of the AutoFilter feature.
+    summary: >-
+      Represents the worksheet protection option allowing use of the AutoFilter
+      feature.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -44,11 +48,13 @@ properties:
       return:
         type: boolean
   - name: allowDeleteColumns
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowDeleteColumns:member'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtectionOptions#allowDeleteColumns:member
     package: ExcelScript!
     fullName: allowDeleteColumns
     summary: Represents the worksheet protection option allowing deleting of columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -56,11 +62,12 @@ properties:
       return:
         type: boolean
   - name: allowDeleteRows
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowDeleteRows:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowDeleteRows:member
     package: ExcelScript!
     fullName: allowDeleteRows
     summary: Represents the worksheet protection option allowing deleting of rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -68,11 +75,12 @@ properties:
       return:
         type: boolean
   - name: allowEditObjects
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowEditObjects:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowEditObjects:member
     package: ExcelScript!
     fullName: allowEditObjects
     summary: Represents the worksheet protection option allowing editing of objects.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -80,11 +88,13 @@ properties:
       return:
         type: boolean
   - name: allowEditScenarios
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowEditScenarios:member'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtectionOptions#allowEditScenarios:member
     package: ExcelScript!
     fullName: allowEditScenarios
     summary: Represents the worksheet protection option allowing editing of scenarios.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -92,11 +102,12 @@ properties:
       return:
         type: boolean
   - name: allowFormatCells
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatCells:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatCells:member
     package: ExcelScript!
     fullName: allowFormatCells
     summary: Represents the worksheet protection option allowing formatting of cells.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -104,11 +115,13 @@ properties:
       return:
         type: boolean
   - name: allowFormatColumns
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatColumns:member'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatColumns:member
     package: ExcelScript!
     fullName: allowFormatColumns
     summary: Represents the worksheet protection option allowing formatting of columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -116,11 +129,12 @@ properties:
       return:
         type: boolean
   - name: allowFormatRows
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatRows:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowFormatRows:member
     package: ExcelScript!
     fullName: allowFormatRows
     summary: Represents the worksheet protection option allowing formatting of rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -128,11 +142,13 @@ properties:
       return:
         type: boolean
   - name: allowInsertColumns
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertColumns:member'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertColumns:member
     package: ExcelScript!
     fullName: allowInsertColumns
     summary: Represents the worksheet protection option allowing inserting of columns.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -140,11 +156,15 @@ properties:
       return:
         type: boolean
   - name: allowInsertHyperlinks
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertHyperlinks:member'
+    uid: >-
+      ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertHyperlinks:member
     package: ExcelScript!
     fullName: allowInsertHyperlinks
-    summary: Represents the worksheet protection option allowing inserting of hyperlinks.
+    summary: >-
+      Represents the worksheet protection option allowing inserting of
+      hyperlinks.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -152,11 +172,12 @@ properties:
       return:
         type: boolean
   - name: allowInsertRows
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertRows:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowInsertRows:member
     package: ExcelScript!
     fullName: allowInsertRows
     summary: Represents the worksheet protection option allowing inserting of rows.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -164,11 +185,14 @@ properties:
       return:
         type: boolean
   - name: allowPivotTables
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowPivotTables:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowPivotTables:member
     package: ExcelScript!
     fullName: allowPivotTables
-    summary: Represents the worksheet protection option allowing use of the PivotTable feature.
+    summary: >-
+      Represents the worksheet protection option allowing use of the PivotTable
+      feature.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -176,11 +200,14 @@ properties:
       return:
         type: boolean
   - name: allowSort
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#allowSort:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#allowSort:member
     package: ExcelScript!
     fullName: allowSort
-    summary: Represents the worksheet protection option allowing use of the sort feature.
+    summary: >-
+      Represents the worksheet protection option allowing use of the sort
+      feature.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -188,14 +215,15 @@ properties:
       return:
         type: boolean
   - name: selectionMode
-    uid: 'ExcelScript!ExcelScript.WorksheetProtectionOptions#selectionMode:member'
+    uid: ExcelScript!ExcelScript.WorksheetProtectionOptions#selectionMode:member
     package: ExcelScript!
     fullName: selectionMode
     summary: Represents the worksheet protection option of selection mode.
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
       content: 'selectionMode?: ProtectionSelectionMode;'
       return:
-        type: '<xref uid="ExcelScript!ExcelScript.ProtectionSelectionMode:enum" />'
+        type: <xref uid="ExcelScript!ExcelScript.ProtectionSelectionMode:enum" />

--- a/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetsearchcriteria.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/excelscript.worksheetsearchcriteria.yml
@@ -1,6 +1,6 @@
 ### YamlMime:TSType
 name: ExcelScript.WorksheetSearchCriteria
-uid: 'ExcelScript!ExcelScript.WorksheetSearchCriteria:interface'
+uid: ExcelScript!ExcelScript.WorksheetSearchCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetSearchCriteria
 summary: Represents the worksheet search criteria to be used.
@@ -30,19 +30,22 @@ remarks: |-
     noCells.getFormat().getFill().setColor("red");
   }
   ```
+
 isPreview: false
 isDeprecated: false
 type: interface
 properties:
   - name: completeMatch
-    uid: 'ExcelScript!ExcelScript.WorksheetSearchCriteria#completeMatch:member'
+    uid: ExcelScript!ExcelScript.WorksheetSearchCriteria#completeMatch:member
     package: ExcelScript!
     fullName: completeMatch
     summary: >-
-      Specifies if the match needs to be complete or partial. A complete match matches the entire contents of the cell.
-      A partial match matches a substring within the content of the cell (e.g., `cat` partially matches `caterpillar`
-      and `scatter`<!-- -->). Default is `false` (partial).
+      Specifies if the match needs to be complete or partial. A complete match
+      matches the entire contents of the cell. A partial match matches a
+      substring within the content of the cell (e.g., `cat` partially matches
+      `caterpillar` and `scatter`<!-- -->). Default is `false` (partial).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:
@@ -50,11 +53,14 @@ properties:
       return:
         type: boolean
   - name: matchCase
-    uid: 'ExcelScript!ExcelScript.WorksheetSearchCriteria#matchCase:member'
+    uid: ExcelScript!ExcelScript.WorksheetSearchCriteria#matchCase:member
     package: ExcelScript!
     fullName: matchCase
-    summary: Specifies if the match is case-sensitive. Default is `false` (case-insensitive).
+    summary: >-
+      Specifies if the match is case-sensitive. Default is `false`
+      (case-insensitive).
     remarks: ''
+
     isPreview: false
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailattachment.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailattachment.yml
@@ -1,23 +1,26 @@
 ### YamlMime:TSType
 name: Global.OfficeScript.EmailAttachment
-uid: 'ExcelScript!Global.OfficeScript.EmailAttachment:interface'
+uid: ExcelScript!Global.OfficeScript.EmailAttachment:interface
 package: ExcelScript!
 fullName: Global.OfficeScript.EmailAttachment
 summary: >-
-  The attachment to send with the email. A value must be specified for at least one of the `to`<!-- -->, `cc`<!-- -->,
-  or `bcc` parameters. If no recipient is specified, the following error is shown: "The message has no recipient. Please
+  The attachment to send with the email. A value must be specified for at least
+  one of the `to`<!-- -->, `cc`<!-- -->, or `bcc` parameters. If no recipient is
+  specified, the following error is shown: "The message has no recipient. Please
   enter a value for at least one of the "to", "cc", or "bcc" parameters."
 remarks: ''
+
 isPreview: true
 isDeprecated: false
 type: interface
 properties:
   - name: content
-    uid: 'ExcelScript!Global.OfficeScript.EmailAttachment#content:member'
+    uid: ExcelScript!Global.OfficeScript.EmailAttachment#content:member
     package: ExcelScript!
     fullName: content
     summary: The contents of the file.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -25,13 +28,14 @@ properties:
       return:
         type: string
   - name: name
-    uid: 'ExcelScript!Global.OfficeScript.EmailAttachment#name:member'
+    uid: ExcelScript!Global.OfficeScript.EmailAttachment#name:member
     package: ExcelScript!
     fullName: name
     summary: >-
-      The text that is displayed below the icon representing the attachment. This string doesn't need to match the file
-      name.
+      The text that is displayed below the icon representing the attachment.
+      This string doesn't need to match the file name.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:

--- a/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailcontenttype.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailcontenttype.yml
@@ -1,20 +1,21 @@
 ### YamlMime:TSEnum
 name: Global.OfficeScript.EmailContentType
-uid: 'ExcelScript!Global.OfficeScript.EmailContentType:enum'
+uid: ExcelScript!Global.OfficeScript.EmailContentType:enum
 package: ExcelScript!
 fullName: Global.OfficeScript.EmailContentType
 summary: The type of the content. Possible values are text or HTML.
 remarks: ''
+
 isPreview: true
 isDeprecated: false
 fields:
   - name: html
-    uid: 'ExcelScript!Global.OfficeScript.EmailContentType.html:member'
+    uid: ExcelScript!Global.OfficeScript.EmailContentType.html:member
     package: ExcelScript!
     summary: The email message body is in HTML format.
     value: '"html"'
   - name: text
-    uid: 'ExcelScript!Global.OfficeScript.EmailContentType.text:member'
+    uid: ExcelScript!Global.OfficeScript.EmailContentType.text:member
     package: ExcelScript!
     summary: The email message body is in plain text format.
     value: '"text"'

--- a/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailimportance.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/global.officescript.emailimportance.yml
@@ -1,27 +1,28 @@
 ### YamlMime:TSEnum
 name: Global.OfficeScript.EmailImportance
-uid: 'ExcelScript!Global.OfficeScript.EmailImportance:enum'
+uid: ExcelScript!Global.OfficeScript.EmailImportance:enum
 package: ExcelScript!
 fullName: Global.OfficeScript.EmailImportance
 summary: >-
-  The importance value of the email. Corresponds to "high", "normal", and "low" importance values available in the
-  Outlook UI.
+  The importance value of the email. Corresponds to "high", "normal", and "low"
+  importance values available in the Outlook UI.
 remarks: ''
+
 isPreview: true
 isDeprecated: false
 fields:
   - name: high
-    uid: 'ExcelScript!Global.OfficeScript.EmailImportance.high:member'
+    uid: ExcelScript!Global.OfficeScript.EmailImportance.high:member
     package: ExcelScript!
     summary: Email is marked as high importance.
     value: '"high"'
   - name: low
-    uid: 'ExcelScript!Global.OfficeScript.EmailImportance.low:member'
+    uid: ExcelScript!Global.OfficeScript.EmailImportance.low:member
     package: ExcelScript!
     summary: Email is marked as low importance.
     value: '"low"'
   - name: normal
-    uid: 'ExcelScript!Global.OfficeScript.EmailImportance.normal:member'
+    uid: ExcelScript!Global.OfficeScript.EmailImportance.normal:member
     package: ExcelScript!
     summary: Email does not have any importance specified.
     value: '"normal"'

--- a/docs/docs-ref-autogen/excel/excelscript/global.officescript.mailproperties.yml
+++ b/docs/docs-ref-autogen/excel/excelscript/global.officescript.mailproperties.yml
@@ -1,58 +1,68 @@
 ### YamlMime:TSType
 name: Global.OfficeScript.MailProperties
-uid: 'ExcelScript!Global.OfficeScript.MailProperties:interface'
+uid: ExcelScript!Global.OfficeScript.MailProperties:interface
 package: ExcelScript!
 fullName: Global.OfficeScript.MailProperties
 summary: The properties of the email to be sent.
 remarks: ''
+
 isPreview: true
 isDeprecated: false
 type: interface
 properties:
   - name: attachments
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#attachments:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#attachments:member
     package: ExcelScript!
     fullName: attachments
-    summary: A file (such as a text file or Excel workbook) attached to a message. Optional.
+    summary: >-
+      A file (such as a text file or Excel workbook) attached to a message.
+      Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'attachments?: EmailAttachment | EmailAttachment[];'
       return:
         type: >-
-          <xref uid="ExcelScript!Global.OfficeScript.EmailAttachment:interface" /> | <xref
+          <xref uid="ExcelScript!Global.OfficeScript.EmailAttachment:interface"
+          /> | <xref
           uid="ExcelScript!Global.OfficeScript.EmailAttachment:interface" />[]
   - name: bcc
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#bcc:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#bcc:member
     package: ExcelScript!
     fullName: bcc
-    summary: The blind carbon copy (BCC) recipient or recipients of the email. Optional.
+    summary: >-
+      The blind carbon copy (BCC) recipient or recipients of the email.
+      Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'bcc?: string | string[];'
       return:
-        type: 'string | string[]'
+        type: string | string[]
   - name: cc
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#cc:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#cc:member
     package: ExcelScript!
     fullName: cc
     summary: The carbon copy (CC) recipient or recipients of the email. Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'cc?: string | string[];'
       return:
-        type: 'string | string[]'
+        type: string | string[]
   - name: content
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#content:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#content:member
     package: ExcelScript!
     fullName: content
     summary: The content of the email. Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -60,37 +70,43 @@ properties:
       return:
         type: string
   - name: contentType
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#contentType:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#contentType:member
     package: ExcelScript!
     fullName: contentType
-    summary: The type of the content in the email. Possible values are text or HTML. Optional.
+    summary: >-
+      The type of the content in the email. Possible values are text or HTML.
+      Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'contentType?: EmailContentType;'
       return:
-        type: '<xref uid="ExcelScript!Global.OfficeScript.EmailContentType:enum" />'
+        type: <xref uid="ExcelScript!Global.OfficeScript.EmailContentType:enum" />
   - name: importance
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#importance:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#importance:member
     package: ExcelScript!
     fullName: importance
     summary: >-
-      The importance of the email. The possible values are `low`<!-- -->, `normal`<!-- -->, and `high`<!-- -->. Default
-      value is `normal`<!-- -->. Optional.
+      The importance of the email. The possible values are `low`<!-- -->,
+      `normal`<!-- -->, and `high`<!-- -->. Default value is `normal`<!-- -->.
+      Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'importance?: EmailImportance;'
       return:
-        type: '<xref uid="ExcelScript!Global.OfficeScript.EmailImportance:enum" />'
+        type: <xref uid="ExcelScript!Global.OfficeScript.EmailImportance:enum" />
   - name: subject
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#subject:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#subject:member
     package: ExcelScript!
     fullName: subject
     summary: The subject of the email. Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
@@ -98,14 +114,15 @@ properties:
       return:
         type: string
   - name: to
-    uid: 'ExcelScript!Global.OfficeScript.MailProperties#to:member'
+    uid: ExcelScript!Global.OfficeScript.MailProperties#to:member
     package: ExcelScript!
     fullName: to
     summary: The direct recipient or recipients of the email. Optional.
     remarks: ''
+
     isPreview: true
     isDeprecated: false
     syntax:
       content: 'to?: string | string[];'
       return:
-        type: 'string | string[]'
+        type: string | string[]

--- a/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
+++ b/generate-docs/api-extractor-inputs-excel/tsdoc-metadata.json
@@ -5,7 +5,7 @@
   "toolPackages": [
     {
       "packageName": "@microsoft/api-extractor",
-      "packageVersion": "7.52.1"
+      "packageVersion": "7.52.8"
     }
   ]
 }

--- a/generate-docs/package-lock.json
+++ b/generate-docs/package-lock.json
@@ -8,8 +8,8 @@
       "name": "generate-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@microsoft/api-documenter": "^7.26.17",
-        "@microsoft/api-extractor": "^7.52.1",
+        "@microsoft/api-documenter": "^7.26.27",
+        "@microsoft/api-extractor": "^7.52.8",
         "reference-coverage-tester": "^0.1.0"
       }
     },
@@ -318,16 +318,16 @@
       }
     },
     "node_modules/@microsoft/api-documenter": {
-      "version": "7.26.17",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.26.17.tgz",
-      "integrity": "sha512-LOS9U6EJVpejN0vNXFBPdbRW9D2bPJI8FYfLGSaEeiqPfMBlH5QYLKt+OaJomx72uj9Ei6/W49mftK/c+UGPjg==",
+      "version": "7.26.27",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-documenter/-/api-documenter-7.26.27.tgz",
+      "integrity": "sha512-POELaGjCyxYBHP0vGUS9SoyClEEA3+YLeGYwEShJ+ttbB/DzdkWDH1IK5pUGxwe/J2bJ7SuRbI7u17O16MrxCA==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.30.4",
+        "@microsoft/api-extractor-model": "7.30.6",
         "@microsoft/tsdoc": "~0.15.1",
-        "@rushstack/node-core-library": "5.12.0",
-        "@rushstack/terminal": "0.15.1",
-        "@rushstack/ts-command-line": "4.23.6",
+        "@rushstack/node-core-library": "5.13.1",
+        "@rushstack/terminal": "0.15.3",
+        "@rushstack/ts-command-line": "5.0.1",
         "js-yaml": "~3.13.1",
         "resolve": "~1.22.1"
       },
@@ -336,18 +336,18 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.52.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.1.tgz",
-      "integrity": "sha512-m3I5uAwE05orsu3D1AGyisX5KxsgVXB+U4bWOOaX/Z7Ftp/2Cy41qsNhO6LPvSxHBaapyser5dVorF1t5M6tig==",
+      "version": "7.52.8",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.8.tgz",
+      "integrity": "sha512-cszYIcjiNscDoMB1CIKZ3My61+JOhpERGlGr54i6bocvGLrcL/wo9o+RNXMBrb7XgLtKaizZWUpqRduQuHQLdg==",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.30.4",
+        "@microsoft/api-extractor-model": "7.30.6",
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.12.0",
+        "@rushstack/node-core-library": "5.13.1",
         "@rushstack/rig-package": "0.5.3",
-        "@rushstack/terminal": "0.15.1",
-        "@rushstack/ts-command-line": "4.23.6",
+        "@rushstack/terminal": "0.15.3",
+        "@rushstack/ts-command-line": "5.0.1",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -360,14 +360,14 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.30.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.4.tgz",
-      "integrity": "sha512-RobC0gyVYsd2Fao9MTKOfTdBm41P/bCMUmzS5mQ7/MoAKEqy0FOBph3JOYdq4X4BsEnMEiSHc+0NUNmdzxCpjA==",
+      "version": "7.30.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.6.tgz",
+      "integrity": "sha512-znmFn69wf/AIrwHya3fxX6uB5etSIn6vg4Q4RB/tb5VDDs1rqREc+AvMC/p19MUN13CZ7+V/8pkYPTj7q8tftg==",
       "license": "MIT",
       "dependencies": {
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.12.0"
+        "@rushstack/node-core-library": "5.13.1"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -389,9 +389,9 @@
       }
     },
     "node_modules/@rushstack/node-core-library": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.12.0.tgz",
-      "integrity": "sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==",
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.13.1.tgz",
+      "integrity": "sha512-5yXhzPFGEkVc9Fu92wsNJ9jlvdwz4RNb2bMso+/+TH0nMm1jDDDsOIf4l8GAkPxGuwPw5DH24RliWVfSPhlW/Q==",
       "license": "MIT",
       "dependencies": {
         "ajv": "~8.13.0",
@@ -439,12 +439,12 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.1.tgz",
-      "integrity": "sha512-3vgJYwumcjoDOXU3IxZfd616lqOdmr8Ezj4OWgJZfhmiBK4Nh7eWcv8sU8N/HdzXcuHDXCRGn/6O2Q75QvaZMA==",
+      "version": "0.15.3",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.3.tgz",
+      "integrity": "sha512-DGJ0B2Vm69468kZCJkPj3AH5nN+nR9SPmC0rFHtzsS4lBQ7/dgOwtwVxYP7W9JPDMuRBkJ4KHmWKr036eJsj9g==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/node-core-library": "5.12.0",
+        "@rushstack/node-core-library": "5.13.1",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -457,12 +457,12 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.23.6",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.6.tgz",
-      "integrity": "sha512-7WepygaF3YPEoToh4MAL/mmHkiIImQq3/uAkQX46kVoKTNOOlCtFGyNnze6OYuWw2o9rxsyrHVfIBKxq/am2RA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.1.tgz",
+      "integrity": "sha512-bsbUucn41UXrQK7wgM8CNM/jagBytEyJqXw/umtI8d68vFm1Jwxh1OtLrlW7uGZgjCWiiPH6ooUNa1aVsuVr3Q==",
       "license": "MIT",
       "dependencies": {
-        "@rushstack/terminal": "0.15.1",
+        "@rushstack/terminal": "0.15.3",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -576,9 +576,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",

--- a/generate-docs/package.json
+++ b/generate-docs/package.json
@@ -2,8 +2,8 @@
   "name": "generate-docs",
   "version": "1.0.0",
   "dependencies": {
-    "@microsoft/api-extractor": "^7.52.1",
-    "@microsoft/api-documenter": "^7.26.17",
+    "@microsoft/api-extractor": "^7.52.8",
+    "@microsoft/api-documenter": "^7.26.27",
     "reference-coverage-tester": "^0.1.0"
   }
 }

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "fs-extra": "11.2.0",
-        "inquirer": "^9.2.17",
+        "fs-extra": "11.3.0",
+        "inquirer": "^12.6.3",
         "isomorphic-fetch": "^3.0.0",
         "js-yaml": "4.1.0",
         "lodash": "^4.17.21"
@@ -18,15 +18,15 @@
       "devDependencies": {
         "@types/fs-extra": "11.0.4",
         "@types/js-yaml": "4.0.9",
-        "@types/lodash": "4.17.0",
-        "@types/node": "20.12.5",
-        "@typescript-eslint/eslint-plugin": "^6.16.0",
-        "@typescript-eslint/parser": "^6.16.0",
-        "del": "7.1.0",
-        "eslint": "^8.56.0",
-        "eslint-config-prettier": "^9.1.0",
+        "@types/lodash": "4.17.17",
+        "@types/node": "24.0.3",
+        "@typescript-eslint/eslint-plugin": "^8.34.1",
+        "@typescript-eslint/parser": "^8.34.1",
+        "del": "8.0.0",
+        "eslint": "^9.29.0",
+        "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prefer-arrow": "^1.2.3",
-        "typescript": "5.4.4"
+        "typescript": "5.8.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -39,39 +39,107 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "eslint-visitor-keys": "^3.3.0"
+        "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       },
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.10.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
     },
-    "node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+    "node_modules/@eslint/config-array": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
+      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
+      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -79,20 +147,31 @@
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -100,6 +179,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -108,48 +188,91 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-      "integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.2.tgz",
+      "integrity": "sha512-4SaFZCNfJqvk/kenHpI8xvN42DMaoycy4PzKc5otHxRswww1kAt82OlBuwRVLofCACCTZEcla2Ydxv8scMXaTg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.2",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
+        "@eslint/core": "^0.15.0",
+        "levn": "^0.4.1"
       },
       "engines": {
-        "node": ">=10.10.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
+      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "*"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.6",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+      "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+      "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -165,29 +288,322 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "dev": true
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.8.tgz",
+      "integrity": "sha512-d/QAsnwuHX2OPolxvYcgSj7A9DO9H6gVOy2DvBTx+P2LH2iRTo/RSGV3iwCzW024nP9hw98KIuDmdyhZQj1UQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.12.tgz",
+      "integrity": "sha512-dpq+ielV9/bqgXRUbNH//KsY6WEw9DrGPmipkpmgC1Y46cwuBTNx7PXFWTjc3MQ+urcc0QxoVHcMI0FW4Ok0hg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.13.tgz",
+      "integrity": "sha512-1viSxebkYN2nJULlzCxES6G9/stgHSepZ9LqqfdIGPHj5OHhiBUXVS0a6R0bEC2A+VL4D9w6QB66ebCr6HGllA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.13.tgz",
+      "integrity": "sha512-WbicD9SUQt/K8O5Vyk9iC2ojq5RHoCLK6itpp2fHsWe44VxxcA9z3GTWlvjSTGmMQpZr+lbVmrxdHcumJoLbMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.15.tgz",
+      "integrity": "sha512-4Y+pbr/U9Qcvf+N/goHzPEXiHH8680lM3Dr3Y9h9FFw4gHS+zVpbj8LfbKWIb/jayIB4aSO4pWiBTrBYWkvi5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.1.tgz",
-      "integrity": "sha512-mtup3wVKia3ZwULPHcbs4Mor8Voi+iIXEWD7wCNbIO6lYR62oPCTQyrddi5OMYVXHzeCSoneZwJuS8sBvlEwDw==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.12.tgz",
+      "integrity": "sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@ljharb/through": {
-      "version": "2.3.13",
-      "resolved": "https://registry.npmjs.org/@ljharb/through/-/through-2.3.13.tgz",
-      "integrity": "sha512-/gKJun8NNiWGZJkGzI/Ragc53cOdcLNdzjLaIa+GEjguQs0ulsurx8WN0jijdK9yPqDvziX995sMRLyLt1uZMQ==",
+    "node_modules/@inquirer/input": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.12.tgz",
+      "integrity": "sha512-xJ6PFZpDjC+tC1P8ImGprgcsrzQRsUh9aH3IZixm1lAZFK49UGHxM3ltFfuInN2kPYNfyoPRh+tU4ftsjPLKqQ==",
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7"
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
       },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.15.tgz",
+      "integrity": "sha512-xWg+iYfqdhRiM55MvqiTCleHzszpoigUpN5+t1OMcRkJrUrw7va3AzXaxvS+Ak7Gny0j2mFSTv2JJj8sMtbV2g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.15.tgz",
+      "integrity": "sha512-75CT2p43DGEnfGTaqFpbDC2p2EEMrq0S+IRrf9iJvYreMy5mAWj087+mdKyLHapUEPLjN10mNvABpGbk8Wdraw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.5.3.tgz",
+      "integrity": "sha512-8YL0WiV7J86hVAxrh3fE5mDCzcTDe1670unmJRz6ArDgN+DBK1a0+rbnNWp4DUB5rPMwqD5ZP6YHl9KK1mbZRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.1.8",
+        "@inquirer/confirm": "^5.1.12",
+        "@inquirer/editor": "^4.2.13",
+        "@inquirer/expand": "^4.0.15",
+        "@inquirer/input": "^4.1.12",
+        "@inquirer/number": "^3.0.15",
+        "@inquirer/password": "^4.0.15",
+        "@inquirer/rawlist": "^4.1.3",
+        "@inquirer/search": "^3.0.15",
+        "@inquirer/select": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.3.tgz",
+      "integrity": "sha512-7XrV//6kwYumNDSsvJIPeAqa8+p7GJh7H5kRuxirct2cgOcSWwwNGoXDRgpNFbY/MG2vQ4ccIWCi8+IXXyFMZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.15.tgz",
+      "integrity": "sha512-YBMwPxYBrADqyvP4nNItpwkBnGGglAvCLVW8u4pRmmvOsHUtCAUIMbUrLX5B3tFL1/WsLGdQ2HNzkqswMs5Uaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.2.3.tgz",
+      "integrity": "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/figures": "^1.0.12",
+        "@inquirer/type": "^3.0.7",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.7.tgz",
+      "integrity": "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -195,6 +611,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -208,6 +625,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -217,6 +635,7 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -224,6 +643,26 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/fs-extra": {
       "version": "11.0.4",
@@ -245,7 +684,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsonfile": {
       "version": "6.1.4",
@@ -257,140 +697,166 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
+      "version": "4.17.17",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.17.tgz",
+      "integrity": "sha512-RRVJ+J3J+WmyOTqnz3PiBLA501eKwXl2noseKOrNo/6+XEHjTAxO4xHvxQB6QuNm+s4WRbn6rSiap8+EA+ykFQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.12.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.5.tgz",
-      "integrity": "sha512-BD+BjQ9LS/D8ST9p5uqBxghlN+S42iuNxjsUGjeZobe/ciXzk2qb1B6IXc6AnRLS+yFJRpN2IPEHMzwspfDJNw==",
-      "dev": true,
+      "version": "24.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
+      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "devOptional": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.8.0"
       }
     },
-    "node_modules/@types/semver": {
-      "version": "7.5.8",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
-      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.34.1.tgz",
+      "integrity": "sha512-STXcN6ebF6li4PxwNeFnqF8/2BNDvBupf2OPx2yWNzr6mKNGF7q49VM00Pz5FaomJyqvbXpY6PhO+T9w139YEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.5.1",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/type-utils": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/type-utils": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "graphemer": "^1.4.0",
-        "ignore": "^5.2.4",
+        "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.34.1",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.34.1.tgz",
+      "integrity": "sha512-4O3idHxhyzjClSMJ0a29AcoK0+YwnEqzI6oz3vlRf3xw0zbzt15MzXwItOlnr5nIth6zlY2RENLsOPvhyrKAQA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.34.1.tgz",
+      "integrity": "sha512-nuHlOmFZfuRwLJKDGQOVc0xnQrAmuq1Mj/ISou5044y1ajGNp2BNliIqp7F2LPQ5sForz8lempMFCovfeS1XoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.34.1",
+        "@typescript-eslint/types": "^8.34.1",
+        "debug": "^4.3.4"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.34.1.tgz",
+      "integrity": "sha512-beu6o6QY4hJAgL1E8RaXNC071G4Kso2MGmJskCFQhRhg8VOH/FDbC8soP8NHN7e/Hdphwp8G8cE6OBzC8o41ZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/type-utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.34.1.tgz",
+      "integrity": "sha512-K4Sjdo4/xF9NEeA2khOb7Y5nY6NSXBnod87uniVYW9kHP+hNlDV8trUSFeynA2uxWam4gIWgWoygPrv9VMWrYg==",
       "dev": true,
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/utils": "6.21.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.0.1"
-      },
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.34.1.tgz",
+      "integrity": "sha512-Tv7tCCr6e5m8hP4+xFugcrwTOucB8lshffJ6zf1mF1TbU67R+ntCc6DzLNKM+s/uzDyv8gLq7tufaAhIBYeV8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "8.34.1",
+        "@typescript-eslint/utils": "8.34.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
       },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.34.1.tgz",
+      "integrity": "sha512-rjLVbmE7HR18kDsjNIZQHxmv9RZwlgzavryL5Lnj2ujIRTeXlKtILHgRNmQ3j4daw7zd+mQgy+uyt6Zo6I0IGA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -398,86 +864,95 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.34.1.tgz",
+      "integrity": "sha512-rjCNqqYPuMUF5ODD+hWBNmOitjBWghkGKJg6hiCHzUvXRy6rK22Jd3rwbP2Xi+R7oYVvIKhokHVhH41BxPV5mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
+        "@typescript-eslint/project-service": "8.34.1",
+        "@typescript-eslint/tsconfig-utils": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/visitor-keys": "8.34.1",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/utils": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@types/json-schema": "^7.0.12",
-        "@types/semver": "^7.5.0",
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
+        "typescript": ">=4.8.4 <5.9.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.34.1.tgz",
+      "integrity": "sha512-mqOwUdZ3KjtGk7xJJnLbHxTuWVn3GO2WZZuM+Slhkun4+qthLdXx32C8xIXbO1kfCECb3jIs3eoxK3eryk7aoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.34.1",
+        "@typescript-eslint/types": "8.34.1",
+        "@typescript-eslint/typescript-estree": "8.34.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <5.9.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "8.34.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.34.1.tgz",
+      "integrity": "sha512-xoh5rJ+tgsRKoXnkBPFRLZ7rjKM0AfVbC68UZ/ECXoDbfggb9RbEySN359acY1vS3qZ0jVTVWzbtfapwm5ztxw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/types": "8.34.1",
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
     },
     "node_modules/acorn": {
-      "version": "8.11.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-      "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -490,24 +965,9 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/aggregate-error": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-4.0.1.tgz",
-      "integrity": "sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^4.0.0",
-        "indent-string": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ajv": {
@@ -515,6 +975,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -555,6 +1016,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -578,55 +1040,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
-    "node_modules/array-union": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
@@ -636,6 +1061,7 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -643,52 +1069,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
-    },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -697,6 +1083,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -711,71 +1098,16 @@
     "node_modules/chardet": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
-    },
-    "node_modules/clean-stack": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-4.2.0.tgz",
-      "integrity": "sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==",
-      "dev": true,
-      "dependencies": {
-        "escape-string-regexp": "5.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clean-stack/node_modules/escape-string-regexp": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
-      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
       "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -838,121 +1170,32 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/del": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-7.1.0.tgz",
-      "integrity": "sha512-v2KyNk7efxhlyHpjEvfyxaAihKKK0nWCuf6ZtqZcFFpQRG0bJ12Qsr0RpvsICMjAAZ8DOVCxrlqpxISlMHC4Kg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-8.0.0.tgz",
+      "integrity": "sha512-R6ep6JJ+eOBZsBr9esiNN1gxFbZE4Q2cULkUSFumGYecAiS6qodDvcPx/sFuWHMNul7DWmrtoEOpYSm7o6tbSA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "globby": "^13.1.2",
-        "graceful-fs": "^4.2.10",
+        "globby": "^14.0.2",
         "is-glob": "^4.0.3",
         "is-path-cwd": "^3.0.0",
         "is-path-inside": "^4.0.0",
-        "p-map": "^5.5.0",
-        "rimraf": "^3.0.2",
-        "slash": "^4.0.0"
+        "p-map": "^7.0.2",
+        "slash": "^5.1.0"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/del/node_modules/globby": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
-      "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
-      "dev": true,
-      "dependencies": {
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.3.0",
-        "ignore": "^5.2.4",
-        "merge2": "^1.4.1",
-        "slash": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/dir-glob": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "dev": true,
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "engines": {
-        "node": ">= 0.4"
-      }
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -967,67 +1210,77 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.57.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-      "integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.29.0.tgz",
+      "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.0",
-        "@humanwhocodes/config-array": "^0.11.14",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.20.1",
+        "@eslint/config-helpers": "^0.2.1",
+        "@eslint/core": "^0.14.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.29.0",
+        "@eslint/plugin-kit": "^0.3.1",
+        "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
+        "file-entry-cache": "^8.0.0",
         "find-up": "^5.0.0",
         "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
         "ignore": "^5.2.0",
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
-        "url": "https://opencollective.com/eslint"
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
@@ -1043,16 +1296,17 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1071,22 +1325,37 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/eslint/node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=8"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/eslint/node_modules/minimatch": {
@@ -1102,17 +1371,31 @@
       }
     },
     "node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.9.0",
+        "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -1135,6 +1418,7 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -1156,6 +1440,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1164,6 +1449,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
       "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
       "dependencies": {
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
@@ -1177,19 +1463,21 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -1200,6 +1488,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1211,7 +1500,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -1220,24 +1510,26 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "flat-cache": "^3.0.4"
+        "flat-cache": "^4.0.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16.0.0"
       }
     },
     "node_modules/fill-range": {
@@ -1245,6 +1537,7 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1269,29 +1562,31 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
+        "keyv": "^4.5.4"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=16"
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-      "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
-      "dev": true
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fs-extra": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
-      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -1299,58 +1594,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -1365,81 +1608,38 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.2.9",
-        "ignore": "^5.2.0",
-        "merge2": "^1.4.1",
-        "slash": "^3.0.0"
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/globby/node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -1457,58 +1657,16 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -1516,39 +1674,22 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1569,67 +1710,30 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "node_modules/inquirer": {
-      "version": "9.2.19",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.2.19.tgz",
-      "integrity": "sha512-WpxOT71HGsFya6/mj5PUue0sWwbpbiPfAR+332zLj/siB0QA1PZM8v3GepegFV1Op189UxHUCF6y8AySdtOMVA==",
+      "version": "12.6.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.6.3.tgz",
+      "integrity": "sha512-eX9beYAjr1MqYsIjx1vAheXsRk1jbZRvHLcBu5nA9wX0rXR1IfCZLnVLp4Ym4mrhqmh7AuANwcdtgQ291fZDfQ==",
+      "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.1",
-        "@ljharb/through": "^2.3.13",
+        "@inquirer/core": "^10.1.13",
+        "@inquirer/prompts": "^7.5.3",
+        "@inquirer/type": "^3.0.7",
         "ansi-escapes": "^4.3.2",
-        "chalk": "^5.3.0",
-        "cli-cursor": "^3.1.0",
-        "cli-width": "^4.1.0",
-        "external-editor": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mute-stream": "1.0.0",
-        "ora": "^5.4.1",
+        "mute-stream": "^2.0.0",
         "run-async": "^3.0.0",
-        "rxjs": "^7.8.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^6.2.0"
+        "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/inquirer/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/is-extglob": {
@@ -1645,6 +1749,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -1661,19 +1766,12 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-interactive": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -1697,17 +1795,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "engines": {
-        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1743,13 +1830,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1773,6 +1862,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -1816,38 +1906,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -1866,19 +1930,12 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -1896,11 +1953,12 @@
       "dev": true
     },
     "node_modules/mute-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
-      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/natural-compare": {
@@ -1928,29 +1986,6 @@
         }
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
@@ -1968,32 +2003,11 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2029,15 +2043,13 @@
       }
     },
     "node_modules/p-map": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-5.5.0.tgz",
-      "integrity": "sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
-      "dependencies": {
-        "aggregate-error": "^4.0.0"
-      },
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2048,6 +2060,7 @@
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -2064,15 +2077,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -2083,12 +2087,16 @@
       }
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/picomatch": {
@@ -2096,6 +2104,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -2117,6 +2126,7 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2139,65 +2149,28 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
+      ],
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/run-async": {
@@ -2227,71 +2200,37 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/shebang-command": {
@@ -2316,34 +2255,35 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/slash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
-      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2357,6 +2297,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2369,6 +2310,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -2380,6 +2322,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2387,16 +2330,11 @@
         "node": ">=8"
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -2409,6 +2347,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -2422,21 +2361,23 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-api-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.3.0.tgz",
-      "integrity": "sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -2450,23 +2391,12 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.4.tgz",
-      "integrity": "sha512-dGE2Vv8cpVvw28v8HCPqyb08EzbBURxDpuhJvTrusShUfGnhHBafDsLdS1EhhxyL6BJQE+2cT3dDPAv+MQ6oLw==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2476,10 +2406,24 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -2494,21 +2438,9 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-      "dependencies": {
-        "defaults": "^1.0.3"
       }
     },
     "node_modules/webidl-conversions": {
@@ -2549,6 +2481,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2558,18 +2491,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2577,6 +2498,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/generate-docs/scripts/package.json
+++ b/generate-docs/scripts/package.json
@@ -13,19 +13,19 @@
   "devDependencies": {
     "@types/fs-extra": "11.0.4",
     "@types/js-yaml": "4.0.9",
-    "@types/lodash": "4.17.0",
-    "@types/node": "20.12.5",
-    "@typescript-eslint/eslint-plugin": "^6.16.0",
-    "@typescript-eslint/parser": "^6.16.0",
-    "del": "7.1.0",
-    "eslint": "^8.56.0",
-    "eslint-config-prettier": "^9.1.0",
+    "@types/lodash": "4.17.17",
+    "@types/node": "24.0.3",
+    "@typescript-eslint/eslint-plugin": "^8.34.1",
+    "@typescript-eslint/parser": "^8.34.1",
+    "del": "8.0.0",
+    "eslint": "^9.29.0",
+    "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prefer-arrow": "^1.2.3",
-    "typescript": "5.4.4"
+    "typescript": "5.8.3"
   },
   "dependencies": {
-    "fs-extra": "11.2.0",
-    "inquirer": "^9.2.17",
+    "fs-extra": "11.3.0",
+    "inquirer": "^12.6.3",
     "isomorphic-fetch": "^3.0.0",
     "js-yaml": "4.1.0",
     "lodash": "^4.17.21"

--- a/generate-docs/scripts/simple-prompts.ts
+++ b/generate-docs/scripts/simple-prompts.ts
@@ -1,4 +1,5 @@
-import * as inquirer from "inquirer";
+
+import inquirer from 'inquirer';
 import { cloneDeep, isString, isUndefined } from "lodash";
 
 const NO_CHOICE_SELECTED = '---';
@@ -73,6 +74,7 @@ export async function promptFromList(options: {
 
 export async function promptCustomText(message: string): Promise<string> {
     let answer = ((await inquirer.prompt({
+        type:  'input',
         name: 'question',
         message: message
     }))['question'] as string).trim();


### PR DESCRIPTION
Annoyingly, this PR does some benign whitespace change because of the yaml loading. Please verify some standard pages and the one TypeAlias page (internal review site here: https://review.learn.microsoft.com/en-us/javascript/api/office-scripts/excelscript/excelscript.cellcontrol?view=office-scripts&branch=AlexJ-TypeDef).