### PR TITLE
Fix moniker

### DIFF
--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -35,6 +35,7 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "group": "office-scripts",
         "src": "docs-ref-autogen",
         "dest": "api/office-scripts",
         "exclude": [
@@ -49,15 +50,6 @@
           "LICENSE-CODE",
           "ThirdPartyNotices"
         ]
-      },
-      {
-        "files": [
-          "**/*.md",
-          "**/*.yml"
-        ],
-        "group": "office-scripts",
-        "src": "docs-ref-autogen",
-        "dest": "api/office-scripts"
       },
       {
         "files": [


### PR DESCRIPTION
This PR fixes the issue that the content lost moniker.

docfx.json has two duplicated build entry. First one does not configured moniker (the property `group`), the later one has the configuration. But the first one takes effect. The moniker is not working.

[Current Page:](https://learn.microsoft.com/en-us/javascript/api/office-scripts/excelscript)
<img width="2006" height="761" alt="image" src="https://github.com/user-attachments/assets/17014838-b860-4cd1-aeca-d99b8ecdac16" />

[Fixed Page:](https://review.learn.microsoft.com/en-us/javascript/api/office-scripts/excelscript?view=office-scripts&branch=pr-en-us-387)
<img width="2338" height="644" alt="image" src="https://github.com/user-attachments/assets/be6cbaad-6939-4883-90aa-f92d5bf08b7f" />
