### PR TITLE
[admin] Convert @throws to normal description text

### DIFF
--- a/docs/docs-ref-autogen/officescript.yml
+++ b/docs/docs-ref-autogen/officescript.yml
@@ -102,6 +102,22 @@ functions:
       necessarily indicate that the API failed. The workbook copy may still be
       created, but after the timeout limit this API does not return a success or
       failure message.
+
+
+      **Throws**: `ExternalAPITimeout` The error thrown if the API reaches
+      the timeout limit of 30 seconds. Note that the copy may still be created.
+
+
+      **Throws**: `InvalidExtensionError` The error thrown if the file name
+      doesn't end with ".xlsx".
+
+
+      **Throws**: `SaveCopyAsFileMayAlreadyExistError` The error thrown if
+      the file name of the copy already exists.
+
+
+      **Throws**: `SaveCopyAsFileNotOnOneDriveError` The error thrown if the
+      document is not saved to OneDrive.
     remarks: ''
 
     isPreview: true

--- a/generate-docs/api-extractor-inputs-officescript/officescript.d.ts
+++ b/generate-docs/api-extractor-inputs-officescript/officescript.d.ts
@@ -3,10 +3,14 @@ export declare namespace OfficeScript {
      * Saves a copy of the current workbook in OneDrive, in the same directory as the original file, with the specified file name.
      * The API has a timeout limit of 30 seconds. This limit is rarely exceeded.
      * Note: Timeout doesn't necessarily indicate that the API failed. The workbook copy may still be created, but after the timeout limit this API does not return a success or failure message.
-     * @throws ExternalApiTimeout The error thrown if the API reaches the timeout limit of 30 seconds. Note that the copy may still be created.
-     * @throws InvalidExtensionError The error thrown if the file name doesn't end with ".xlsx".
-     * @throws SaveCopyAsFileMayAlreadyExistError The error thrown if the file name of the copy already exists.
-     * @throws SaveCopyAsFileNotOnOneDriveError The error thrown if the document is not saved to OneDrive.
+     
+     * **Throws**:  `ExternalApiTimeout` The error thrown if the API reaches the timeout limit of 30 seconds. Note that the copy may still be created.
+     
+     * **Throws**:  `InvalidExtensionError` The error thrown if the file name doesn't end with ".xlsx".
+     
+     * **Throws**:  `SaveCopyAsFileMayAlreadyExistError` The error thrown if the file name of the copy already exists.
+     
+     * **Throws**:  `SaveCopyAsFileNotOnOneDriveError` The error thrown if the document is not saved to OneDrive.
      * @param filename - The file name of the copied and saved file. The file name must end with ".xlsx".
      * @beta
      */

--- a/generate-docs/scripts/preprocessor.ts
+++ b/generate-docs/scripts/preprocessor.ts
@@ -118,8 +118,8 @@ function applyRegularExpressions (definitionsIn) {
         .replace(/^(\s*)(interface)(\s+)/gm, `$1export $2$3`)
         .replace(/^(\s*)(module)(\s+)/gm, `$1export $2$3`)
         .replace(/^(\s*)(function)(\s+)/gm, `$1export $2$3`)
-        .replace(/(\s*)(@param)(\s+)(\w+)(\s)(\s)/g, `$1$2$3$4$5`)
-        .replace(/(\s*)(@param)(\s+)(\w+)(\s+)([^\-])/g, `$1$2$3$4$5- $6`);
+        .replace(/(\s*)(@param)(\s+)(\w+)(\s+)([^\-])/g, `$1$2$3$4$5- $6`)
+        .replace(/(\s*)\*(\s*)(@throws)(\s+)(\w+)(.*)/g, `$1$1*$2**Throws**: $4\`$5\`$6`);
 }
 
 function readySnippets(snippetsSourceFile: string, snippetDestinationFile: string) {


### PR DESCRIPTION
The `@throws` TSDoc isn't handled properly by the API Extractor/Documenter chain. This PR adds some text conversion to the preprocessor to keep the information in the docs.