### PR TITLE
[all hosts] (workflows) Update to use node.js LTS

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -2,7 +2,7 @@ name: auto-publish
 run-name: Automatically publish documentation
 on:
   schedule:
-    # Run at 2:15 AM UTC on Wednesday and Friday
+    # Run at 2:15 AM UTC on Wednesday and Friday.
     - cron: '15 2 * * WED,FRI'
 jobs:
   auto-publish:
@@ -15,7 +15,7 @@ jobs:
         working-directory: ./
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Check out main

--- a/.github/workflows/autogen-docs.yml
+++ b/.github/workflows/autogen-docs.yml
@@ -2,6 +2,7 @@ name: autogen-docs
 run-name: Automatically run GenerateDocs
 on:
   schedule:
+    # Run at 10:45 AM UTC on Tuesday and Thursday.
     - cron: '45 10 * * TUE'
     - cron: '45 10 * * THU'
 jobs:
@@ -15,15 +16,16 @@ jobs:
         working-directory: ./generate-docs
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Make the script file executable
         run: |
           echo "Making script file executable"
           chmod +x ./GenerateDocs.sh
       - name: Set up node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '18'
+          # Use an Active LTS version of Node.js.
+          node-version: 'lts/*'
       - name: Run GenerateDocs script
         run: |
           echo "Generating docs"


### PR DESCRIPTION
Updated the jobs to use the active LTS version and updated the dependent actions to versions that support the active LTS version. Addresses run warnings.

I did an ad-hoc run of the office-js-docs-reference autogen-docs workflow and found no issues.