### PR TITLE
[scripts] Add 'Used by' sections to API reference pages

### DIFF
--- a/docs/docs-ref-autogen/excelscript/excelscript.aggregationfunction.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.aggregationfunction.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.AggregationFunction:enum
 package: ExcelScript!
 fullName: ExcelScript.AggregationFunction
 summary: Aggregation function for the `DataPivotHierarchy`<!-- -->.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataPivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy):
+  [getSummarizeBy](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy#excelscript-excelscript-datapivothierarchy-getsummarizeby-member(1)),
+  [setSummarizeBy](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy#excelscript-excelscript-datapivothierarchy-setsummarizeby-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script changes how the data in a PivotTable is aggregated.
    */
@@ -21,6 +33,7 @@ remarks: |-
     const dataHierarchy = pivotTable.getDataHierarchies()[0];
     dataHierarchy.setSummarizeBy(ExcelScript.AggregationFunction.average);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.alloweditrange.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.alloweditrange.yml
@@ -8,7 +8,14 @@ summary: >-
   with worksheet protection properties. When worksheet protection is enabled, an
   `AllowEditRange` object can be used to allow editing of a specific range,
   while maintaining protection on the rest of the worksheet.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.WorksheetProtection](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection):
+  [getAllowEditRange](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-getalloweditrange-member(1)),
+  [getAllowEditRanges](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-getalloweditranges-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.alloweditrangeoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.alloweditrangeoptions.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.AllowEditRangeOptions
 summary: >-
   The interface used to construct optional fields of the `AllowEditRange`
   object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.WorksheetProtection](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection):
+  [addAllowEditRange](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-addalloweditrange-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a password-protected, editable range
    * to an otherwise protected worksheet.
@@ -32,6 +43,7 @@ remarks: |-
       // Protect the worksheet.
       sheetProtection.protect();
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.application.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.application.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.Application:interface
 package: ExcelScript!
 fullName: ExcelScript.Application
 summary: Represents the Excel application that manages the workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getApplication](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getapplication-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.arrowheadlength.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.arrowheadlength.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.ArrowheadLength:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadLength
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Line](/javascript/api/office-scripts/excelscript/excelscript.line):
+  [getBeginArrowheadLength](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getbeginarrowheadlength-member(1)),
+  [getEndArrowheadLength](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getendarrowheadlength-member(1)),
+  [setBeginArrowheadLength](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setbeginarrowheadlength-member(1)),
+  [setEndArrowheadLength](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setendarrowheadlength-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a line that goes from cell B2 to cell F4 on the current worksheet.
    */ 
@@ -34,6 +48,7 @@ remarks: |-
     line.setEndArrowheadStyle(ExcelScript.ArrowheadStyle.open);
     line.setEndArrowheadLength(ExcelScript.ArrowheadLength.long);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.arrowheadstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.arrowheadstyle.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.ArrowheadStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadStyle
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Line](/javascript/api/office-scripts/excelscript/excelscript.line):
+  [getBeginArrowheadStyle](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getbeginarrowheadstyle-member(1)),
+  [getEndArrowheadStyle](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getendarrowheadstyle-member(1)),
+  [setBeginArrowheadStyle](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setbeginarrowheadstyle-member(1)),
+  [setEndArrowheadStyle](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setendarrowheadstyle-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a line that goes from cell B2 to cell F4 on the current worksheet.
    */ 
@@ -33,6 +47,7 @@ remarks: |-
     const line = newShape.getLine();
     line.setEndArrowheadStyle(ExcelScript.ArrowheadStyle.open);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.arrowheadwidth.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.arrowheadwidth.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.ArrowheadWidth:enum
 package: ExcelScript!
 fullName: ExcelScript.ArrowheadWidth
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Line](/javascript/api/office-scripts/excelscript/excelscript.line):
+  [getBeginArrowheadWidth](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getbeginarrowheadwidth-member(1)),
+  [getEndArrowheadWidth](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getendarrowheadwidth-member(1)),
+  [setBeginArrowheadWidth](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setbeginarrowheadwidth-member(1)),
+  [setEndArrowheadWidth](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setendarrowheadwidth-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a line that goes from cell B2 to cell F4 on the current worksheet.
    */ 
@@ -34,6 +48,7 @@ remarks: |-
     line.setEndArrowheadStyle(ExcelScript.ArrowheadStyle.triangle);
     line.setEndArrowheadWidth(ExcelScript.ArrowheadWidth.wide);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.autofilltype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.autofilltype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.AutoFillType:enum
 package: ExcelScript!
 fullName: ExcelScript.AutoFillType
 summary: The behavior types when AutoFill is used on a range in the workbook.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [autoFill](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-autofill-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script uses the autofill feature to complete a table with days of the month.
    * See https://support.microsoft.com/office/74e31bdd-d993-45da-aa82-35a236c5b5db
@@ -25,6 +36,7 @@ remarks: |-
     // Autofill the connected range. C2:C3 are filled in with dates. C4:C54 are blank.
     dataRange.autoFill("C2:C54", ExcelScript.AutoFillType.fillDays);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.autofilter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.autofilter.yml
@@ -6,12 +6,27 @@ fullName: ExcelScript.AutoFilter
 summary: >-
   Represents the `AutoFilter` object. AutoFilter turns the values in Excel
   column into specific filters based on the cell contents.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Table](/javascript/api/office-scripts/excelscript/excelscript.table):
+  [getAutoFilter](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getautofilter-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [getAutoFilter](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getautofilter-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates an autoFilter on the worksheet that filters out rows based on column values. 
    * The autoFilter filters to only include rows that have a value in column C in the lowest 10 values 
@@ -30,6 +45,7 @@ remarks: |-
       filterOn: ExcelScript.FilterOn.bottomItems
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.basicdatavalidation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.basicdatavalidation.yml
@@ -4,12 +4,25 @@ uid: ExcelScript!ExcelScript.BasicDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.BasicDataValidation
 summary: Represents the basic type data validation criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidationRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule):
+  [decimal](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-decimal-member),
+  [textLength](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-textlength-member),
+  [wholeNumber](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-wholenumber-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a data validation rule for the range B1:B5.
    * All values in that range must be a positive number.
@@ -42,6 +55,7 @@ remarks: |-
     };
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.binding.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.binding.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.Binding:interface
 package: ExcelScript!
 fullName: ExcelScript.Binding
 summary: Represents an Office.js binding that is defined in the workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addBinding](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbinding-member(1)),
+  [addBindingFromNamedItem](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbindingfromnameditem-member(1)),
+  [addBindingFromSelection](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbindingfromselection-member(1)),
+  [getBinding](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getbinding-member(1)),
+  [getBindings](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getbindings-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.bindingtype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.bindingtype.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.BindingType:enum
 package: ExcelScript!
 fullName: ExcelScript.BindingType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Binding](/javascript/api/office-scripts/excelscript/excelscript.binding):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.binding#excelscript-excelscript-binding-gettype-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addBinding](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbinding-member(1)),
+  [addBindingFromNamedItem](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbindingfromnameditem-member(1)),
+  [addBindingFromSelection](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbindingfromselection-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.borderindex.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.borderindex.yml
@@ -4,12 +4,31 @@ uid: ExcelScript!ExcelScript.BorderIndex:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderIndex
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getrangeborder-member(1))
+
+  -
+  [ExcelScript.RangeBorder](/javascript/api/office-scripts/excelscript/excelscript.rangeborder):
+  [getSideIndex](/javascript/api/office-scripts/excelscript/excelscript.rangeborder#excelscript-excelscript-rangeborder-getsideindex-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getrangeborder-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a border around a range.
    */
@@ -36,6 +55,7 @@ remarks: |-
     edgeRight.setStyle(ExcelScript.BorderLineStyle.dashDot);
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.borderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.borderlinestyle.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.BorderLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderLineStyle
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeBorder](/javascript/api/office-scripts/excelscript/excelscript.rangeborder):
+  [getStyle](/javascript/api/office-scripts/excelscript/excelscript.rangeborder#excelscript-excelscript-rangeborder-getstyle-member(1)),
+  [setStyle](/javascript/api/office-scripts/excelscript/excelscript.rangeborder#excelscript-excelscript-rangeborder-setstyle-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a border around a range.
    */
@@ -36,6 +48,7 @@ remarks: |-
     edgeRight.setStyle(ExcelScript.BorderLineStyle.dashDot);
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.borderweight.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.borderweight.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.BorderWeight:enum
 package: ExcelScript!
 fullName: ExcelScript.BorderWeight
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeBorder](/javascript/api/office-scripts/excelscript/excelscript.rangeborder):
+  [getWeight](/javascript/api/office-scripts/excelscript/excelscript.rangeborder#excelscript-excelscript-rangeborder-getweight-member(1)),
+  [setWeight](/javascript/api/office-scripts/excelscript/excelscript.rangeborder#excelscript-excelscript-rangeborder-setweight-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a border around a range.
    */
@@ -36,6 +48,7 @@ remarks: |-
     edgeRight.setStyle(ExcelScript.BorderLineStyle.dashDot);
     edgeRight.setWeight(ExcelScript.BorderWeight.thick);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.calculationmode.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.calculationmode.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.CalculationMode:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationMode
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Application](/javascript/api/office-scripts/excelscript/excelscript.application):
+  [getCalculationMode](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-getcalculationmode-member(1)),
+  [setCalculationMode](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-setcalculationmode-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script recalculates the used range of a specific worksheet.
    */
@@ -25,6 +37,7 @@ remarks: |-
       sheet.getUsedRange().calculate();
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.calculationstate.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.calculationstate.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.CalculationState:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationState
 summary: Represents the state of calculation across the entire Excel application.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Application](/javascript/api/office-scripts/excelscript/excelscript.application):
+  [getCalculationState](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-getcalculationstate-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script uses the fill color of the first cell to indicate the current
    * calculation state of the workbook.
@@ -35,6 +46,7 @@ remarks: |-
         break;
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.calculationtype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.calculationtype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.CalculationType:enum
 package: ExcelScript!
 fullName: ExcelScript.CalculationType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Application](/javascript/api/office-scripts/excelscript/excelscript.application):
+  [calculate](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-calculate-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script fully recalculates the entire workbook.
    * This code is useful when automatic recalculation is turned off
@@ -19,6 +30,7 @@ remarks: |-
     const application = workbook.getApplication();
     application.calculate(ExcelScript.CalculationType.fullRebuild);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.cellcontrol.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.cellcontrol.yml
@@ -5,6 +5,13 @@ package: ExcelScript!
 fullName: ExcelScript.CellControl
 summary: Represents an interactable control inside of a cell.
 remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getControl](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getcontrol-member(1)),
+  [setControl](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-setcontrol-member(1))
 
 
   Learn more about the types in this type alias through the following links. 

--- a/docs/docs-ref-autogen/excelscript/excelscript.cellvalueconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.cellvalueconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.CellValueConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.CellValueConditionalFormat
 summary: Represents a cell value conditional format.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getCellValue](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getcellvalue-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies conditional formatting to a range.
    * That formatting is conditional upon the cell's numerical value.
@@ -37,6 +48,7 @@ remarks: |-
     format.getFill().setColor("yellow");
     format.getFont().setItalic(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chart.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chart.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.Chart:interface
 package: ExcelScript!
 fullName: ExcelScript.Chart
 summary: Represents a chart object in a workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getActiveChart](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getactivechart-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addChart](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addchart-member(1)),
+  [getChart](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getchart-member(1)),
+  [getCharts](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcharts-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartareaformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartareaformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartAreaFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAreaFormat
 summary: Encapsulates the format properties for the overall chart area.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxes.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxes.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ChartAxes:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxes
 summary: Represents the chart axes.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getAxes](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getaxes-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample gets the chart axes and customizes them.
    * This assumes the active worksheet has a chart.
@@ -24,6 +35,7 @@ remarks: |-
     axes.getValueAxis().setDisplayUnit(ExcelScript.ChartAxisDisplayUnit.thousands);
     axes.getCategoryAxis().setVisible(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxis.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxis.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.ChartAxis:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxis
 summary: Represents a single axis in a chart.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxes](/javascript/api/office-scripts/excelscript/excelscript.chartaxes):
+  [getCategoryAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getcategoryaxis-member(1)),
+  [getChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getchartaxis-member(1)),
+  [getSeriesAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getseriesaxis-member(1)),
+  [getValueAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getvalueaxis-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample customizes the value axis of a chart.
    * This assumes the active worksheet has a chart.
@@ -25,6 +39,7 @@ remarks: |-
     valueAxis.setMaximum(60000);
     valueAxis.setDisplayUnit(ExcelScript.ChartAxisDisplayUnit.thousands);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxiscategorytype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxiscategorytype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartAxisCategoryType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisCategoryType
 summary: Specifies the type of the category axis.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getCategoryType](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getcategorytype-member(1)),
+  [setCategoryType](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setcategorytype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisdisplayunit.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisdisplayunit.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartAxisDisplayUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisDisplayUnit
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getDisplayUnit](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getdisplayunit-member(1)),
+  [setDisplayUnit](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setdisplayunit-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartAxisFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisFormat
 summary: Encapsulates the format properties for the chart axis.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisgroup.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisgroup.yml
@@ -4,7 +4,22 @@ uid: ExcelScript!ExcelScript.ChartAxisGroup:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisGroup
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxes](/javascript/api/office-scripts/excelscript/excelscript.chartaxes):
+  [getChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getchartaxis-member(1))
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getAxisGroup](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getaxisgroup-member(1))
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getAxisGroup](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getaxisgroup-member(1)),
+  [setAxisGroup](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setaxisgroup-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisposition.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartAxisPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisPosition
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisscaletype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisscaletype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartAxisScaleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisScaleType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getScaleType](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getscaletype-member(1)),
+  [setScaleType](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setscaletype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxisticklabelposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxisticklabelposition.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartAxisTickLabelPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTickLabelPosition
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getTickLabelPosition](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getticklabelposition-member(1)),
+  [setTickLabelPosition](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setticklabelposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxistickmark.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxistickmark.yml
@@ -4,7 +4,16 @@ uid: ExcelScript!ExcelScript.ChartAxisTickMark:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTickMark
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getMajorTickMark](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getmajortickmark-member(1)),
+  [getMinorTickMark](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getminortickmark-member(1)),
+  [setMajorTickMark](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setmajortickmark-member(1)),
+  [setMinorTickMark](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setminortickmark-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxistimeunit.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxistimeunit.yml
@@ -4,7 +4,18 @@ uid: ExcelScript!ExcelScript.ChartAxisTimeUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTimeUnit
 summary: Specifies the unit of time for chart axes and data series.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getBaseTimeUnit](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getbasetimeunit-member(1)),
+  [getMajorTimeUnitScale](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getmajortimeunitscale-member(1)),
+  [getMinorTimeUnitScale](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getminortimeunitscale-member(1)),
+  [setBaseTimeUnit](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setbasetimeunit-member(1)),
+  [setMajorTimeUnitScale](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setmajortimeunitscale-member(1)),
+  [setMinorTimeUnitScale](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setminortimeunitscale-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxistitle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxistitle.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartAxisTitle:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTitle
 summary: Represents the title of a chart axis.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getTitle](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-gettitle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxistitleformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxistitleformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartAxisTitleFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisTitleFormat
 summary: Represents the chart axis title formatting.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxisTitle](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitle):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitle#excelscript-excelscript-chartaxistitle-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartaxistype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartaxistype.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.ChartAxisType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartAxisType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxes](/javascript/api/office-scripts/excelscript/excelscript.chartaxes):
+  [getChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxes#excelscript-excelscript-chartaxes-getchartaxis-member(1))
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-gettype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartbinoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartbinoptions.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartBinOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBinOptions
 summary: Encapsulates the bin options for histogram charts and pareto charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getBinOptions](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getbinoptions-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartbintype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartbintype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartBinType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartBinType
 summary: Specifies the bin type of a histogram chart or pareto chart series.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartBinOptions](/javascript/api/office-scripts/excelscript/excelscript.chartbinoptions):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.chartbinoptions#excelscript-excelscript-chartbinoptions-gettype-member(1)),
+  [setType](/javascript/api/office-scripts/excelscript/excelscript.chartbinoptions#excelscript-excelscript-chartbinoptions-settype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartborder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartborder.yml
@@ -4,7 +4,45 @@ uid: ExcelScript!ExcelScript.ChartBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBorder
 summary: Represents the border formatting of a chart element.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat#excelscript-excelscript-chartareaformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartAxisTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat#excelscript-excelscript-chartaxistitleformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartDataLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat#excelscript-excelscript-chartdatalabelformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartDataTableFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat#excelscript-excelscript-chartdatatableformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartLegendFormat](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat#excelscript-excelscript-chartlegendformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartPlotAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartplotareaformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartplotareaformat#excelscript-excelscript-chartplotareaformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartPointFormat](/javascript/api/office-scripts/excelscript/excelscript.chartpointformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.chartpointformat#excelscript-excelscript-chartpointformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat#excelscript-excelscript-charttitleformat-getborder-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat):
+  [getBorder](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat#excelscript-excelscript-charttrendlinelabelformat-getborder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartboxquartilecalculation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartboxquartilecalculation.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartBoxQuartileCalculation
 summary: >-
   Represents the quartile calculation type of chart series layout. Only applies
   to a box and whisker chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartBoxwhiskerOptions](/javascript/api/office-scripts/excelscript/excelscript.chartboxwhiskeroptions):
+  [getQuartileCalculation](/javascript/api/office-scripts/excelscript/excelscript.chartboxwhiskeroptions#excelscript-excelscript-chartboxwhiskeroptions-getquartilecalculation-member(1)),
+  [setQuartileCalculation](/javascript/api/office-scripts/excelscript/excelscript.chartboxwhiskeroptions#excelscript-excelscript-chartboxwhiskeroptions-setquartilecalculation-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartboxwhiskeroptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartboxwhiskeroptions.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartBoxwhiskerOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartBoxwhiskerOptions
 summary: Represents the properties of a box and whisker chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getBoxwhiskerOptions](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getboxwhiskeroptions-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartcolorscheme.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartcolorscheme.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartColorScheme:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartColorScheme
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat):
+  [getColorScheme](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat#excelscript-excelscript-chartareaformat-getcolorscheme-member(1)),
+  [setColorScheme](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat#excelscript-excelscript-chartareaformat-setcolorscheme-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabel.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabel.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartDataLabel:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabel
 summary: Represents the data label of a chart point.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartPoint](/javascript/api/office-scripts/excelscript/excelscript.chartpoint):
+  [getDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartpoint#excelscript-excelscript-chartpoint-getdatalabel-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelanchor.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelanchor.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartDataLabelAnchor:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelAnchor
 summary: Represents the chart data label anchor.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getTailAnchor](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-gettailanchor-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelformat.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.ChartDataLabelFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelFormat
 summary: Encapsulates the format properties for the chart data labels.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-getformat-member(1))
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabelposition.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.ChartDataLabelPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabelPosition
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-setposition-member(1))
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-setposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabels.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatalabels.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.ChartDataLabels:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataLabels
 summary: Represents a collection of all the data labels on a chart point.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getdatalabels-member(1))
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getdatalabels-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample configures data labels on a chart series.
    * This assumes the active worksheet has a pie chart.
@@ -27,6 +42,7 @@ remarks: |-
     dataLabels.setShowCategoryName(false);
     dataLabels.setShowValue(false);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatasourcetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatasourcetype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartDataSourceType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDataSourceType
 summary: Specifies the data source type of the chart series.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getDimensionDataSourceType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getdimensiondatasourcetype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatatable.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatatable.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartDataTable:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataTable
 summary: Represents the data table object of a chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getDataTable](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getdatatable-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdatatableformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdatatableformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartDataTableFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartDataTableFormat
 summary: Represents the format of a chart data table.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataTable](/javascript/api/office-scripts/excelscript/excelscript.chartdatatable):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatatable#excelscript-excelscript-chartdatatable-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartdisplayblanksas.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartdisplayblanksas.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartDisplayBlanksAs:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartDisplayBlanksAs
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getDisplayBlanksAs](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getdisplayblanksas-member(1)),
+  [setDisplayBlanksAs](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setdisplayblanksas-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charterrorbars.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charterrorbars.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartErrorBars:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBars
 summary: This object represents the attributes for a chart's error bars.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getXErrorBars](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getxerrorbars-member(1)),
+  [getYErrorBars](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getyerrorbars-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarsformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarsformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartErrorBarsFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsFormat
 summary: Encapsulates the format properties for chart error bars.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartErrorBars](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars#excelscript-excelscript-charterrorbars-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarsinclude.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarsinclude.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartErrorBarsInclude:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsInclude
 summary: Represents which parts of the error bar to include.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartErrorBars](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars):
+  [getInclude](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars#excelscript-excelscript-charterrorbars-getinclude-member(1)),
+  [setInclude](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars#excelscript-excelscript-charterrorbars-setinclude-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarstype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charterrorbarstype.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.ChartErrorBarsType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartErrorBarsType
 summary: Represents the range type for error bars.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartErrorBars](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars#excelscript-excelscript-charterrorbars-gettype-member(1)),
+  [setType](/javascript/api/office-scripts/excelscript/excelscript.charterrorbars#excelscript-excelscript-charterrorbars-settype-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds error bars for the standard error of each chart series point.
    */
@@ -28,6 +40,7 @@ remarks: |-
       series.getYErrorBars().setVisible(true);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartfill.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartfill.yml
@@ -4,12 +4,63 @@ uid: ExcelScript!ExcelScript.ChartFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartFill
 summary: Represents the fill formatting for a chart element.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat#excelscript-excelscript-chartareaformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartAxisFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat#excelscript-excelscript-chartaxisformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartAxisTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat#excelscript-excelscript-chartaxistitleformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartDataLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat#excelscript-excelscript-chartdatalabelformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartDataTableFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat#excelscript-excelscript-chartdatatableformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartLegendFormat](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat#excelscript-excelscript-chartlegendformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartPlotAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartplotareaformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartplotareaformat#excelscript-excelscript-chartplotareaformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartPointFormat](/javascript/api/office-scripts/excelscript/excelscript.chartpointformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartpointformat#excelscript-excelscript-chartpointformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartSeriesFormat](/javascript/api/office-scripts/excelscript/excelscript.chartseriesformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.chartseriesformat#excelscript-excelscript-chartseriesformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat#excelscript-excelscript-charttitleformat-getfill-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat#excelscript-excelscript-charttrendlinelabelformat-getfill-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample sets the fill color of a chart series.
    * This assumes the active worksheet has a stock chart (e.g., Volume-High-Low-Close).
@@ -23,6 +74,7 @@ remarks: |-
     const volumeSeries = chart.getSeries()[0];
     volumeSeries.getFormat().getFill().setSolidColor("#B0C4DE");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartfont.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartfont.yml
@@ -6,7 +6,45 @@ fullName: ExcelScript.ChartFont
 summary: >-
   This object represents the font attributes (such as font name, font size, and
   color) for a chart object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAreaFormat](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartareaformat#excelscript-excelscript-chartareaformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartAxisFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat#excelscript-excelscript-chartaxisformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartAxisTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartaxistitleformat#excelscript-excelscript-chartaxistitleformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartDataLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabelformat#excelscript-excelscript-chartdatalabelformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartDataTableFormat](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartdatatableformat#excelscript-excelscript-chartdatatableformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartFormatString](/javascript/api/office-scripts/excelscript/excelscript.chartformatstring):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartformatstring#excelscript-excelscript-chartformatstring-getfont-member(1))
+
+  -
+  [ExcelScript.ChartLegendFormat](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.chartlegendformat#excelscript-excelscript-chartlegendformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartTitleFormat](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.charttitleformat#excelscript-excelscript-charttitleformat-getfont-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineLabelFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabelformat#excelscript-excelscript-charttrendlinelabelformat-getfont-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartformatstring.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartformatstring.yml
@@ -6,7 +6,17 @@ fullName: ExcelScript.ChartFormatString
 summary: >-
   Represents the substring in chart related objects that contain text, like a
   `ChartTitle` object or `ChartAxisTitle` object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getSubstring](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-getsubstring-member(1))
+
+  -
+  [ExcelScript.ChartTitle](/javascript/api/office-scripts/excelscript/excelscript.charttitle):
+  [getSubstring](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-getsubstring-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartgradientstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartgradientstyle.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartGradientStyle
 summary: >-
   Represents the gradient style of a chart series. This is only applicable for
   region map charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getGradientStyle](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getgradientstyle-member(1)),
+  [setGradientStyle](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setgradientstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartgradientstyletype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartgradientstyletype.yml
@@ -6,7 +6,18 @@ fullName: ExcelScript.ChartGradientStyleType
 summary: >-
   Represents the gradient style type of a chart series. This is only applicable
   for region map charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getGradientMaximumType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getgradientmaximumtype-member(1)),
+  [getGradientMidpointType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getgradientmidpointtype-member(1)),
+  [getGradientMinimumType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getgradientminimumtype-member(1)),
+  [setGradientMaximumType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setgradientmaximumtype-member(1)),
+  [setGradientMidpointType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setgradientmidpointtype-member(1)),
+  [setGradientMinimumType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setgradientminimumtype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartgridlines.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartgridlines.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartGridlines:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartGridlines
 summary: Represents major or minor gridlines on a chart axis.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getMajorGridlines](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getmajorgridlines-member(1)),
+  [getMinorGridlines](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getminorgridlines-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartgridlinesformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartgridlinesformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartGridlinesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartGridlinesFormat
 summary: Encapsulates the format properties for chart gridlines.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartGridlines](/javascript/api/office-scripts/excelscript/excelscript.chartgridlines):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartgridlines#excelscript-excelscript-chartgridlines-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartleaderlines.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartleaderlines.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartLeaderLines:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLeaderLines
 summary: Gets an object that represents the formatting of chart leader lines.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getLeaderLines](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-getleaderlines-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartleaderlinesformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartleaderlinesformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartLeaderLinesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLeaderLinesFormat
 summary: Encapsulates the format properties for leader lines.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartLeaderLines](/javascript/api/office-scripts/excelscript/excelscript.chartleaderlines):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartleaderlines#excelscript-excelscript-chartleaderlines-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlegend.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlegend.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ChartLegend:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegend
 summary: Represents the legend in a chart.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getLegend](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getlegend-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample configures the chart legend.
    * This assumes the active worksheet has a chart.
@@ -24,6 +35,7 @@ remarks: |-
     legend.setPosition(ExcelScript.ChartLegendPosition.bottom);
     legend.setVisible(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlegendentry.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlegendentry.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartLegendEntry:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendEntry
 summary: Represents the legend entry in `legendEntryCollection`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartLegend](/javascript/api/office-scripts/excelscript/excelscript.chartlegend):
+  [getLegendEntries](/javascript/api/office-scripts/excelscript/excelscript.chartlegend#excelscript-excelscript-chartlegend-getlegendentries-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlegendformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlegendformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartLegendFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendFormat
 summary: Encapsulates the format properties of a chart legend.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartLegend](/javascript/api/office-scripts/excelscript/excelscript.chartlegend):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartlegend#excelscript-excelscript-chartlegend-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlegendposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlegendposition.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartLegendPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartLegendPosition
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartLegend](/javascript/api/office-scripts/excelscript/excelscript.chartlegend):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.chartlegend#excelscript-excelscript-chartlegend-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chartlegend#excelscript-excelscript-chartlegend-setposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlineformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlineformat.yml
@@ -4,7 +4,33 @@ uid: ExcelScript!ExcelScript.ChartLineFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartLineFormat
 summary: Encapsulates the formatting options for line elements.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxisFormat](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.chartaxisformat#excelscript-excelscript-chartaxisformat-getline-member(1))
+
+  -
+  [ExcelScript.ChartErrorBarsFormat](/javascript/api/office-scripts/excelscript/excelscript.charterrorbarsformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.charterrorbarsformat#excelscript-excelscript-charterrorbarsformat-getline-member(1))
+
+  -
+  [ExcelScript.ChartGridlinesFormat](/javascript/api/office-scripts/excelscript/excelscript.chartgridlinesformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.chartgridlinesformat#excelscript-excelscript-chartgridlinesformat-getline-member(1))
+
+  -
+  [ExcelScript.ChartLeaderLinesFormat](/javascript/api/office-scripts/excelscript/excelscript.chartleaderlinesformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.chartleaderlinesformat#excelscript-excelscript-chartleaderlinesformat-getline-member(1))
+
+  -
+  [ExcelScript.ChartSeriesFormat](/javascript/api/office-scripts/excelscript/excelscript.chartseriesformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.chartseriesformat#excelscript-excelscript-chartseriesformat-getline-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendlineformat):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.charttrendlineformat#excelscript-excelscript-charttrendlineformat-getline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartlinestyle.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.ChartLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartLineStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartBorder](/javascript/api/office-scripts/excelscript/excelscript.chartborder):
+  [getLineStyle](/javascript/api/office-scripts/excelscript/excelscript.chartborder#excelscript-excelscript-chartborder-getlinestyle-member(1)),
+  [setLineStyle](/javascript/api/office-scripts/excelscript/excelscript.chartborder#excelscript-excelscript-chartborder-setlinestyle-member(1))
+
+  -
+  [ExcelScript.ChartLineFormat](/javascript/api/office-scripts/excelscript/excelscript.chartlineformat):
+  [getLineStyle](/javascript/api/office-scripts/excelscript/excelscript.chartlineformat#excelscript-excelscript-chartlineformat-getlinestyle-member(1)),
+  [setLineStyle](/javascript/api/office-scripts/excelscript/excelscript.chartlineformat#excelscript-excelscript-chartlineformat-setlinestyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartmaparealevel.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartmaparealevel.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartMapAreaLevel
 summary: >-
   Represents the mapping level of a chart series. This only applies to region
   map charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartMapOptions](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions):
+  [getLevel](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-getlevel-member(1)),
+  [setLevel](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-setlevel-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartmaplabelstrategy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartmaplabelstrategy.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartMapLabelStrategy
 summary: >-
   Represents the region level of a chart series layout. This only applies to
   region map charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartMapOptions](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions):
+  [getLabelStrategy](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-getlabelstrategy-member(1)),
+  [setLabelStrategy](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-setlabelstrategy-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartmapoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartmapoptions.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartMapOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartMapOptions
 summary: Encapsulates the properties for a region map chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getMapOptions](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getmapoptions-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartmapprojectiontype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartmapprojectiontype.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartMapProjectionType
 summary: >-
   Represents the region projection type of a chart series layout. This only
   applies to region map charts.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartMapOptions](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions):
+  [getProjectionType](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-getprojectiontype-member(1)),
+  [setProjectionType](/javascript/api/office-scripts/excelscript/excelscript.chartmapoptions#excelscript-excelscript-chartmapoptions-setprojectiontype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartmarkerstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartmarkerstyle.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.ChartMarkerStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartMarkerStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartPoint](/javascript/api/office-scripts/excelscript/excelscript.chartpoint):
+  [getMarkerStyle](/javascript/api/office-scripts/excelscript/excelscript.chartpoint#excelscript-excelscript-chartpoint-getmarkerstyle-member(1)),
+  [setMarkerStyle](/javascript/api/office-scripts/excelscript/excelscript.chartpoint#excelscript-excelscript-chartpoint-setmarkerstyle-member(1))
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getMarkerStyle](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getmarkerstyle-member(1)),
+  [setMarkerStyle](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setmarkerstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartparentlabelstrategy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartparentlabelstrategy.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ChartParentLabelStrategy
 summary: >-
   Represents the parent label strategy of the chart series layout. This only
   applies to treemap charts
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getParentLabelStrategy](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getparentlabelstrategy-member(1)),
+  [setParentLabelStrategy](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setparentlabelstrategy-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartpivotoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartpivotoptions.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartPivotOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPivotOptions
 summary: Encapsulates the options for the pivot chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getPivotOptions](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getpivotoptions-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartplotarea.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartplotarea.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartPlotArea:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotArea
 summary: This object represents the attributes for a chart plot area.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getPlotArea](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getplotarea-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartplotareaformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartplotareaformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartPlotAreaFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotAreaFormat
 summary: Represents the format properties for a chart plot area.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartPlotArea](/javascript/api/office-scripts/excelscript/excelscript.chartplotarea):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartplotarea#excelscript-excelscript-chartplotarea-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartplotareaposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartplotareaposition.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartPlotAreaPosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotAreaPosition
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartPlotArea](/javascript/api/office-scripts/excelscript/excelscript.chartplotarea):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.chartplotarea#excelscript-excelscript-chartplotarea-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chartplotarea#excelscript-excelscript-chartplotarea-setposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartplotby.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartplotby.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.ChartPlotBy:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartPlotBy
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getPlotBy](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getplotby-member(1)),
+  [setPlotBy](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setplotby-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample performs the "Switch Row/Column" action on a chart named "ColumnClusteredChart".
    */
@@ -29,6 +41,7 @@ remarks: |-
       columnClusteredChart.setPlotBy(ExcelScript.ChartPlotBy.columns);
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartpoint.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartpoint.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartPoint:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPoint
 summary: Represents a point of a series in a chart.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getPoints](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getpoints-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartpointformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartpointformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartPointFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartPointFormat
 summary: Represents the formatting object for chart points.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartPoint](/javascript/api/office-scripts/excelscript/excelscript.chartpoint):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartpoint#excelscript-excelscript-chartpoint-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartseries.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartseries.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.ChartSeries:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartSeries
 summary: Represents a series in a chart.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [addChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-addchartseries-member(1)),
+  [getSeries](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getseries-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample produces a line chart with two series.
    * The chart assumes data in A1:E5 that looks like this:
@@ -37,6 +49,7 @@ remarks: |-
     secondSeries.setXAxisValues(headerRange);
     secondSeries.setValues(secondSeriesRange);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartseriesby.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartseriesby.yml
@@ -8,12 +8,27 @@ summary: >-
   the "auto" option will inspect the source data shape to automatically guess
   whether the data is by rows or columns. In Excel on the web, "auto" will
   simply default to "columns".
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [setData](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setdata-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addChart](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addchart-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a clustered-column chart using an existing table.
    */
@@ -29,6 +44,7 @@ remarks: |-
           ExcelScript.ChartSeriesBy.columns
       );   
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartseriesdimension.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartseriesdimension.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.ChartSeriesDimension:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartSeriesDimension
 summary: Represents the dimensions when getting values from chart series.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getDimensionDataSourceString](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getdimensiondatasourcestring-member(1)),
+  [getDimensionDataSourceType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getdimensiondatasourcetype-member(1)),
+  [getDimensionValues](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getdimensionvalues-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartseriesformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartseriesformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ChartSeriesFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartSeriesFormat
 summary: Encapsulates the format properties for the chart series
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample gets the series format to customize fill and line properties.
    * This assumes the active worksheet has a chart.
@@ -24,6 +35,7 @@ remarks: |-
     const seriesFormat = series.getFormat();
     seriesFormat.getFill().setSolidColor("#B0C4DE");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartsplittype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartsplittype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartSplitType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartSplitType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getSplitType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getsplittype-member(1)),
+  [setSplitType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setsplittype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttexthorizontalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttexthorizontalalignment.yml
@@ -4,7 +4,29 @@ uid: ExcelScript!ExcelScript.ChartTextHorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTextHorizontalAlignment
 summary: Represents the horizontal alignment for the specified object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-sethorizontalalignment-member(1))
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-sethorizontalalignment-member(1))
+
+  -
+  [ExcelScript.ChartTitle](/javascript/api/office-scripts/excelscript/excelscript.charttitle):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-sethorizontalalignment-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineLabel](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel#excelscript-excelscript-charttrendlinelabel-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel#excelscript-excelscript-charttrendlinelabel-sethorizontalalignment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttextverticalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttextverticalalignment.yml
@@ -4,7 +4,29 @@ uid: ExcelScript!ExcelScript.ChartTextVerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTextVerticalAlignment
 summary: Represents the vertical alignment for the specified object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-setverticalalignment-member(1))
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-setverticalalignment-member(1))
+
+  -
+  [ExcelScript.ChartTitle](/javascript/api/office-scripts/excelscript/excelscript.charttitle):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-setverticalalignment-member(1))
+
+  -
+  [ExcelScript.ChartTrendlineLabel](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel#excelscript-excelscript-charttrendlinelabel-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel#excelscript-excelscript-charttrendlinelabel-setverticalalignment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartticklabelalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartticklabelalignment.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartTickLabelAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTickLabelAlignment
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [getAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-getalignment-member(1)),
+  [setAlignment](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setalignment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttitle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttitle.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ChartTitle:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTitle
 summary: Represents a chart title object of a chart.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getTitle](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-gettitle-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample accesses and customizes the chart title.
    * This assumes the active worksheet has a chart.
@@ -24,6 +35,7 @@ remarks: |-
     title.setText("Quarterly Sales by Product");
     title.setVisible(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttitleformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttitleformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartTitleFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTitleFormat
 summary: Provides access to the formatting options for a chart title.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartTitle](/javascript/api/office-scripts/excelscript/excelscript.charttitle):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttitleposition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttitleposition.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartTitlePosition:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTitlePosition
 summary: Represents the position of the chart title.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartTitle](/javascript/api/office-scripts/excelscript/excelscript.charttitle):
+  [getPosition](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-getposition-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.charttitle#excelscript-excelscript-charttitle-setposition-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttrendline.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttrendline.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.ChartTrendline:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendline
 summary: This object represents the attributes for a chart trendline object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [addChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-addcharttrendline-member(1)),
+  [getChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getcharttrendline-member(1)),
+  [getTrendlines](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-gettrendlines-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttrendlineformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttrendlineformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartTrendlineFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineFormat
 summary: Represents the format properties for the chart trendline.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.charttrendline):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendline#excelscript-excelscript-charttrendline-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinelabel.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinelabel.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartTrendlineLabel:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineLabel
 summary: This object represents the attributes for a chart trendline label object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.charttrendline):
+  [getLabel](/javascript/api/office-scripts/excelscript/excelscript.charttrendline#excelscript-excelscript-charttrendline-getlabel-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinelabelformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinelabelformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ChartTrendlineLabelFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineLabelFormat
 summary: Encapsulates the format properties for the chart trendline label.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartTrendlineLabel](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.charttrendlinelabel#excelscript-excelscript-charttrendlinelabel-getformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttrendlinetype.yml
@@ -4,7 +4,18 @@ uid: ExcelScript!ExcelScript.ChartTrendlineType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartTrendlineType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [addChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-addcharttrendline-member(1))
+
+  -
+  [ExcelScript.ChartTrendline](/javascript/api/office-scripts/excelscript/excelscript.charttrendline):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.charttrendline#excelscript-excelscript-charttrendline-gettype-member(1)),
+  [setType](/javascript/api/office-scripts/excelscript/excelscript.charttrendline#excelscript-excelscript-charttrendline-settype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.charttype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.charttype.yml
@@ -4,12 +4,33 @@ uid: ExcelScript!ExcelScript.ChartType:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getChartType](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getcharttype-member(1)),
+  [setChartType](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setcharttype-member(1))
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [getChartType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-getcharttype-member(1)),
+  [setChartType](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setcharttype-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addChart](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addchart-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample creates a column-clustered chart based on the current worksheet's data.
    */
@@ -26,6 +47,7 @@ remarks: |-
     // Name the chart for easy access in other scripts.
     chart.setName("ColumnChart");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.chartunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.chartunderlinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ChartUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ChartUnderlineStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartFont](/javascript/api/office-scripts/excelscript/excelscript.chartfont):
+  [getUnderline](/javascript/api/office-scripts/excelscript/excelscript.chartfont#excelscript-excelscript-chartfont-getunderline-member(1)),
+  [setUnderline](/javascript/api/office-scripts/excelscript/excelscript.chartfont#excelscript-excelscript-chartfont-setunderline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.clearapplyto.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.clearapplyto.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.ClearApplyTo:enum
 package: ExcelScript!
 fullName: ExcelScript.ClearApplyTo
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [clear](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-clear-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [clear](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-clear-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script removes any extra formatting that's been applied to a table. 
    * This leaves only the base table style effects.
@@ -26,6 +41,7 @@ remarks: |-
     // Clear all the formatting that is not applied by the table and the table style.
     range.clear(ExcelScript.ClearApplyTo.formats);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.colorscaleconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.colorscaleconditionalformat.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ColorScaleConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ColorScaleConditionalFormat
 summary: Represents the color scale criteria for conditional formatting.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getColorScale](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getcolorscale-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.comment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.comment.yml
@@ -4,7 +4,29 @@ uid: ExcelScript!ExcelScript.Comment:interface
 package: ExcelScript!
 fullName: ExcelScript.Comment
 summary: Represents a comment in the workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.CommentReply](/javascript/api/office-scripts/excelscript/excelscript.commentreply):
+  [getParentComment](/javascript/api/office-scripts/excelscript/excelscript.commentreply#excelscript-excelscript-commentreply-getparentcomment-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addcomment-member(1)),
+  [getComment](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcomment-member(1)),
+  [getCommentByCell](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcommentbycell-member(1)),
+  [getCommentByReplyId](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcommentbyreplyid-member(1)),
+  [getComments](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcomments-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addcomment-member(1)),
+  [getComment](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcomment-member(1)),
+  [getCommentByCell](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcommentbycell-member(1)),
+  [getCommentByReplyId](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcommentbyreplyid-member(1)),
+  [getComments](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcomments-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.commentmention.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.commentmention.yml
@@ -4,12 +4,31 @@ uid: ExcelScript!ExcelScript.CommentMention:interface
 package: ExcelScript!
 fullName: ExcelScript.CommentMention
 summary: Represents the entity that is mentioned in comments.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Comment](/javascript/api/office-scripts/excelscript/excelscript.comment):
+  [getMentions](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-getmentions-member(1))
+
+  -
+  [ExcelScript.CommentReply](/javascript/api/office-scripts/excelscript/excelscript.commentreply):
+  [getMentions](/javascript/api/office-scripts/excelscript/excelscript.commentreply#excelscript-excelscript-commentreply-getmentions-member(1))
+
+  -
+  [ExcelScript.CommentRichContent](/javascript/api/office-scripts/excelscript/excelscript.commentrichcontent):
+  [mentions](/javascript/api/office-scripts/excelscript/excelscript.commentrichcontent#excelscript-excelscript-commentrichcontent-mentions-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample creates a comment that mentions a specific person.
    * That person will get a notification and link to the workbook.
@@ -45,6 +64,7 @@ remarks: |-
     // Add the comment.
     currentSheet.addComment(cell, content, ExcelScript.ContentType.mention);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.commentreply.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.commentreply.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.CommentReply:interface
 package: ExcelScript!
 fullName: ExcelScript.CommentReply
 summary: Represents a comment reply in the workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Comment](/javascript/api/office-scripts/excelscript/excelscript.comment):
+  [addCommentReply](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-addcommentreply-member(1)),
+  [getCommentReply](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-getcommentreply-member(1)),
+  [getReplies](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-getreplies-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.commentrichcontent.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.commentrichcontent.yml
@@ -7,7 +7,26 @@ summary: >-
   Represents the content contained within a comment or comment reply. Rich
   content incudes the text string and any other objects contained within the
   comment body, such as mentions.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Comment](/javascript/api/office-scripts/excelscript/excelscript.comment):
+  [addCommentReply](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-addcommentreply-member(1)),
+  [updateMentions](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-updatementions-member(1))
+
+  -
+  [ExcelScript.CommentReply](/javascript/api/office-scripts/excelscript/excelscript.commentreply):
+  [updateMentions](/javascript/api/office-scripts/excelscript/excelscript.commentreply#excelscript-excelscript-commentreply-updatementions-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addcomment-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addcomment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalcellvalueoperator.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalcellvalueoperator.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalCellValueOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalCellValueOperator
 summary: Represents the operator of the text conditional format type.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalCellValueRule](/javascript/api/office-scripts/excelscript/excelscript.conditionalcellvaluerule):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.conditionalcellvaluerule#excelscript-excelscript-conditionalcellvaluerule-operator-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies conditional formatting to a range.
    * That formatting is conditional upon the cell's numerical value.
@@ -37,6 +48,7 @@ remarks: |-
     };
     cellValueConditionalFormatting.setRule(rule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalcellvaluerule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalcellvaluerule.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.ConditionalCellValueRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalCellValueRule
 summary: Represents a cell value conditional format rule.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.CellValueConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.cellvalueconditionalformat):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.cellvalueconditionalformat#excelscript-excelscript-cellvalueconditionalformat-getrule-member(1)),
+  [setRule](/javascript/api/office-scripts/excelscript/excelscript.cellvalueconditionalformat#excelscript-excelscript-cellvalueconditionalformat-setrule-member(1))
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [changeRuleToCellValue](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-changeruletocellvalue-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies conditional formatting to a range.
    * That formatting is conditional upon the cell's numerical value.
@@ -37,6 +53,7 @@ remarks: |-
     format.getFill().setColor("yellow");
     format.getFont().setItalic(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalcolorscalecriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalcolorscalecriteria.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ConditionalColorScaleCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalColorScaleCriteria
 summary: Represents the criteria of the color scale.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ColorScaleConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.colorscaleconditionalformat):
+  [getCriteria](/javascript/api/office-scripts/excelscript/excelscript.colorscaleconditionalformat#excelscript-excelscript-colorscaleconditionalformat-getcriteria-member(1)),
+  [setCriteria](/javascript/api/office-scripts/excelscript/excelscript.colorscaleconditionalformat#excelscript-excelscript-colorscaleconditionalformat-setcriteria-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalcolorscalecriterion.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalcolorscalecriterion.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.ConditionalColorScaleCriterion:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalColorScaleCriterion
 summary: Represents a color scale criterion which contains a type, value, and a color.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalColorScaleCriteria](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriteria):
+  [maximum](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriteria#excelscript-excelscript-conditionalcolorscalecriteria-maximum-member),
+  [midpoint](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriteria#excelscript-excelscript-conditionalcolorscalecriteria-midpoint-member),
+  [minimum](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriteria#excelscript-excelscript-conditionalcolorscalecriteria-minimum-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabaraxisformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabaraxisformat.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ConditionalDataBarAxisFormat:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarAxisFormat
 summary: Represents the format options for a data bar axis.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.DataBarConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat):
+  [getAxisFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getaxisformat-member(1)),
+  [setAxisFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-setaxisformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabardirection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabardirection.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ConditionalDataBarDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarDirection
 summary: Represents the data bar direction within a cell.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.DataBarConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat):
+  [getBarDirection](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getbardirection-member(1)),
+  [setBarDirection](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-setbardirection-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarnegativeformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarnegativeformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalDataBarNegativeFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarNegativeFormat
 summary: Represents a conditional format for the negative side of the data bar.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataBarConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat):
+  [getNegativeFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getnegativeformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies data bar conditional formatting to a range.
    * It sets the data bar colors to be green when positive and red when negative.
@@ -29,6 +40,7 @@ remarks: |-
       const negativeFormat: ExcelScript.ConditionalDataBarNegativeFormat = dataBarConditionalFormat.getNegativeFormat();
       negativeFormat.setFillColor("red");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarpositiveformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarpositiveformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalDataBarPositiveFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarPositiveFormat
 summary: Represents a conditional format for the positive side of the data bar.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataBarConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat):
+  [getPositiveFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getpositiveformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies data bar conditional formatting to a range.
    * It sets the data bar colors to be green when positive and red when negative.
@@ -29,6 +40,7 @@ remarks: |-
       const negativeFormat: ExcelScript.ConditionalDataBarNegativeFormat = dataBarConditionalFormat.getNegativeFormat();
       negativeFormat.setFillColor("red");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaldatabarrule.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.ConditionalDataBarRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalDataBarRule
 summary: Represents a rule-type for a data bar.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataBarConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat):
+  [getLowerBoundRule](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getlowerboundrule-member(1)),
+  [getUpperBoundRule](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-getupperboundrule-member(1)),
+  [setLowerBoundRule](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-setlowerboundrule-member(1)),
+  [setUpperBoundRule](/javascript/api/office-scripts/excelscript/excelscript.databarconditionalformat#excelscript-excelscript-databarconditionalformat-setupperboundrule-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates data bar conditional formatting on the selected range.
    * The scale of the data bar goes from 0 to 1000.
@@ -36,6 +50,7 @@ remarks: |-
     };
     dataBarFormat.setUpperBoundRule(upperBound);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformat.yml
@@ -6,7 +6,21 @@ fullName: ExcelScript.ConditionalFormat
 summary: >-
   An object encapsulating a conditional format's range, format, rule, and other
   properties.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [addConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-addconditionalformat-member(1)),
+  [getConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getconditionalformat-member(1)),
+  [getConditionalFormats](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getconditionalformats-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [addConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-addconditionalformat-member(1)),
+  [getConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getconditionalformat-member(1)),
+  [getConditionalFormats](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getconditionalformats-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatcolorcriteriontype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatcolorcriteriontype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalFormatColorCriterionType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatColorCriterionType
 summary: Represents the types of color criterion for conditional formatting.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalColorScaleCriterion](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriterion):
+  [type](/javascript/api/office-scripts/excelscript/excelscript.conditionalcolorscalecriterion#excelscript-excelscript-conditionalcolorscalecriterion-type-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a red, white, and blue color scale to the selected range.
    */
@@ -36,6 +47,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformaticonruletype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformaticonruletype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalFormatIconRuleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatIconRuleType
 summary: Represents the types of icon conditional format.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalIconCriterion](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion):
+  [type](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion#excelscript-excelscript-conditionaliconcriterion-type-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies icon set conditional formatting to a range.
    */
@@ -40,6 +51,7 @@ remarks: |-
       }];
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatpresetcriterion.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatpresetcriterion.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalFormatPresetCriterion:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatPresetCriterion
 summary: Represents the criteria of the preset criteria conditional format type.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalPresetCriteriaRule](/javascript/api/office-scripts/excelscript/excelscript.conditionalpresetcriteriarule):
+  [criterion](/javascript/api/office-scripts/excelscript/excelscript.conditionalpresetcriteriarule#excelscript-excelscript-conditionalpresetcriteriarule-criterion-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a conditional format that uses a preset criterion.
    * Any cell in row 1 will have the color fill set to green if it is a duplicate value
@@ -34,6 +45,7 @@ remarks: |-
     };
     presetFormat.setRule(duplicateRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatrule.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalFormatRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatRule
 summary: Represents a rule, for all traditional rule/format pairings.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.CustomConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.customconditionalformat):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.customconditionalformat#excelscript-excelscript-customconditionalformat-getrule-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a custom conditional formatting to the selected range.
    * A light-green fill is applied to a cell if the value is larger than the value in the row's previous column.
@@ -29,6 +40,7 @@ remarks: |-
     let positiveRule: ExcelScript.ConditionalFormatRule = positiveCustom.getRule();
     positiveRule.setFormula(`=${selectedRange.getCell(0, 0).getAddress()}>${selectedRange.getOffsetRange(0, -1).getCell(0, 0).getAddress()}`);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatruletype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformatruletype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalFormatRuleType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatRuleType
 summary: Represents the types of conditional format values.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalDataBarRule](/javascript/api/office-scripts/excelscript/excelscript.conditionaldatabarrule):
+  [type](/javascript/api/office-scripts/excelscript/excelscript.conditionaldatabarrule#excelscript-excelscript-conditionaldatabarrule-type-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates data bar conditional formatting on the selected range.
    * The scale of the data bar goes from 0 to 1000.
@@ -36,6 +47,7 @@ remarks: |-
     };
     dataBarFormat.setUpperBoundRule(upperBound);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalformattype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalformattype.yml
@@ -4,12 +4,31 @@ uid: ExcelScript!ExcelScript.ConditionalFormatType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalFormatType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-gettype-member(1))
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [addConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-addconditionalformat-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [addConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-addconditionalformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a red, white, and blue color scale to the selected range.
    */
@@ -36,6 +55,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaliconcriterion.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaliconcriterion.yml
@@ -6,12 +6,24 @@ fullName: ExcelScript.ConditionalIconCriterion
 summary: >-
   Represents an icon criterion which contains a type, value, an operator, and an
   optional custom icon, if not using an icon set.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.IconSetConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat):
+  [getCriteria](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat#excelscript-excelscript-iconsetconditionalformat-getcriteria-member(1)),
+  [setCriteria](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat#excelscript-excelscript-iconsetconditionalformat-setcriteria-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies icon set conditional formatting to a range.
    */
@@ -42,6 +54,7 @@ remarks: |-
       }];
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaliconcriterionoperator.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaliconcriterionoperator.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalIconCriterionOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalIconCriterionOperator
 summary: Represents the operator for each icon criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalIconCriterion](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion#excelscript-excelscript-conditionaliconcriterion-operator-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies icon set conditional formatting to a range.
    */
@@ -40,6 +51,7 @@ remarks: |-
       }];
     conditionalFormatting.getIconSet().setCriteria(criteria);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalpresetcriteriarule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalpresetcriteriarule.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.ConditionalPresetCriteriaRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalPresetCriteriaRule
 summary: Represents the preset criteria conditional format rule.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [changeRuleToPresetCriteria](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-changeruletopresetcriteria-member(1))
+
+  -
+  [ExcelScript.PresetCriteriaConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.presetcriteriaconditionalformat):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.presetcriteriaconditionalformat#excelscript-excelscript-presetcriteriaconditionalformat-getrule-member(1)),
+  [setRule](/javascript/api/office-scripts/excelscript/excelscript.presetcriteriaconditionalformat#excelscript-excelscript-presetcriteriaconditionalformat-setrule-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a conditional format that uses a preset criterion.
    * Any cell in row 1 will have the color fill set to green if it is a duplicate value
@@ -34,6 +50,7 @@ remarks: |-
     };
     presetFormat.setRule(duplicateRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborder.yml
@@ -4,7 +4,18 @@ uid: ExcelScript!ExcelScript.ConditionalRangeBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorder
 summary: Represents the border of an object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat):
+  [getBorders](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getborders-member(1)),
+  [getConditionalRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangeborder-member(1)),
+  [getConditionalRangeBorderBottom](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangeborderbottom-member(1)),
+  [getConditionalRangeBorderLeft](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangeborderleft-member(1)),
+  [getConditionalRangeBorderRight](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangeborderright-member(1)),
+  [getConditionalRangeBorderTop](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangebordertop-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborderindex.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborderindex.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.ConditionalRangeBorderIndex:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorderIndex
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeborder):
+  [getSideIndex](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeborder#excelscript-excelscript-conditionalrangeborder-getsideindex-member(1))
+
+  -
+  [ExcelScript.ConditionalRangeFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat):
+  [getConditionalRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getconditionalrangeborder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeborderlinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ConditionalRangeBorderLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeBorderLineStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeborder):
+  [getStyle](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeborder#excelscript-excelscript-conditionalrangeborder-getstyle-member(1)),
+  [setStyle](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeborder#excelscript-excelscript-conditionalrangeborder-setstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefill.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefill.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalRangeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFill
 summary: Represents the background of a conditional range object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getfill-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies cell value conditional formatting to a range.
    * Any value less than 60 will have the cell's fill color changed and the font made italic.
@@ -36,6 +47,7 @@ remarks: |-
     fill.setColor("yellow");
     font.setItalic(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefont.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefont.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.ConditionalRangeFont
 summary: >-
   This object represents the font attributes (font style, color, etc.) for an
   object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangeformat#excelscript-excelscript-conditionalrangeformat-getfont-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies cell value conditional formatting to a range.
    * Any value less than 60 will have the cell's fill color changed and the font made italic.
@@ -38,6 +49,7 @@ remarks: |-
     fill.setColor("yellow");
     font.setItalic(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefontunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangefontunderlinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ConditionalRangeFontUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalRangeFontUnderlineStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalRangeFont](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangefont):
+  [getUnderline](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangefont#excelscript-excelscript-conditionalrangefont-getunderline-member(1)),
+  [setUnderline](/javascript/api/office-scripts/excelscript/excelscript.conditionalrangefont#excelscript-excelscript-conditionalrangefont-setunderline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionalrangeformat.yml
@@ -6,12 +6,39 @@ fullName: ExcelScript.ConditionalRangeFormat
 summary: >-
   A format object encapsulating the conditional formats range's font, fill,
   borders, and other properties.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.CellValueConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.cellvalueconditionalformat):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.cellvalueconditionalformat#excelscript-excelscript-cellvalueconditionalformat-getformat-member(1))
+
+  -
+  [ExcelScript.CustomConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.customconditionalformat):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.customconditionalformat#excelscript-excelscript-customconditionalformat-getformat-member(1))
+
+  -
+  [ExcelScript.PresetCriteriaConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.presetcriteriaconditionalformat):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.presetcriteriaconditionalformat#excelscript-excelscript-presetcriteriaconditionalformat-getformat-member(1))
+
+  -
+  [ExcelScript.TextConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.textconditionalformat):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.textconditionalformat#excelscript-excelscript-textconditionalformat-getformat-member(1))
+
+  -
+  [ExcelScript.TopBottomConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.topbottomconditionalformat):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.topbottomconditionalformat#excelscript-excelscript-topbottomconditionalformat-getformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies cell value conditional formatting to a range.
    * Any value less than 60 will have the cell's fill color changed and the font made italic.
@@ -36,6 +63,7 @@ remarks: |-
     format.getFill().setColor("yellow");
     format.getFont().setItalic(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaltextcomparisonrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaltextcomparisonrule.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.ConditionalTextComparisonRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTextComparisonRule
 summary: Represents a cell value conditional format rule.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [changeRuleToContainsText](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-changeruletocontainstext-member(1))
+
+  -
+  [ExcelScript.TextConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.textconditionalformat):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.textconditionalformat#excelscript-excelscript-textconditionalformat-getrule-member(1)),
+  [setRule](/javascript/api/office-scripts/excelscript/excelscript.textconditionalformat#excelscript-excelscript-textconditionalformat-setrule-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds conditional formatting to the first column in the worksheet.
    * This formatting gives the cells a green fill if they have text starting with "Excel".
@@ -33,6 +49,7 @@ remarks: |-
     };
     textConditionFormat.setRule(textRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaltextoperator.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaltextoperator.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ConditionalTextOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTextOperator
 summary: Represents the operator of the text conditional format type.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalTextComparisonRule](/javascript/api/office-scripts/excelscript/excelscript.conditionaltextcomparisonrule):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.conditionaltextcomparisonrule#excelscript-excelscript-conditionaltextcomparisonrule-operator-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds conditional formatting to the first column in the worksheet.
    * This formatting gives the cells a green fill if they have text starting with "Excel".
@@ -33,6 +44,7 @@ remarks: |-
     };
     textConditionFormat.setRule(textRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaltopbottomcriteriontype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaltopbottomcriteriontype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ConditionalTopBottomCriterionType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTopBottomCriterionType
 summary: Represents the criteria for the above/below average conditional format type.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalTopBottomRule](/javascript/api/office-scripts/excelscript/excelscript.conditionaltopbottomrule):
+  [type](/javascript/api/office-scripts/excelscript/excelscript.conditionaltopbottomrule#excelscript-excelscript-conditionaltopbottomrule-type-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.conditionaltopbottomrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.conditionaltopbottomrule.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.ConditionalTopBottomRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ConditionalTopBottomRule
 summary: Represents the rule of the top/bottom conditional format.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [changeRuleToTopBottom](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-changeruletotopbottom-member(1))
+
+  -
+  [ExcelScript.TopBottomConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.topbottomconditionalformat):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.topbottomconditionalformat#excelscript-excelscript-topbottomconditionalformat-getrule-member(1)),
+  [setRule](/javascript/api/office-scripts/excelscript/excelscript.topbottomconditionalformat#excelscript-excelscript-topbottomconditionalformat-setrule-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample applies conditional formatting to the currently used range in the worksheet. 
    * The conditional formatting is a pink fill for the 5 lowest values.
@@ -29,6 +45,7 @@ remarks: |-
       type: ExcelScript.ConditionalTopBottomCriterionType.bottomItems /* The type of the top/bottom condition. */
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.connectortype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.connectortype.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.ConnectorType:enum
 package: ExcelScript!
 fullName: ExcelScript.ConnectorType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Line](/javascript/api/office-scripts/excelscript/excelscript.line):
+  [getConnectorType](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getconnectortype-member(1)),
+  [setConnectorType](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-setconnectortype-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addLine](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addline-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a line that goes from cell B2 to cell F4 on the current worksheet.
    */ 
@@ -29,6 +45,7 @@ remarks: |-
       f4Range.getTop(),
       ExcelScript.ConnectorType.straight);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.contenttype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.contenttype.yml
@@ -4,12 +4,36 @@ uid: ExcelScript!ExcelScript.ContentType:enum
 package: ExcelScript!
 fullName: ExcelScript.ContentType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Comment](/javascript/api/office-scripts/excelscript/excelscript.comment):
+  [addCommentReply](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-addcommentreply-member(1)),
+  [getContentType](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-getcontenttype-member(1))
+
+  -
+  [ExcelScript.CommentReply](/javascript/api/office-scripts/excelscript/excelscript.commentreply):
+  [getContentType](/javascript/api/office-scripts/excelscript/excelscript.commentreply#excelscript-excelscript-commentreply-getcontenttype-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addcomment-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addcomment-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample creates a comment that mentions a specific person.
    * That person will get a notification and link to the workbook.
@@ -45,6 +69,7 @@ remarks: |-
     // Add the comment.
     currentSheet.addComment(cell, content, ExcelScript.ContentType.mention);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.cultureinfo.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.cultureinfo.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.CultureInfo
 summary: >-
   Provides information based on current system culture settings. This includes
   the culture names, number formatting, and other culturally dependent settings.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Application](/javascript/api/office-scripts/excelscript/excelscript.application):
+  [getCultureInfo](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-getcultureinfo-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the value of a cell to a date string for January 2, 2023.
    * It writes the day or month first in the string based on system settings.
@@ -32,6 +43,7 @@ remarks: |-
       cell.setValue("2/1/2023");
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.customconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.customconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.CustomConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomConditionalFormat
 summary: Represents a custom conditional format type.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getCustom](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getcustom-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a custom three-color conditional formatting to the selected range.
    * The three colors represent positive, negative, or no changes from the values in the previous column.
@@ -36,6 +47,7 @@ remarks: |-
     sameCustom.getFormat().getFill().setColor("lightyellow");
     sameCustom.getRule().setFormula(`=${selectedRange.getCell(0, 0).getAddress()}=${selectedRange.getOffsetRange(0, -1).getCell(0, 0).getAddress()}`);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.customdatavalidation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.customdatavalidation.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.CustomDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomDataValidation
 summary: Represents the custom data validation criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidationRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule):
+  [custom](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-custom-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds data validation to a range.
    * The validation prevents duplicate entries within that range.
@@ -29,6 +40,7 @@ remarks: |-
       custom: duplicateRule
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.customproperty.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.customproperty.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.CustomProperty:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomProperty
 summary: Represents a custom property.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.DocumentProperties](/javascript/api/office-scripts/excelscript/excelscript.documentproperties):
+  [addCustomProperty](/javascript/api/office-scripts/excelscript/excelscript.documentproperties#excelscript-excelscript-documentproperties-addcustomproperty-member(1)),
+  [getCustom](/javascript/api/office-scripts/excelscript/excelscript.documentproperties#excelscript-excelscript-documentproperties-getcustom-member(1)),
+  [getCustomProperty](/javascript/api/office-scripts/excelscript/excelscript.documentproperties#excelscript-excelscript-documentproperties-getcustomproperty-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.customxmlpart.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.customxmlpart.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.CustomXmlPart:interface
 package: ExcelScript!
 fullName: ExcelScript.CustomXmlPart
 summary: Represents a custom XML part object in a workbook.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addCustomXmlPart](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addcustomxmlpart-member(1)),
+  [getCustomXmlPart](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcustomxmlpart-member(1)),
+  [getCustomXmlPartByNamespace](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcustomxmlpartbynamespace-member(1)),
+  [getCustomXmlParts](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcustomxmlparts-member(1)),
+  [getCustomXmlPartsByNamespace](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcustomxmlpartsbynamespace-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.databarconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.databarconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.DataBarConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.DataBarConditionalFormat
 summary: Represents an Excel conditional data bar type.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getDataBar](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getdatabar-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates data bar conditional formatting on the selected range.
    * The scale of the data bar goes from 0 to 1000.
@@ -36,6 +47,7 @@ remarks: |-
     };
     dataBarFormat.setUpperBoundRule(upperBound);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datapivothierarchy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datapivothierarchy.yml
@@ -4,12 +4,34 @@ uid: ExcelScript!ExcelScript.DataPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.DataPivotHierarchy
 summary: Represents the Excel DataPivotHierarchy.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [sortByValues](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-sortbyvalues-member(1))
+
+  -
+  [ExcelScript.PivotLayout](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout):
+  [getDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getdatahierarchy-member(1))
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [addDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-adddatahierarchy-member(1)),
+  [getDataHierarchies](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getdatahierarchies-member(1)),
+  [getDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getdatahierarchy-member(1)),
+  [removeDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-removedatahierarchy-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    *  This sample sorts the rows of a PivotTable.
    */
@@ -26,6 +48,7 @@ remarks: |-
     // Sort the "Farm" row's only field by the values in "Sum of Crates Sold Wholesale".
     rowToSort.getFields()[0].sortByValues(ExcelScript.SortBy.descending, valueFieldToSortOn);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datasourcetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datasourcetype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.DataSourceType:enum
 package: ExcelScript!
 fullName: ExcelScript.DataSourceType
 summary: Represents a command type of `DataConnection`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [getDataSourceType](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getdatasourcetype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidation.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.DataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidation
 summary: Represents the data validation applied to the current range.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getDataValidation](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getdatavalidation-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getDataValidation](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getdatavalidation-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationalertstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationalertstyle.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.DataValidationAlertStyle
 summary: >-
   Represents the data validation error alert style. The default is `Stop`<!--
   -->.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidationErrorAlert](/javascript/api/office-scripts/excelscript/excelscript.datavalidationerroralert):
+  [style](/javascript/api/office-scripts/excelscript/excelscript.datavalidationerroralert#excelscript-excelscript-datavalidationerroralert-style-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a data validation rule for the range B1:B5.
    * All values in that range must be a positive number.
@@ -44,6 +55,7 @@ remarks: |-
     };
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationerroralert.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationerroralert.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.DataValidationErrorAlert:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidationErrorAlert
 summary: Represents the error alert properties for the data validation.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidation](/javascript/api/office-scripts/excelscript/excelscript.datavalidation):
+  [getErrorAlert](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-geterroralert-member(1)),
+  [setErrorAlert](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-seterroralert-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a data validation rule for the range B1:B5.
    * All values in that range must be a positive number.
@@ -42,6 +54,7 @@ remarks: |-
     };
     rangeDataValidation.setErrorAlert(positiveNumberOnlyAlert);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationoperator.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationoperator.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.DataValidationOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.DataValidationOperator
 summary: Represents the data validation operator enum.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.BasicDataValidation](/javascript/api/office-scripts/excelscript/excelscript.basicdatavalidation):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.basicdatavalidation#excelscript-excelscript-basicdatavalidation-operator-member)
+
+  -
+  [ExcelScript.DateTimeDataValidation](/javascript/api/office-scripts/excelscript/excelscript.datetimedatavalidation):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.datetimedatavalidation#excelscript-excelscript-datetimedatavalidation-operator-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a data validation rule for the range B1:B5.
    * All values in that range must be a positive number.
@@ -32,6 +47,7 @@ remarks: |-
     const rangeDataValidation = positiveNumberOnlyCells.getDataValidation();
     rangeDataValidation.setRule(positiveNumberOnlyRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationprompt.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationprompt.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.DataValidationPrompt:interface
 package: ExcelScript!
 fullName: ExcelScript.DataValidationPrompt
 summary: Represents the user prompt properties for the data validation.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidation](/javascript/api/office-scripts/excelscript/excelscript.datavalidation):
+  [getPrompt](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-getprompt-member(1)),
+  [setPrompt](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-setprompt-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a text prompt that's shown in C2:C8 when a user enters the cell.
    */
@@ -29,6 +41,7 @@ remarks: |-
       }
       dataValidation.setPrompt(prompt);
   }    
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationrule.yml
@@ -7,7 +7,14 @@ summary: >-
   A data validation rule contains different types of data validation. You can
   only use one of them at a time according the
   `ExcelScript.DataValidationType`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidation](/javascript/api/office-scripts/excelscript/excelscript.datavalidation):
+  [getRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-getrule-member(1)),
+  [setRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-setrule-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datavalidationtype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datavalidationtype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.DataValidationType:enum
 package: ExcelScript!
 fullName: ExcelScript.DataValidationType
 summary: Represents the data validation type enum.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidation](/javascript/api/office-scripts/excelscript/excelscript.datavalidation):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-gettype-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample reads and logs the data validation type of the currently selected range.
    */
@@ -28,6 +39,7 @@ remarks: |-
      */
     console.log(validationType.toString());
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datefiltercondition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datefiltercondition.yml
@@ -7,12 +7,23 @@ summary: >-
   Enum representing all accepted conditions by which a date filter can be
   applied. Used to configure the type of PivotFilter that is applied to the
   field.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotDateFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter):
+  [condition](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter#excelscript-excelscript-pivotdatefilter-condition-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a filter to a PivotTable that filters out rows 
    * that aren't from this month.
@@ -33,6 +44,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datetimedatavalidation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datetimedatavalidation.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.DateTimeDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.DateTimeDataValidation
 summary: Represents the date data validation criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidationRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule):
+  [date](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-date-member),
+  [time](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-time-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets a validation rule that only allows for certain dates to be entered.
    */
@@ -35,6 +47,7 @@ remarks: |-
           style: ExcelScript.DataValidationAlertStyle.stop
       });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.datetimeformatinfo.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.datetimeformatinfo.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.DatetimeFormatInfo
 summary: >-
   Defines the culturally appropriate format of displaying numbers. This is based
   on current system culture settings.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.CultureInfo](/javascript/api/office-scripts/excelscript/excelscript.cultureinfo):
+  [getDatetimeFormat](/javascript/api/office-scripts/excelscript/excelscript.cultureinfo#excelscript-excelscript-cultureinfo-getdatetimeformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the value of a cell to a date string for January 2, 2023.
    * It writes the day or month first in the string based on system settings.
@@ -32,6 +43,7 @@ remarks: |-
       cell.setValue("2/1/2023");
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.deleteshiftdirection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.deleteshiftdirection.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.DeleteShiftDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.DeleteShiftDirection
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [delete](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-delete-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample creates a sample range, then deletes
    * "A1" using different DeleteShiftDirection values.
@@ -40,6 +51,7 @@ remarks: |-
     */
     console.log(currentSheet.getRange("A1:D4").getValues()); 
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.documentproperties.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.documentproperties.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.DocumentProperties:interface
 package: ExcelScript!
 fullName: ExcelScript.DocumentProperties
 summary: Represents workbook properties.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getProperties](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getproperties-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a new worksheet that displays some of the document properties.
    */
@@ -29,6 +40,7 @@ remarks: |-
       // Set the property values to a range on the new worksheet.
       newWorksheet.getRange("A1:B3").setValues(values);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.documentpropertytype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.documentpropertytype.yml
@@ -4,16 +4,28 @@ uid: ExcelScript!ExcelScript.DocumentPropertyType:enum
 package: ExcelScript!
 fullName: ExcelScript.DocumentPropertyType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.CustomProperty](/javascript/api/office-scripts/excelscript/excelscript.customproperty):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.customproperty#excelscript-excelscript-customproperty-gettype-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script uses a custom property to set the value and formatting of a cell.
    * If the value of "Routing Number" is not set or is not a number, the cell will be red.
   */
+
   function main(workbook: ExcelScript.Workbook) {
     // Get the first cell from Sheet1.
     const cell = workbook.getWorksheet("Sheet1").getCell(0,0);
@@ -32,6 +44,7 @@ remarks: |-
       cell.setValue(routingNumber.getValue());
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.dynamicfiltercriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.dynamicfiltercriteria.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.DynamicFilterCriteria:enum
 package: ExcelScript!
 fullName: ExcelScript.DynamicFilterCriteria
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Filter](/javascript/api/office-scripts/excelscript/excelscript.filter):
+  [applyDynamicFilter](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-applydynamicfilter-member(1))
+
+  -
+  [ExcelScript.FilterCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria):
+  [dynamicCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria#excelscript-excelscript-filtercriteria-dynamiccriteria-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a filter to a table that filters it 
    * to only show rows with dates from the previous month.
@@ -25,6 +40,7 @@ remarks: |-
     // `lastMonth` will only show rows with a date from the previous month.
     dateColumn.getFilter().applyDynamicFilter(ExcelScript.DynamicFilterCriteria.lastMonth);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.fillpattern.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.fillpattern.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.FillPattern:enum
 package: ExcelScript!
 fullName: ExcelScript.FillPattern
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeFill](/javascript/api/office-scripts/excelscript/excelscript.rangefill):
+  [getPattern](/javascript/api/office-scripts/excelscript/excelscript.rangefill#excelscript-excelscript-rangefill-getpattern-member(1)),
+  [setPattern](/javascript/api/office-scripts/excelscript/excelscript.rangefill#excelscript-excelscript-rangefill-setpattern-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets a black-checkered fill on the selected range.
    */
@@ -18,6 +30,7 @@ remarks: |-
     selected.getFormat().getFill().setPattern(ExcelScript.FillPattern.checker);
     selected.getFormat().getFill().setPatternColor("black");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filter.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.Filter:interface
 package: ExcelScript!
 fullName: ExcelScript.Filter
 summary: Manages the filtering of a table's column.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.TableColumn](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn):
+  [getFilter](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn#excelscript-excelscript-tablecolumn-getfilter-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a table filter to only show the top 10% of values 
    * belonging to a particular column.
@@ -24,6 +35,7 @@ remarks: |-
       // Apply a filter to only show the rows with the top 10% of values in this column.
       pageViewFilter.applyTopPercentFilter(10);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filtercriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filtercriteria.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.FilterCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterCriteria
 summary: Represents the filtering criteria applied to a column.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.AutoFilter](/javascript/api/office-scripts/excelscript/excelscript.autofilter):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.autofilter#excelscript-excelscript-autofilter-apply-member(1)),
+  [getCriteria](/javascript/api/office-scripts/excelscript/excelscript.autofilter#excelscript-excelscript-autofilter-getcriteria-member(1))
+
+  -
+  [ExcelScript.Filter](/javascript/api/office-scripts/excelscript/excelscript.filter):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-apply-member(1)),
+  [getCriteria](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-getcriteria-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filterdatetime.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filterdatetime.yml
@@ -4,12 +4,33 @@ uid: ExcelScript!ExcelScript.FilterDatetime:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterDatetime
 summary: Represents how to filter a date when filtering on values.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Filter](/javascript/api/office-scripts/excelscript/excelscript.filter):
+  [applyValuesFilter](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-applyvaluesfilter-member(1))
+
+  -
+  [ExcelScript.FilterCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria):
+  [values](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria#excelscript-excelscript-filtercriteria-values-member)
+
+  -
+  [ExcelScript.PivotDateFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter):
+  [comparator](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter#excelscript-excelscript-pivotdatefilter-comparator-member),
+  [lowerBound](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter#excelscript-excelscript-pivotdatefilter-lowerbound-member),
+  [upperBound](/javascript/api/office-scripts/excelscript/excelscript.pivotdatefilter#excelscript-excelscript-pivotdatefilter-upperbound-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a filter to a PivotTable that filters it
    * to only show rows from between June 20th, 2022 and July 10th, 2022.
@@ -40,6 +61,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filterdatetimespecificity.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filterdatetimespecificity.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.FilterDatetimeSpecificity:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterDatetimeSpecificity
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.FilterDatetime](/javascript/api/office-scripts/excelscript/excelscript.filterdatetime):
+  [specificity](/javascript/api/office-scripts/excelscript/excelscript.filterdatetime#excelscript-excelscript-filterdatetime-specificity-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a filter to a PivotTable that filters it
    * to only show rows from between June 20th, 2022 and July 10th, 2022.
@@ -40,6 +51,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filteron.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filteron.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.FilterOn:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterOn
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.FilterCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria):
+  [filterOn](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria#excelscript-excelscript-filtercriteria-filteron-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a filter to a table so that 
    * only rows with values in column 1 that start with "L" are shown.
@@ -28,6 +39,7 @@ remarks: |-
     // Apply the filter to column 1 (zero-based).
     autoFilter.apply(table.getRange(), 1, filterCriteria);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filteroperator.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filteroperator.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.FilterOperator:enum
 package: ExcelScript!
 fullName: ExcelScript.FilterOperator
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Filter](/javascript/api/office-scripts/excelscript/excelscript.filter):
+  [applyCustomFilter](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-applycustomfilter-member(1))
+
+  -
+  [ExcelScript.FilterCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria):
+  [operator](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria#excelscript-excelscript-filtercriteria-operator-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * The script filters rows from a table based on a numerical range.
    */
@@ -22,6 +37,7 @@ remarks: |-
     // greater than 0 and less than or equal to 60.
     table.getColumnByName("Exam Score").getFilter().applyCustomFilter(">0", "<=60", ExcelScript.FilterOperator.and);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.filterpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.filterpivothierarchy.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.FilterPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.FilterPivotHierarchy
 summary: Represents the Excel FilterPivotHierarchy.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [addFilterHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addfilterhierarchy-member(1)),
+  [getFilterHierarchies](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getfilterhierarchies-member(1)),
+  [getFilterHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getfilterhierarchy-member(1)),
+  [removeFilterHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-removefilterhierarchy-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a PivotTable with a filter.
    */
@@ -30,6 +44,7 @@ remarks: |-
 
     // Add other hierarchies...
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.formatprotection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.formatprotection.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.FormatProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.FormatProtection
 summary: Represents the format protection of a range object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getProtection](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getprotection-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.geometricshape.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.geometricshape.yml
@@ -7,7 +7,13 @@ summary: >-
   Represents a geometric shape inside a worksheet. A geometric shape can be a
   rectangle, block arrow, equation symbol, flowchart item, star, banner,
   callout, or any other basic shape in Excel.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getGeometricShape](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getgeometricshape-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.geometricshapetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.geometricshapetype.yml
@@ -4,12 +4,38 @@ uid: ExcelScript!ExcelScript.GeometricShapeType:enum
 package: ExcelScript!
 fullName: ExcelScript.GeometricShapeType
 summary: Specifies the shape type for a `GeometricShape` object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ChartDataLabel](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel):
+  [getGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-getgeometricshapetype-member(1)),
+  [setGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabel#excelscript-excelscript-chartdatalabel-setgeometricshapetype-member(1))
+
+  -
+  [ExcelScript.ChartDataLabels](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels):
+  [getGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-getgeometricshapetype-member(1)),
+  [setGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.chartdatalabels#excelscript-excelscript-chartdatalabels-setgeometricshapetype-member(1))
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getgeometricshapetype-member(1)),
+  [setGeometricShapeType](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-setgeometricshapetype-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addGeometricShape](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addgeometricshape-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a hexagon shape on the current worksheet.
    */
@@ -26,6 +52,7 @@ remarks: |-
     hexagon.setLeft(100);
     hexagon.setTop(100);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.groupoption.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.groupoption.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.GroupOption:enum
 package: ExcelScript!
 fullName: ExcelScript.GroupOption
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [group](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-group-member(1)),
+  [hideGroupDetails](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-hidegroupdetails-member(1)),
+  [showGroupDetails](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-showgroupdetails-member(1)),
+  [ungroup](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-ungroup-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a two-level column-based outline on Sheet1.
    */
@@ -23,6 +37,7 @@ remarks: |-
     sheet.getRange("A:B").group(ExcelScript.GroupOption.byColumns);
     sheet.getRange("D:E").group(ExcelScript.GroupOption.byColumns);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.headerfooter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.headerfooter.yml
@@ -4,7 +4,16 @@ uid: ExcelScript!ExcelScript.HeaderFooter:interface
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooter
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.HeaderFooterGroup](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup):
+  [getDefaultForAllPages](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-getdefaultforallpages-member(1)),
+  [getEvenPages](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-getevenpages-member(1)),
+  [getFirstPage](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-getfirstpage-member(1)),
+  [getOddPages](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-getoddpages-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.headerfootergroup.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.headerfootergroup.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.HeaderFooterGroup:interface
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooterGroup
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getHeadersFooters](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getheadersfooters-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.headerfooterstate.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.headerfooterstate.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.HeaderFooterState:enum
 package: ExcelScript!
 fullName: ExcelScript.HeaderFooterState
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.HeaderFooterGroup](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup):
+  [getState](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-getstate-member(1)),
+  [setState](/javascript/api/office-scripts/excelscript/excelscript.headerfootergroup#excelscript-excelscript-headerfootergroup-setstate-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.horizontalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.horizontalalignment.yml
@@ -4,12 +4,29 @@ uid: ExcelScript!ExcelScript.HorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.HorizontalAlignment
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-sethorizontalalignment-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-sethorizontalalignment-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script centers the text in a table's header row cells.
    */
@@ -24,6 +41,7 @@ remarks: |-
     // Set the horizontal text alignment to `center`.
     headerRange.getFormat().setHorizontalAlignment(ExcelScript.HorizontalAlignment.center);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.icon.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.icon.yml
@@ -4,7 +4,25 @@ uid: ExcelScript!ExcelScript.Icon:interface
 package: ExcelScript!
 fullName: ExcelScript.Icon
 summary: Represents a cell icon.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalIconCriterion](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion):
+  [customIcon](/javascript/api/office-scripts/excelscript/excelscript.conditionaliconcriterion#excelscript-excelscript-conditionaliconcriterion-customicon-member)
+
+  -
+  [ExcelScript.Filter](/javascript/api/office-scripts/excelscript/excelscript.filter):
+  [applyIconFilter](/javascript/api/office-scripts/excelscript/excelscript.filter#excelscript-excelscript-filter-applyiconfilter-member(1))
+
+  -
+  [ExcelScript.FilterCriteria](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria):
+  [icon](/javascript/api/office-scripts/excelscript/excelscript.filtercriteria#excelscript-excelscript-filtercriteria-icon-member)
+
+  -
+  [ExcelScript.SortField](/javascript/api/office-scripts/excelscript/excelscript.sortfield):
+  [icon](/javascript/api/office-scripts/excelscript/excelscript.sortfield#excelscript-excelscript-sortfield-icon-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.iconset.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.iconset.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.IconSet:enum
 package: ExcelScript!
 fullName: ExcelScript.IconSet
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Icon](/javascript/api/office-scripts/excelscript/excelscript.icon):
+  [set](/javascript/api/office-scripts/excelscript/excelscript.icon#excelscript-excelscript-icon-set-member)
+
+  -
+  [ExcelScript.IconSetConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat):
+  [getStyle](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat#excelscript-excelscript-iconsetconditionalformat-getstyle-member(1)),
+  [setStyle](/javascript/api/office-scripts/excelscript/excelscript.iconsetconditionalformat#excelscript-excelscript-iconsetconditionalformat-setstyle-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies icon set conditional formatting to a range.
    */
@@ -38,6 +54,7 @@ remarks: |-
         type:ExcelScript.ConditionalFormatIconRuleType.percent
       }]);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.iconsetconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.iconsetconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.IconSetConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.IconSetConditionalFormat
 summary: Represents an icon set criteria for conditional formatting.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getIconSet](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-geticonset-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies icon set conditional formatting to a range.
    */
@@ -38,6 +49,7 @@ remarks: |-
         type:ExcelScript.ConditionalFormatIconRuleType.percent
       }]);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.image.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.image.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.Image
 summary: >-
   Represents an image in the worksheet. To get the corresponding `Shape` object,
   use `Image.getShape`<!-- -->.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getImage](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getimage-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script transfers an image from one worksheet to another.
    */
@@ -32,6 +43,7 @@ remarks: |-
     // Copy the image to another worksheet.
     image.getShape().copyTo("SecondSheet");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.imagefittingmode.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.imagefittingmode.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ImageFittingMode:enum
 package: ExcelScript!
 fullName: ExcelScript.ImageFittingMode
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getImage](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getimage-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script returns an image of the first chart in the first worksheet.
    * That image is 600x400 pixels and the chart will be 
@@ -30,6 +41,7 @@ remarks: |-
 
     return base64String;
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.insertshiftdirection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.insertshiftdirection.yml
@@ -6,16 +6,28 @@ fullName: ExcelScript.InsertShiftDirection
 summary: >-
   Determines the direction in which existing cells will be shifted to
   accommodate what is being inserted.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [insert](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-insert-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script inserts headers at the top of the worksheet.
    */
   function main(workbook: ExcelScript.Workbook)
+
   {
     let currentSheet = workbook.getActiveWorksheet();
 
@@ -29,6 +41,7 @@ remarks: |-
     // Add the headers.
     currentSheet.getRange("A1:C1").setValues(myHeaders);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.iterativecalculation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.iterativecalculation.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.IterativeCalculation:interface
 package: ExcelScript!
 fullName: ExcelScript.IterativeCalculation
 summary: Represents the iterative calculation settings.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Application](/javascript/api/office-scripts/excelscript/excelscript.application):
+  [getIterativeCalculation](/javascript/api/office-scripts/excelscript/excelscript.application#excelscript-excelscript-application-getiterativecalculation-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.keyboarddirection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.keyboarddirection.yml
@@ -4,17 +4,30 @@ uid: ExcelScript!ExcelScript.KeyboardDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.KeyboardDirection
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getExtendedRange](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getextendedrange-member(1)),
+  [getRangeEdge](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getrangeedge-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script makes the font bold on all the contiguous cells between 
    * A1 and the bottom of the used range of the first column.
    */
   function main(workbook: ExcelScript.Workbook)
+
   {
     // Get the current worksheet.
     let selectedSheet = workbook.getActiveWorksheet();
@@ -27,6 +40,7 @@ remarks: |-
     // Set the font to bold in that range.
     firstColumn.getFormat().getFont().setBold(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.labelfiltercondition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.labelfiltercondition.yml
@@ -8,12 +8,23 @@ summary: >-
   applied. Used to configure the type of PivotFilter that is applied to the
   field. `PivotFilter.criteria.exclusive` can be set to `true` to invert many of
   these conditions.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotLabelFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotlabelfilter):
+  [condition](/javascript/api/office-scripts/excelscript/excelscript.pivotlabelfilter#excelscript-excelscript-pivotlabelfilter-condition-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script filters items that start with "L" from the "Type" field
    * of the "Farm Sales" PivotTable.
@@ -35,6 +46,7 @@ remarks: |-
     // Apply the label filter to the field.
     field.applyFilter({ labelFilter: filter });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.line.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.line.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.Line
 summary: >-
   Represents a line inside a worksheet. To get the corresponding `Shape` object,
   use `Line.shape`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getLine](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.linkeddatatypestate.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.linkeddatatypestate.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.LinkedDataTypeState:enum
 package: ExcelScript!
 fullName: ExcelScript.LinkedDataTypeState
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getLinkedDataTypeState](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getlinkeddatatypestate-member(1)),
+  [getLinkedDataTypeStates](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getlinkeddatatypestates-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.linkedworkbook.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.linkedworkbook.yml
@@ -8,7 +8,14 @@ summary: >-
   to data in another workbook, the second workbook is linked to the first
   workbook. In this scenario, the second workbook is called the "linked
   workbook".
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getLinkedWorkbookByUrl](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getlinkedworkbookbyurl-member(1)),
+  [getLinkedWorkbooks](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getlinkedworkbooks-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.listdatavalidation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.listdatavalidation.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ListDataValidation:interface
 package: ExcelScript!
 fullName: ExcelScript.ListDataValidation
 summary: Represents the List data validation criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataValidationRule](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule):
+  [list](/javascript/api/office-scripts/excelscript/excelscript.datavalidationrule#excelscript-excelscript-datavalidationrule-list-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a dropdown selection list for a cell.
    * It uses the existing values of the selected range as the choices for the list.
@@ -44,6 +55,7 @@ remarks: |-
       };
       dataValidation.setRule(validationRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.loadtotype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.loadtotype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.LoadToType:enum
 package: ExcelScript!
 fullName: ExcelScript.LoadToType
 summary: An enum that specifies the query load to destination.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Query](/javascript/api/office-scripts/excelscript/excelscript.query):
+  [getLoadedTo](/javascript/api/office-scripts/excelscript/excelscript.query#excelscript-excelscript-query-getloadedto-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.nameditem.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.nameditem.yml
@@ -8,12 +8,33 @@ summary: >-
   primitive named objects (as seen in the type below), range object, or a
   reference to a range. This object can be used to obtain range object
   associated with names.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addNamedItem](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addnameditem-member(1)),
+  [addNamedItemFormulaLocal](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addnameditemformulalocal-member(1)),
+  [getNamedItem](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getnameditem-member(1)),
+  [getNames](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getnames-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addNamedItem](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addnameditem-member(1)),
+  [addNamedItemFormulaLocal](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addnameditemformulalocal-member(1)),
+  [getNamedItem](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getnameditem-member(1)),
+  [getNames](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getnames-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a named formula and uses it in another part of the workbook.
    */
@@ -33,6 +54,7 @@ remarks: |-
     // Switch to the new worksheet.
     otherSheet.activate();
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.nameditemarrayvalues.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.nameditemarrayvalues.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.NamedItemArrayValues:interface
 package: ExcelScript!
 fullName: ExcelScript.NamedItemArrayValues
 summary: Represents an object containing values and types of a named item.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.NamedItem](/javascript/api/office-scripts/excelscript/excelscript.nameditem):
+  [getArrayValues](/javascript/api/office-scripts/excelscript/excelscript.nameditem#excelscript-excelscript-nameditem-getarrayvalues-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.nameditemscope.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.nameditemscope.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.NamedItemScope:enum
 package: ExcelScript!
 fullName: ExcelScript.NamedItemScope
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.NamedItem](/javascript/api/office-scripts/excelscript/excelscript.nameditem):
+  [getScope](/javascript/api/office-scripts/excelscript/excelscript.nameditem#excelscript-excelscript-nameditem-getscope-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.nameditemtype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.nameditemtype.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.NamedItemType:enum
 package: ExcelScript!
 fullName: ExcelScript.NamedItemType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.NamedItem](/javascript/api/office-scripts/excelscript/excelscript.nameditem):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.nameditem#excelscript-excelscript-nameditem-gettype-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script looks for every named range with "Review" in the name 
    * and marks the range with a yellow fill.
@@ -28,6 +39,7 @@ remarks: |-
       }
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.namedsheetview.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.namedsheetview.yml
@@ -8,7 +8,17 @@ summary: >-
   filter rules for a particular worksheet. Every sheet view (even a temporary
   sheet view) has a unique, worksheet-scoped name that is used to access the
   view.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addNamedSheetView](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addnamedsheetview-member(1)),
+  [enterTemporaryNamedSheetView](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-entertemporarynamedsheetview-member(1)),
+  [getActiveNamedSheetView](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getactivenamedsheetview-member(1)),
+  [getNamedSheetView](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getnamedsheetview-member(1)),
+  [getNamedSheetViews](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getnamedsheetviews-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.numberformatcategory.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.numberformatcategory.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.NumberFormatCategory:enum
 package: ExcelScript!
 fullName: ExcelScript.NumberFormatCategory
 summary: Represents a category of number formats.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getNumberFormatCategories](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getnumberformatcategories-member(1)),
+  [getNumberFormatCategory](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getnumberformatcategory-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script finds cells in a table column that are not formatted as currency
    * and sets the fill color to red.
@@ -30,6 +42,7 @@ remarks: |-
       }
     }); 
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.numberformatinfo.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.numberformatinfo.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.NumberFormatInfo
 summary: >-
   Defines the culturally appropriate format of displaying numbers. This is based
   on current system culture settings.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.CultureInfo](/javascript/api/office-scripts/excelscript/excelscript.cultureinfo):
+  [getNumberFormat](/javascript/api/office-scripts/excelscript/excelscript.cultureinfo#excelscript-excelscript-cultureinfo-getnumberformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pagebreak.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pagebreak.yml
@@ -4,7 +4,16 @@ uid: ExcelScript!ExcelScript.PageBreak:interface
 package: ExcelScript!
 fullName: ExcelScript.PageBreak
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addHorizontalPageBreak](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addhorizontalpagebreak-member(1)),
+  [addVerticalPageBreak](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addverticalpagebreak-member(1)),
+  [getHorizontalPageBreaks](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-gethorizontalpagebreaks-member(1)),
+  [getVerticalPageBreaks](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getverticalpagebreaks-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pagelayout.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pagelayout.yml
@@ -7,12 +7,23 @@ summary: >-
   Represents layout and print settings that are not dependent on any
   printer-specific implementation. These settings include margins, orientation,
   page numbering, title rows, and print area.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [getPageLayout](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getpagelayout-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets some basic page layout settings for printing.
    */
@@ -31,6 +42,7 @@ remarks: |-
       pageLayout.setOrientation(ExcelScript.PageOrientation.landscape);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pagelayoutmarginoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pagelayoutmarginoptions.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.PageLayoutMarginOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.PageLayoutMarginOptions
 summary: Represents the options in page layout margins.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [setPrintMargins](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintmargins-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pagelayoutzoomoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pagelayoutzoomoptions.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PageLayoutZoomOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.PageLayoutZoomOptions
 summary: Represents page zoom properties.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getZoom](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getzoom-member(1)),
+  [setZoom](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setzoom-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script changes the scale-to-fit of the page layout.
    */
@@ -24,6 +36,7 @@ remarks: |-
       }
       layout.setZoom(zoomOptions)
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pageorientation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pageorientation.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PageOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.PageOrientation
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getOrientation](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getorientation-member(1)),
+  [setOrientation](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setorientation-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the printing orientation for the entire workbook.
    */
@@ -22,6 +34,7 @@ remarks: |-
       pageLayout.setOrientation(ExcelScript.PageOrientation.landscape);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.papertype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.papertype.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PaperType:enum
 package: ExcelScript!
 fullName: ExcelScript.PaperType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPaperSize](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getpapersize-member(1)),
+  [setPaperSize](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setpapersize-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the page size for printing.
    */
@@ -21,6 +33,7 @@ remarks: |-
       pageLayout.setPaperSize(ExcelScript.PaperType.letter);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pictureformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pictureformat.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.PictureFormat:enum
 package: ExcelScript!
 fullName: ExcelScript.PictureFormat
 summary: The format of the image.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Image](/javascript/api/office-scripts/excelscript/excelscript.image):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.image#excelscript-excelscript-image-getformat-member(1))
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getAsImage](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getasimage-member(1)),
+  [getImageAsBase64](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getimageasbase64-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a star shape with the value from cell A1.
    * It then returns the image as a base64-encoded string. 
@@ -31,6 +47,7 @@ remarks: |-
     // Return the shape as a PNG image represented by a base64-encoded string.
     return star.getAsImage(ExcelScript.PictureFormat.png);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotdatefilter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotdatefilter.yml
@@ -7,7 +7,13 @@ summary: >-
   Configurable template for a date filter to apply to a PivotField. The
   `condition` defines what criteria need to be set in order for the filter to
   operate.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotFilters](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters):
+  [dateFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters#excelscript-excelscript-pivotfilters-datefilter-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotfield.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotfield.yml
@@ -4,7 +4,40 @@ uid: ExcelScript!ExcelScript.PivotField:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotField
 summary: Represents the Excel PivotField.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.DataPivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy):
+  [getField](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy#excelscript-excelscript-datapivothierarchy-getfield-member(1))
+
+  -
+  [ExcelScript.FilterPivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.filterpivothierarchy):
+  [getFields](/javascript/api/office-scripts/excelscript/excelscript.filterpivothierarchy#excelscript-excelscript-filterpivothierarchy-getfields-member(1)),
+  [getPivotField](/javascript/api/office-scripts/excelscript/excelscript.filterpivothierarchy#excelscript-excelscript-filterpivothierarchy-getpivotfield-member(1))
+
+  -
+  [ExcelScript.PivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivothierarchy):
+  [getFields](/javascript/api/office-scripts/excelscript/excelscript.pivothierarchy#excelscript-excelscript-pivothierarchy-getfields-member(1)),
+  [getPivotField](/javascript/api/office-scripts/excelscript/excelscript.pivothierarchy#excelscript-excelscript-pivothierarchy-getpivotfield-member(1))
+
+  -
+  [ExcelScript.RowColumnPivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.rowcolumnpivothierarchy):
+  [getFields](/javascript/api/office-scripts/excelscript/excelscript.rowcolumnpivothierarchy#excelscript-excelscript-rowcolumnpivothierarchy-getfields-member(1)),
+  [getPivotField](/javascript/api/office-scripts/excelscript/excelscript.rowcolumnpivothierarchy#excelscript-excelscript-rowcolumnpivothierarchy-getpivotfield-member(1))
+
+  -
+  [ExcelScript.ShowAsRule](/javascript/api/office-scripts/excelscript/excelscript.showasrule):
+  [baseField](/javascript/api/office-scripts/excelscript/excelscript.showasrule#excelscript-excelscript-showasrule-basefield-member)
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addslicer-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotfilters.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotfilters.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.PivotFilters
 summary: >-
   An interface representing all PivotFilters currently applied to a given
   PivotField.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [applyFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-applyfilter-member(1)),
+  [getFilters](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-getfilters-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotfiltertype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotfiltertype.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PivotFilterType:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotFilterType
 summary: A simple enum that represents a type of filter for a PivotField.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [clearFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-clearfilter-member(1)),
+  [isFiltered](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-isfiltered-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script gets the "Type" field from the "Farms Sales" PivotTable 
    * and clears the value filter from it.
@@ -24,6 +36,7 @@ remarks: |-
     // Clear the value filter (if there is one) from the field.
     typeField.clearFilter(ExcelScript.PivotFilterType.value);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivothierarchy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivothierarchy.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.PivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotHierarchy
 summary: Represents the Excel PivotHierarchy.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [addColumnHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addcolumnhierarchy-member(1)),
+  [addDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-adddatahierarchy-member(1)),
+  [addFilterHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addfilterhierarchy-member(1)),
+  [addRowHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addrowhierarchy-member(1)),
+  [getHierarchies](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-gethierarchies-member(1)),
+  [getHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-gethierarchy-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a PivotTable from an existing table and adds it to a new worksheet.
    * This script assumes there is a table in the current worksheet with columns named "Type" and "Sales".
@@ -27,6 +43,7 @@ remarks: |-
     pivotTable.addRowHierarchy(pivotTable.getHierarchy("Type"));
     pivotTable.addDataHierarchy(pivotTable.getHierarchy("Sales"));
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotitem.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotitem.yml
@@ -4,7 +4,23 @@ uid: ExcelScript!ExcelScript.PivotItem:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotItem
 summary: Represents the Excel PivotItem.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [getItems](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-getitems-member(1)),
+  [getPivotItem](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-getpivotitem-member(1)),
+  [sortByValues](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-sortbyvalues-member(1))
+
+  -
+  [ExcelScript.PivotManualFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotmanualfilter):
+  [selectedItems](/javascript/api/office-scripts/excelscript/excelscript.pivotmanualfilter#excelscript-excelscript-pivotmanualfilter-selecteditems-member)
+
+  -
+  [ExcelScript.ShowAsRule](/javascript/api/office-scripts/excelscript/excelscript.showasrule):
+  [baseItem](/javascript/api/office-scripts/excelscript/excelscript.showasrule#excelscript-excelscript-showasrule-baseitem-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotlabelfilter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotlabelfilter.yml
@@ -7,12 +7,23 @@ summary: >-
   Configurable template for a label filter to apply to a PivotField. The
   `condition` defines what criteria need to be set in order for the filter to
   operate.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotFilters](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters):
+  [labelFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters#excelscript-excelscript-pivotfilters-labelfilter-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script filters items that start with "L" from the "Type" field
    * of the "Farm Sales" PivotTable.
@@ -34,6 +45,7 @@ remarks: |-
     // Apply the label filter to the field.
     field.applyFilter({ labelFilter: filter });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotlayout.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotlayout.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.PivotLayout:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotLayout
 summary: Represents the visual layout of the PivotTable.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [getLayout](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getlayout-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotlayouttype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotlayouttype.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PivotLayoutType:enum
 package: ExcelScript!
 fullName: ExcelScript.PivotLayoutType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotLayout](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout):
+  [getLayoutType](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getlayouttype-member(1)),
+  [setLayoutType](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-setlayouttype-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the layout of the "Farms Sales" PivotTable to the "tabular"
    * setting. This places the fields from the Rows area in separate columns.
@@ -24,6 +36,7 @@ remarks: |-
     // Set the layout type to "tabular".
     layout.setLayoutType(ExcelScript.PivotLayoutType.tabular);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotmanualfilter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotmanualfilter.yml
@@ -7,16 +7,28 @@ summary: >-
   Configurable template for a manual filter to apply to a PivotField. The
   `condition` defines what criteria need to be set in order for the filter to
   operate.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotFilters](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters):
+  [manualFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters#excelscript-excelscript-pivotfilters-manualfilter-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a manual filter to a PivotTable. 
    */
   function main(workbook: ExcelScript.Workbook)
+
   {
     // Get the first PivotTable in the workbook.
     const pivot = workbook.getPivotTables()[0];
@@ -38,6 +50,7 @@ remarks: |-
       manualFilter: cityFilter
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivottable.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivottable.yml
@@ -4,12 +4,37 @@ uid: ExcelScript!ExcelScript.PivotTable:interface
 package: ExcelScript!
 fullName: ExcelScript.PivotTable
 summary: Represents an Excel PivotTable.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getPivotTables](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getpivottables-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addpivottable-member(1)),
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1)),
+  [getPivotTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpivottable-member(1)),
+  [getPivotTables](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpivottables-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addpivottable-member(1)),
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addslicer-member(1)),
+  [getPivotTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getpivottable-member(1)),
+  [getPivotTables](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getpivottables-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a PivotTable from an existing table and adds it to a new worksheet.
    * This script assumes there is a table in the current worksheet with columns named "Type" and "Sales".
@@ -27,6 +52,7 @@ remarks: |-
     pivotTable.addRowHierarchy(pivotTable.getHierarchy("Type"));
     pivotTable.addDataHierarchy(pivotTable.getHierarchy("Sales"));
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivottablestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivottablestyle.yml
@@ -6,7 +6,17 @@ fullName: ExcelScript.PivotTableStyle
 summary: >-
   Represents a PivotTable style, which defines style elements by PivotTable
   region.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addPivotTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addpivottablestyle-member(1)),
+  [getDefaultPivotTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getdefaultpivottablestyle-member(1)),
+  [getPivotTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpivottablestyle-member(1)),
+  [getPivotTableStyles](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpivottablestyles-member(1)),
+  [setDefaultPivotTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-setdefaultpivottablestyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.pivotvaluefilter.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.pivotvaluefilter.yml
@@ -7,12 +7,23 @@ summary: >-
   Configurable template for a value filter to apply to a PivotField. The
   `condition` defines what criteria need to be set in order for the filter to
   operate.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotFilters](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters):
+  [valueFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotfilters#excelscript-excelscript-pivotfilters-valuefilter-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a PivotValueFilter to the first row hierarchy in the PivotTable.
    */
@@ -39,6 +50,7 @@ remarks: |-
       valueFilter: filter
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.placement.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.placement.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.Placement:enum
 package: ExcelScript!
 fullName: ExcelScript.Placement
 summary: Specifies the way that an object is attached to its underlying cells.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getPlacement](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getplacement-member(1)),
+  [setPlacement](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-setplacement-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a diamond shape at cell C3.
    * The shape moves and resizes as the grid underneath it changes.
@@ -30,6 +42,7 @@ remarks: |-
     // Set the placement of the shape so that it resizes and moves with the grid.
     diamond.setPlacement(ExcelScript.Placement.twoCell);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.predefinedcellstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.predefinedcellstyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.PredefinedCellStyle:interface
 package: ExcelScript!
 fullName: ExcelScript.PredefinedCellStyle
 summary: An object encapsulating a style's format and other properties.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getPredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpredefinedcellstyle-member(1)),
+  [getPredefinedCellStyles](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getpredefinedcellstyles-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.presetcriteriaconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.presetcriteriaconditionalformat.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.PresetCriteriaConditionalFormat
 summary: >-
   Represents the preset criteria conditional format such as above average, below
   average, unique values, contains blank, nonblank, error, and noerror.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getPreset](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getpreset-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a conditional format that uses a preset criterion.
    * Any cell in row 1 will have the color fill set to green if it is a duplicate value
@@ -36,6 +47,7 @@ remarks: |-
     };
     presetFormat.setRule(duplicateRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.printcomments.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.printcomments.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PrintComments:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintComments
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPrintComments](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprintcomments-member(1)),
+  [setPrintComments](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintcomments-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script makes the comments print at the end of the worksheet
    * when the workbook is printed.
@@ -24,6 +36,7 @@ remarks: |-
       layout.setPrintComments(ExcelScript.PrintComments.endSheet);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.printerrortype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.printerrortype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.PrintErrorType:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintErrorType
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPrintErrors](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprinterrors-member(1)),
+  [setPrintErrors](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprinterrors-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.printmarginunit.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.printmarginunit.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.PrintMarginUnit:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintMarginUnit
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [setPrintMargins](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintmargins-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.printorder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.printorder.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.PrintOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.PrintOrder
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPrintOrder](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprintorder-member(1)),
+  [setPrintOrder](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintorder-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the print order for every worksheet in the workbook.
    * The order of printed content will go over (e.g., left-to-right) 
@@ -25,6 +37,7 @@ remarks: |-
       layout.setPrintOrder(ExcelScript.PrintOrder.overThenDown);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.protectionselectionmode.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.protectionselectionmode.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ProtectionSelectionMode:enum
 package: ExcelScript!
 fullName: ExcelScript.ProtectionSelectionMode
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.WorksheetProtectionOptions](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotectionoptions):
+  [selectionMode](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotectionoptions#excelscript-excelscript-worksheetprotectionoptions-selectionmode-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script protects cells from being selected on the current worksheet.
    */
@@ -26,6 +37,7 @@ remarks: |-
     // Apply the given protection options.
     sheetProtection.protect(protectionOptions);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.query.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.query.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.Query:interface
 package: ExcelScript!
 fullName: ExcelScript.Query
 summary: Represents a Power Query query.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getQueries](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getqueries-member(1)),
+  [getQuery](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getquery-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script logs information about all the Power Query queries in the workbook.
    */
@@ -22,6 +34,7 @@ remarks: |-
       console.log(`Query ${query.getName()} - last refreshed ${query.getRefreshDate()}`);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.queryerror.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.queryerror.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.QueryError:enum
 package: ExcelScript!
 fullName: ExcelScript.QueryError
 summary: An enum that specifies the query load error message.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Query](/javascript/api/office-scripts/excelscript/excelscript.query):
+  [getError](/javascript/api/office-scripts/excelscript/excelscript.query#excelscript-excelscript-query-geterror-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.range.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.range.yml
@@ -6,12 +6,157 @@ fullName: ExcelScript.Range
 summary: >-
   Range represents a set of one or more contiguous cells such as a cell, a row,
   a column, or a block of cells.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.AutoFilter](/javascript/api/office-scripts/excelscript/excelscript.autofilter):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.autofilter#excelscript-excelscript-autofilter-apply-member(1)),
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.autofilter#excelscript-excelscript-autofilter-getrange-member(1))
+
+  -
+  [ExcelScript.BasicDataValidation](/javascript/api/office-scripts/excelscript/excelscript.basicdatavalidation):
+  [formula1](/javascript/api/office-scripts/excelscript/excelscript.basicdatavalidation#excelscript-excelscript-basicdatavalidation-formula1-member),
+  [formula2](/javascript/api/office-scripts/excelscript/excelscript.basicdatavalidation#excelscript-excelscript-basicdatavalidation-formula2-member)
+
+  -
+  [ExcelScript.Binding](/javascript/api/office-scripts/excelscript/excelscript.binding):
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.binding#excelscript-excelscript-binding-getrange-member(1))
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [setData](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setdata-member(1)),
+  [setPosition](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-setposition-member(1))
+
+  -
+  [ExcelScript.ChartAxis](/javascript/api/office-scripts/excelscript/excelscript.chartaxis):
+  [setCategoryNames](/javascript/api/office-scripts/excelscript/excelscript.chartaxis#excelscript-excelscript-chartaxis-setcategorynames-member(1))
+
+  -
+  [ExcelScript.ChartSeries](/javascript/api/office-scripts/excelscript/excelscript.chartseries):
+  [setBubbleSizes](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setbubblesizes-member(1)),
+  [setValues](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setvalues-member(1)),
+  [setXAxisValues](/javascript/api/office-scripts/excelscript/excelscript.chartseries#excelscript-excelscript-chartseries-setxaxisvalues-member(1))
+
+  -
+  [ExcelScript.Comment](/javascript/api/office-scripts/excelscript/excelscript.comment):
+  [getLocation](/javascript/api/office-scripts/excelscript/excelscript.comment#excelscript-excelscript-comment-getlocation-member(1))
+
+  -
+  [ExcelScript.CommentReply](/javascript/api/office-scripts/excelscript/excelscript.commentreply):
+  [getLocation](/javascript/api/office-scripts/excelscript/excelscript.commentreply#excelscript-excelscript-commentreply-getlocation-member(1))
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getrange-member(1)),
+  [setRanges](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-setranges-member(1))
+
+  -
+  [ExcelScript.DateTimeDataValidation](/javascript/api/office-scripts/excelscript/excelscript.datetimedatavalidation):
+  [formula1](/javascript/api/office-scripts/excelscript/excelscript.datetimedatavalidation#excelscript-excelscript-datetimedatavalidation-formula1-member),
+  [formula2](/javascript/api/office-scripts/excelscript/excelscript.datetimedatavalidation#excelscript-excelscript-datetimedatavalidation-formula2-member)
+
+  -
+  [ExcelScript.ListDataValidation](/javascript/api/office-scripts/excelscript/excelscript.listdatavalidation):
+  [source](/javascript/api/office-scripts/excelscript/excelscript.listdatavalidation#excelscript-excelscript-listdatavalidation-source-member)
+
+  -
+  [ExcelScript.NamedItem](/javascript/api/office-scripts/excelscript/excelscript.nameditem):
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.nameditem#excelscript-excelscript-nameditem-getrange-member(1))
+
+  -
+  [ExcelScript.PageBreak](/javascript/api/office-scripts/excelscript/excelscript.pagebreak):
+  [getCellAfterBreak](/javascript/api/office-scripts/excelscript/excelscript.pagebreak#excelscript-excelscript-pagebreak-getcellafterbreak-member(1))
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPrintTitleColumns](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprinttitlecolumns-member(1)),
+  [getPrintTitleRows](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprinttitlerows-member(1)),
+  [setPrintArea](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintarea-member(1)),
+  [setPrintTitleColumns](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprinttitlecolumns-member(1)),
+  [setPrintTitleRows](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprinttitlerows-member(1))
+
+  -
+  [ExcelScript.PivotLayout](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout):
+  [getBodyAndTotalRange](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getbodyandtotalrange-member(1)),
+  [getColumnLabelRange](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getcolumnlabelrange-member(1)),
+  [getDataHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getdatahierarchy-member(1)),
+  [getFilterAxisRange](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getfilteraxisrange-member(1)),
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getrange-member(1)),
+  [getRowLabelRange](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getrowlabelrange-member(1)),
+  [setAutoSortOnCell](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-setautosortoncell-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [copyFrom](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-copyfrom-member(1)),
+  [getAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getareas-member(1)),
+  [getIntersection](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getintersection-member(1))
+
+  -
+  [ExcelScript.RangeView](/javascript/api/office-scripts/excelscript/excelscript.rangeview):
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.rangeview#excelscript-excelscript-rangeview-getrange-member(1))
+
+  -
+  [ExcelScript.Table](/javascript/api/office-scripts/excelscript/excelscript.table):
+  [convertToRange](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-converttorange-member(1)),
+  [getHeaderRowRange](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getheaderrowrange-member(1)),
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getrange-member(1)),
+  [getRangeBetweenHeaderAndTotal](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getrangebetweenheaderandtotal-member(1)),
+  [getTotalRowRange](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-gettotalrowrange-member(1)),
+  [resize](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-resize-member(1))
+
+  -
+  [ExcelScript.TableColumn](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn):
+  [getHeaderRowRange](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn#excelscript-excelscript-tablecolumn-getheaderrowrange-member(1)),
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn#excelscript-excelscript-tablecolumn-getrange-member(1)),
+  [getRangeBetweenHeaderAndTotal](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn#excelscript-excelscript-tablecolumn-getrangebetweenheaderandtotal-member(1)),
+  [getTotalRowRange](/javascript/api/office-scripts/excelscript/excelscript.tablecolumn#excelscript-excelscript-tablecolumn-gettotalrowrange-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addBinding](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addbinding-member(1)),
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addcomment-member(1)),
+  [addNamedItem](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addnameditem-member(1)),
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addpivottable-member(1)),
+  [addTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addtable-member(1)),
+  [getActiveCell](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getactivecell-member(1)),
+  [getCommentByCell](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getcommentbycell-member(1)),
+  [getSelectedRange](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getselectedrange-member(1))
+
+  -
+  [ExcelScript.WorkbookRangeAreas](/javascript/api/office-scripts/excelscript/excelscript.workbookrangeareas):
+  [getRanges](/javascript/api/office-scripts/excelscript/excelscript.workbookrangeareas#excelscript-excelscript-workbookrangeareas-getranges-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addChart](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addchart-member(1)),
+  [addComment](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addcomment-member(1)),
+  [addHorizontalPageBreak](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addhorizontalpagebreak-member(1)),
+  [addNamedItem](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addnameditem-member(1)),
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addpivottable-member(1)),
+  [addTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addtable-member(1)),
+  [addVerticalPageBreak](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addverticalpagebreak-member(1)),
+  [getCell](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcell-member(1)),
+  [getCommentByCell](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcommentbycell-member(1)),
+  [getRange](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getrange-member(1)),
+  [getRangeByIndexes](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getrangebyindexes-member(1)),
+  [getUsedRange](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getusedrange-member(1))
+
+  -
+  [ExcelScript.WorksheetFreezePanes](/javascript/api/office-scripts/excelscript/excelscript.worksheetfreezepanes):
+  [freezeAt](/javascript/api/office-scripts/excelscript/excelscript.worksheetfreezepanes#excelscript-excelscript-worksheetfreezepanes-freezeat-member(1)),
+  [getLocation](/javascript/api/office-scripts/excelscript/excelscript.worksheetfreezepanes#excelscript-excelscript-worksheetfreezepanes-getlocation-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script logs the address of the used range in the current worksheet.
    */
@@ -25,6 +170,7 @@ remarks: |-
     // Log the range's address to the console.
     console.log(usedRange.getAddress());
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangeareas.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangeareas.yml
@@ -6,12 +6,53 @@ fullName: ExcelScript.RangeAreas
 summary: >-
   `RangeAreas` represents a collection of one or more rectangular ranges in the
   same worksheet.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getRanges](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-getranges-member(1)),
+  [setRanges](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-setranges-member(1))
+
+  -
+  [ExcelScript.DataValidation](/javascript/api/office-scripts/excelscript/excelscript.datavalidation):
+  [getInvalidCells](/javascript/api/office-scripts/excelscript/excelscript.datavalidation#excelscript-excelscript-datavalidation-getinvalidcells-member(1))
+
+  -
+  [ExcelScript.PageLayout](/javascript/api/office-scripts/excelscript/excelscript.pagelayout):
+  [getPrintArea](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-getprintarea-member(1)),
+  [setPrintArea](/javascript/api/office-scripts/excelscript/excelscript.pagelayout#excelscript-excelscript-pagelayout-setprintarea-member(1))
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [copyFrom](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-copyfrom-member(1)),
+  [getMergedAreas](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getmergedareas-member(1)),
+  [getSpecialCells](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getspecialcells-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getSelectedRanges](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getselectedranges-member(1))
+
+  -
+  [ExcelScript.WorkbookRangeAreas](/javascript/api/office-scripts/excelscript/excelscript.workbookrangeareas):
+  [getAreas](/javascript/api/office-scripts/excelscript/excelscript.workbookrangeareas#excelscript-excelscript-workbookrangeareas-getareas-member(1)),
+  [getRangeAreasBySheet](/javascript/api/office-scripts/excelscript/excelscript.workbookrangeareas#excelscript-excelscript-workbookrangeareas-getrangeareasbysheet-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [findAll](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-findall-member(1)),
+  [getRanges](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getranges-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script clears all the cells in the current worksheet that are displaying errors.
    */
@@ -28,6 +69,7 @@ remarks: |-
       errorCells.clear();
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangeborder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangeborder.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.RangeBorder:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeBorder
 summary: Represents the border of an object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getBorders](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getborders-member(1)),
+  [getRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getrangeborder-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getBorders](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getborders-member(1)),
+  [getRangeBorder](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getrangeborder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangecopytype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangecopytype.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.RangeCopyType:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeCopyType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [copyFrom](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-copyfrom-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [copyFrom](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-copyfrom-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script copies all of the values from the current worksheet to a new worksheet.
    */
@@ -32,6 +47,7 @@ remarks: |-
     // Switch the view to the new worksheet.
     newSheet.activate();
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangefill.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangefill.yml
@@ -4,16 +4,32 @@ uid: ExcelScript!ExcelScript.RangeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeFill
 summary: Represents the background of a range object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getfill-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getfill-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the fill color of the used range to green.
    */
   function main(workbook: ExcelScript.Workbook)
+
   {
     // Get the used range of the current worksheet.
     let currentSheet = workbook.getActiveWorksheet();
@@ -25,6 +41,7 @@ remarks: |-
     // Set the fill color to green.
     fill.setColor("green");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangefont.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangefont.yml
@@ -6,12 +6,27 @@ fullName: ExcelScript.RangeFont
 summary: >-
   This object represents the font attributes (font name, font size, color, etc.)
   for an object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getfont-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getfont-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the font of A1 to Arial, size 16.
    */
@@ -24,6 +39,7 @@ remarks: |-
     cellFont.setName("Arial");
     cellFont.setSize(16);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangeformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangeformat.yml
@@ -6,12 +6,27 @@ fullName: ExcelScript.RangeFormat
 summary: >-
   A format object encapsulating the range's font, fill, borders, alignment, and
   other properties.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getformat-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getformat-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies some simple formatting to the top row of the used range.
    */
@@ -26,6 +41,7 @@ remarks: |-
     format.getFont().setColor("white");
     format.getFont().setBold(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangehyperlink.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangehyperlink.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.RangeHyperlink:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeHyperlink
 summary: Represents the necessary strings to get/set a hyperlink (XHL) object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getHyperlink](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-gethyperlink-member(1)),
+  [setHyperlink](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-sethyperlink-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script puts a link to a webpage in a cell.
    */
@@ -28,6 +40,7 @@ remarks: |-
     cell.setHyperlink(sampleHyperlink);
     cell.getFormat().autofitColumns();
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangesort.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangesort.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.RangeSort:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeSort
 summary: Manages sorting operations on `Range` objects.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getSort](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getsort-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangeunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangeunderlinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.RangeUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeUnderlineStyle
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeFont](/javascript/api/office-scripts/excelscript/excelscript.rangefont):
+  [getUnderline](/javascript/api/office-scripts/excelscript/excelscript.rangefont#excelscript-excelscript-rangefont-getunderline-member(1)),
+  [setUnderline](/javascript/api/office-scripts/excelscript/excelscript.rangefont#excelscript-excelscript-rangefont-setunderline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangevaluetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangevaluetype.yml
@@ -4,12 +4,32 @@ uid: ExcelScript!ExcelScript.RangeValueType:enum
 package: ExcelScript!
 fullName: ExcelScript.RangeValueType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.NamedItemArrayValues](/javascript/api/office-scripts/excelscript/excelscript.nameditemarrayvalues):
+  [getTypes](/javascript/api/office-scripts/excelscript/excelscript.nameditemarrayvalues#excelscript-excelscript-nameditemarrayvalues-gettypes-member(1))
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getValueType](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getvaluetype-member(1)),
+  [getValueTypes](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getvaluetypes-member(1))
+
+  -
+  [ExcelScript.RangeView](/javascript/api/office-scripts/excelscript/excelscript.rangeview):
+  [getValueTypes](/javascript/api/office-scripts/excelscript/excelscript.rangeview#excelscript-excelscript-rangeview-getvaluetypes-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script formats rows in a worksheet based on the first value in that row. 
    * If it's the boolean value TRUE, the row is bolded. 
@@ -42,6 +62,7 @@ remarks: |-
       }
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rangeview.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rangeview.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.RangeView:interface
 package: ExcelScript!
 fullName: ExcelScript.RangeView
 summary: RangeView represents a set of visible cells of the parent range.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getVisibleView](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getvisibleview-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script copies values and formatting from the 
    * visible range of a table in Sheet1 into Sheet2.
@@ -26,6 +37,7 @@ remarks: |-
     const otherRangeCorner = otherSheet.getRange("A1");
     otherRangeCorner.copyFrom(source, ExcelScript.RangeCopyType.all);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.readingorder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.readingorder.yml
@@ -4,7 +4,19 @@ uid: ExcelScript!ExcelScript.ReadingOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.ReadingOrder
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getreadingorder-member(1)),
+  [setReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-setreadingorder-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getreadingorder-member(1)),
+  [setReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-setreadingorder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.removeduplicatesresult.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.removeduplicatesresult.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.RemoveDuplicatesResult:interface
 package: ExcelScript!
 fullName: ExcelScript.RemoveDuplicatesResult
 summary: Represents the results from `Range.removeDuplicates`<!-- -->.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [removeDuplicates](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-removeduplicates-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script removes duplicate rows from a range.
    */
@@ -23,6 +34,7 @@ remarks: |-
     // Log the count of removed rows.
     console.log(`Rows removed: ${removedResults.getRemoved()}.`);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.replacecriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.replacecriteria.yml
@@ -4,7 +4,17 @@ uid: ExcelScript!ExcelScript.ReplaceCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.ReplaceCriteria
 summary: Represents the replace criteria to be used.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [replaceAll](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-replaceall-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [replaceAll](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-replaceall-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.rowcolumnpivothierarchy.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.rowcolumnpivothierarchy.yml
@@ -4,12 +4,30 @@ uid: ExcelScript!ExcelScript.RowColumnPivotHierarchy:interface
 package: ExcelScript!
 fullName: ExcelScript.RowColumnPivotHierarchy
 summary: Represents the Excel RowColumnPivotHierarchy.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [addColumnHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addcolumnhierarchy-member(1)),
+  [addRowHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-addrowhierarchy-member(1)),
+  [getColumnHierarchies](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getcolumnhierarchies-member(1)),
+  [getColumnHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getcolumnhierarchy-member(1)),
+  [getRowHierarchies](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getrowhierarchies-member(1)),
+  [getRowHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getrowhierarchy-member(1)),
+  [removeColumnHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-removecolumnhierarchy-member(1)),
+  [removeRowHierarchy](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-removerowhierarchy-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    *  This sample sorts the rows of a PivotTable.
    */
@@ -26,6 +44,7 @@ remarks: |-
     // Sort the "Farm" row's only field by the values in "Sum of Crates Sold Wholesale".
     rowToSort.getFields()[0].sortByValues(ExcelScript.SortBy.descending, valueFieldToSortOn);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.searchcriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.searchcriteria.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.SearchCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.SearchCriteria
 summary: Represents the search criteria to be used.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [find](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-find-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script searches for the next instance of the text "TK" on the current worksheet.
    * It then selects that cell and removes "TK" and all formatting from the cell.
@@ -31,6 +42,7 @@ remarks: |-
     // Remove the "TK" text value from the cell, as well as any formatting that may have been added.
     tkCell.clear(ExcelScript.ClearApplyTo.all);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.searchdirection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.searchdirection.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.SearchDirection:enum
 package: ExcelScript!
 fullName: ExcelScript.SearchDirection
 summary: Specifies the search direction.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.SearchCriteria](/javascript/api/office-scripts/excelscript/excelscript.searchcriteria):
+  [searchDirection](/javascript/api/office-scripts/excelscript/excelscript.searchcriteria#excelscript-excelscript-searchcriteria-searchdirection-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script searches for the next instance of the text "TK" on the current worksheet.
    * It then selects that cell and removes "TK" and all formatting from the cell.
@@ -31,6 +42,7 @@ remarks: |-
     // Remove the "TK" text value from the cell, as well as any formatting that may have been added.
     tkCell.clear(ExcelScript.ClearApplyTo.all);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shape.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shape.yml
@@ -6,12 +6,47 @@ fullName: ExcelScript.Shape
 summary: >-
   Represents a generic shape object in the worksheet. A shape could be a
   geometric shape, a line, a group of shapes, etc.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Image](/javascript/api/office-scripts/excelscript/excelscript.image):
+  [getShape](/javascript/api/office-scripts/excelscript/excelscript.image#excelscript-excelscript-image-getshape-member(1))
+
+  -
+  [ExcelScript.Line](/javascript/api/office-scripts/excelscript/excelscript.line):
+  [connectBeginShape](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-connectbeginshape-member(1)),
+  [connectEndShape](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-connectendshape-member(1)),
+  [getBeginConnectedShape](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getbeginconnectedshape-member(1)),
+  [getEndConnectedShape](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getendconnectedshape-member(1)),
+  [getShape](/javascript/api/office-scripts/excelscript/excelscript.line#excelscript-excelscript-line-getshape-member(1))
+
+  -
+  [ExcelScript.ShapeGroup](/javascript/api/office-scripts/excelscript/excelscript.shapegroup):
+  [getGroupShape](/javascript/api/office-scripts/excelscript/excelscript.shapegroup#excelscript-excelscript-shapegroup-getgroupshape-member(1)),
+  [getShape](/javascript/api/office-scripts/excelscript/excelscript.shapegroup#excelscript-excelscript-shapegroup-getshape-member(1)),
+  [getShapes](/javascript/api/office-scripts/excelscript/excelscript.shapegroup#excelscript-excelscript-shapegroup-getshapes-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addGeometricShape](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addgeometricshape-member(1)),
+  [addGroup](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addgroup-member(1)),
+  [addImage](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addimage-member(1)),
+  [addLine](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addline-member(1)),
+  [addTextBox](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addtextbox-member(1)),
+  [getShape](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getshape-member(1)),
+  [getShapes](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getshapes-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a hexagon shape on the current worksheet.
    */
@@ -28,6 +63,7 @@ remarks: |-
     hexagon.setLeft(100);
     hexagon.setTop(100);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapeautosize.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapeautosize.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.ShapeAutoSize:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeAutoSize
 summary: Determines the type of automatic sizing allowed.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getAutoSizeSetting](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-getautosizesetting-member(1)),
+  [setAutoSizeSetting](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-setautosizesetting-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a star shape with the value from cell A1.
    */
@@ -26,6 +38,7 @@ remarks: |-
     textFrame.getTextRange().setText(value.toString());
     textFrame.setAutoSizeSetting(ExcelScript.ShapeAutoSize.autoSizeShapeToFitText);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapefill.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapefill.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ShapeFill:interface
 package: ExcelScript!
 fullName: ExcelScript.ShapeFill
 summary: Represents the fill formatting of a shape object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getFill](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getfill-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapefilltype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapefilltype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ShapeFillType:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeFillType
 summary: Specifies a shape's fill type.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ShapeFill](/javascript/api/office-scripts/excelscript/excelscript.shapefill):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.shapefill#excelscript-excelscript-shapefill-gettype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapefont.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapefont.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.ShapeFont
 summary: >-
   Represents the font attributes, such as font name, font size, and color, for a
   shape's `TextRange` object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.TextRange](/javascript/api/office-scripts/excelscript/excelscript.textrange):
+  [getFont](/javascript/api/office-scripts/excelscript/excelscript.textrange#excelscript-excelscript-textrange-getfont-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample sets the font of a shape to be bold. 
    */
@@ -27,6 +38,7 @@ remarks: |-
     // Set the font to be bold.
     shapeTextFont.setBold(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapefontunderlinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapefontunderlinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeFontUnderlineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeFontUnderlineStyle
 summary: The type of underline applied to a font.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ShapeFont](/javascript/api/office-scripts/excelscript/excelscript.shapefont):
+  [getUnderline](/javascript/api/office-scripts/excelscript/excelscript.shapefont#excelscript-excelscript-shapefont-getunderline-member(1)),
+  [setUnderline](/javascript/api/office-scripts/excelscript/excelscript.shapefont#excelscript-excelscript-shapefont-setunderline-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapegroup.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapegroup.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.ShapeGroup
 summary: >-
   Represents a shape group inside a worksheet. To get the corresponding `Shape`
   object, use `ShapeGroup.shape`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getGroup](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getgroup-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapelinedashstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapelinedashstyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeLineDashStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeLineDashStyle
 summary: The dash style for a line.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ShapeLineFormat](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat):
+  [getDashStyle](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat#excelscript-excelscript-shapelineformat-getdashstyle-member(1)),
+  [setDashStyle](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat#excelscript-excelscript-shapelineformat-setdashstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapelineformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapelineformat.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.ShapeLineFormat
 summary: >-
   Represents the line formatting for the shape object. For images and geometric
   shapes, line formatting represents the border of the shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getLineFormat](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-getlineformat-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapelinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapelinestyle.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeLineStyle:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeLineStyle
 summary: The style for a line.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.ShapeLineFormat](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat):
+  [getStyle](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat#excelscript-excelscript-shapelineformat-getstyle-member(1)),
+  [setStyle](/javascript/api/office-scripts/excelscript/excelscript.shapelineformat#excelscript-excelscript-shapelineformat-setstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapescalefrom.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapescalefrom.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ShapeScaleFrom
 summary: >-
   Specifies which part of the shape retains its position when the shape is
   scaled.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [scaleHeight](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-scaleheight-member(1)),
+  [scaleWidth](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-scalewidth-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapescaletype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapescaletype.yml
@@ -6,7 +6,14 @@ fullName: ExcelScript.ShapeScaleType
 summary: >-
   Specifies whether the shape is scaled relative to its original or current
   size.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [scaleHeight](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-scaleheight-member(1)),
+  [scaleWidth](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-scalewidth-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetexthorizontalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetexthorizontalalignment.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextHorizontalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextHorizontalAlignment
 summary: Specifies the horizontal alignment for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-gethorizontalalignment-member(1)),
+  [setHorizontalAlignment](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-sethorizontalalignment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetexthorizontaloverflow.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetexthorizontaloverflow.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextHorizontalOverflow:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextHorizontalOverflow
 summary: Specifies the horizontal overflow for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getHorizontalOverflow](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-gethorizontaloverflow-member(1)),
+  [setHorizontalOverflow](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-sethorizontaloverflow-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetextorientation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetextorientation.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextOrientation
 summary: Specifies the orientation for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getOrientation](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-getorientation-member(1)),
+  [setOrientation](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-setorientation-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetextreadingorder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetextreadingorder.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextReadingOrder:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextReadingOrder
 summary: Specifies the reading order for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-getreadingorder-member(1)),
+  [setReadingOrder](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-setreadingorder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetextverticalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetextverticalalignment.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextVerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextVerticalAlignment
 summary: Specifies the vertical alignment for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-setverticalalignment-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetextverticaloverflow.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetextverticaloverflow.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.ShapeTextVerticalOverflow:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeTextVerticalOverflow
 summary: Specifies the vertical overflow for the text frame in a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getVerticalOverflow](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-getverticaloverflow-member(1)),
+  [setVerticalOverflow](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-setverticaloverflow-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapetype.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.ShapeType:enum
 package: ExcelScript!
 fullName: ExcelScript.ShapeType
 summary: Specifies the type of a shape.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getType](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-gettype-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.shapezorder.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.shapezorder.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.ShapeZOrder
 summary: >-
   Specifies where in the z-order a shape should be moved relative to other
   shapes.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [setZOrder](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-setzorder-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sheetvisibility.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sheetvisibility.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.SheetVisibility:enum
 package: ExcelScript!
 fullName: ExcelScript.SheetVisibility
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [getVisibility](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getvisibility-member(1)),
+  [setVisibility](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-setvisibility-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script unhides all the worksheets in the workbook.
    */
@@ -20,6 +32,7 @@ remarks: |-
       worksheet.setVisibility(ExcelScript.SheetVisibility.visible);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.showascalculation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.showascalculation.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.ShowAsCalculation:enum
 package: ExcelScript!
 fullName: ExcelScript.ShowAsCalculation
 summary: The ShowAs calculation function for the DataPivotField.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ShowAsRule](/javascript/api/office-scripts/excelscript/excelscript.showasrule):
+  [calculation](/javascript/api/office-scripts/excelscript/excelscript.showasrule#excelscript-excelscript-showasrule-calculation-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * The script changes the display for "Crates Sold at Farm".
    * It shows the percentage of the grand total, 
@@ -27,6 +38,7 @@ remarks: |-
       calculation: ExcelScript.ShowAsCalculation.percentOfGrandTotal
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.showasrule.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.showasrule.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.ShowAsRule:interface
 package: ExcelScript!
 fullName: ExcelScript.ShowAsRule
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.DataPivotHierarchy](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy):
+  [getShowAs](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy#excelscript-excelscript-datapivothierarchy-getshowas-member(1)),
+  [setShowAs](/javascript/api/office-scripts/excelscript/excelscript.datapivothierarchy#excelscript-excelscript-datapivothierarchy-setshowas-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * The script changes the display for "Crates Sold at Farm".
    * The field shows each value's difference
@@ -38,6 +50,7 @@ remarks: |-
     // Set the name of the field to match the new behavior.
     farmSales.setName("Difference from Lemons of Crates Sold at Farm");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.slicer.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.slicer.yml
@@ -4,12 +4,32 @@ uid: ExcelScript!ExcelScript.Slicer:interface
 package: ExcelScript!
 fullName: ExcelScript.Slicer
 summary: Represents a `Slicer` object in the workbook.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1)),
+  [getActiveSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getactiveslicer-member(1)),
+  [getSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getslicer-member(1)),
+  [getSlicers](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getslicers-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addslicer-member(1)),
+  [getSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getslicer-member(1)),
+  [getSlicers](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getslicers-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds a slicer for an existing PivotTable.
    */
@@ -30,6 +50,7 @@ remarks: |-
     // Set the left margin of the slicer.
     fruitSlicer.setLeft(400);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sliceritem.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sliceritem.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.SlicerItem:interface
 package: ExcelScript!
 fullName: ExcelScript.SlicerItem
 summary: Represents a slicer item in a slicer.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Slicer](/javascript/api/office-scripts/excelscript/excelscript.slicer):
+  [getSlicerItem](/javascript/api/office-scripts/excelscript/excelscript.slicer#excelscript-excelscript-slicer-getsliceritem-member(1)),
+  [getSlicerItems](/javascript/api/office-scripts/excelscript/excelscript.slicer#excelscript-excelscript-slicer-getsliceritems-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.slicersorttype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.slicersorttype.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.SlicerSortType:enum
 package: ExcelScript!
 fullName: ExcelScript.SlicerSortType
 summary: Specifies the slicer sort behavior for `Slicer.sortBy`<!-- -->.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Slicer](/javascript/api/office-scripts/excelscript/excelscript.slicer):
+  [getSortBy](/javascript/api/office-scripts/excelscript/excelscript.slicer#excelscript-excelscript-slicer-getsortby-member(1)),
+  [setSortBy](/javascript/api/office-scripts/excelscript/excelscript.slicer#excelscript-excelscript-slicer-setsortby-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.slicerstyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.slicerstyle.yml
@@ -6,7 +6,17 @@ fullName: ExcelScript.SlicerStyle
 summary: >-
   Represents a slicer style, which defines style elements by region of the
   slicer.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addSlicerStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicerstyle-member(1)),
+  [getDefaultSlicerStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getdefaultslicerstyle-member(1)),
+  [getSlicerStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getslicerstyle-member(1)),
+  [getSlicerStyles](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getslicerstyles-member(1)),
+  [setDefaultSlicerStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-setdefaultslicerstyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sortby.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sortby.yml
@@ -4,7 +4,18 @@ uid: ExcelScript!ExcelScript.SortBy:enum
 package: ExcelScript!
 fullName: ExcelScript.SortBy
 summary: Represents the sort direction.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [sortByLabels](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-sortbylabels-member(1)),
+  [sortByValues](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-sortbyvalues-member(1))
+
+  -
+  [ExcelScript.PivotLayout](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout):
+  [setAutoSortOnCell](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-setautosortoncell-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sortdataoption.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sortdataoption.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.SortDataOption:enum
 package: ExcelScript!
 fullName: ExcelScript.SortDataOption
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.SortField](/javascript/api/office-scripts/excelscript/excelscript.sortfield):
+  [dataOption](/javascript/api/office-scripts/excelscript/excelscript.sortfield#excelscript-excelscript-sortfield-dataoption-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sorts a table based on the values in column 1.
    * If the text of a column-1 value can be treated as a number, 
@@ -32,6 +43,7 @@ remarks: |-
     const sort = table.getSort();
     sort.apply([countSortField]);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sortfield.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sortfield.yml
@@ -4,7 +4,18 @@ uid: ExcelScript!ExcelScript.SortField:interface
 package: ExcelScript!
 fullName: ExcelScript.SortField
 summary: Represents a condition in a sorting operation.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeSort](/javascript/api/office-scripts/excelscript/excelscript.rangesort):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.rangesort#excelscript-excelscript-rangesort-apply-member(1))
+
+  -
+  [ExcelScript.TableSort](/javascript/api/office-scripts/excelscript/excelscript.tablesort):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.tablesort#excelscript-excelscript-tablesort-apply-member(1)),
+  [getFields](/javascript/api/office-scripts/excelscript/excelscript.tablesort#excelscript-excelscript-tablesort-getfields-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sortmethod.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sortmethod.yml
@@ -4,12 +4,28 @@ uid: ExcelScript!ExcelScript.SortMethod:enum
 package: ExcelScript!
 fullName: ExcelScript.SortMethod
 summary: Represents the ordering method to be used when sorting Chinese characters.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeSort](/javascript/api/office-scripts/excelscript/excelscript.rangesort):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.rangesort#excelscript-excelscript-rangesort-apply-member(1))
+
+  -
+  [ExcelScript.TableSort](/javascript/api/office-scripts/excelscript/excelscript.tablesort):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.tablesort#excelscript-excelscript-tablesort-apply-member(1)),
+  [getMethod](/javascript/api/office-scripts/excelscript/excelscript.tablesort#excelscript-excelscript-tablesort-getmethod-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sorts a range using the values in the first column.
    */
@@ -34,6 +50,7 @@ remarks: |-
       ExcelScript.SortMethod.pinYin /* Use phonetic sorting for Chinese characters. */
       );
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sorton.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sorton.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.SortOn:enum
 package: ExcelScript!
 fullName: ExcelScript.SortOn
 summary: Represents the part of the cell used as the sorting criteria.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.SortField](/javascript/api/office-scripts/excelscript/excelscript.sortfield):
+  [sortOn](/javascript/api/office-scripts/excelscript/excelscript.sortfield#excelscript-excelscript-sortfield-sorton-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sorts a range based on the color of the cells.
    * It brings all red cells to the top of the range.
@@ -31,6 +42,7 @@ remarks: |-
     // Apply the SortField to the range.
     rangeToSort.getSort().apply([colorSort]);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.sortorientation.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.sortorientation.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.SortOrientation:enum
 package: ExcelScript!
 fullName: ExcelScript.SortOrientation
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.RangeSort](/javascript/api/office-scripts/excelscript/excelscript.rangesort):
+  [apply](/javascript/api/office-scripts/excelscript/excelscript.rangesort#excelscript-excelscript-rangesort-apply-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.specialcelltype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.specialcelltype.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.SpecialCellType:enum
 package: ExcelScript!
 fullName: ExcelScript.SpecialCellType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getSpecialCells](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getspecialcells-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getSpecialCells](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getspecialcells-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script finds and highlights all the cells in the current worksheet that contain a formula.
    */
@@ -24,6 +39,7 @@ remarks: |-
     // Add a light blue background to the cells containing formulas.
     formulaCells.getFormat().getFill().setColor("#ADD8E6");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.specialcellvaluetype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.specialcellvaluetype.yml
@@ -4,12 +4,27 @@ uid: ExcelScript!ExcelScript.SpecialCellValueType:enum
 package: ExcelScript!
 fullName: ExcelScript.SpecialCellValueType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getSpecialCells](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getspecialcells-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getSpecialCells](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getspecialcells-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script finds and bolds the text of cells containing strings (not numbers or formulas).
    */
@@ -26,6 +41,7 @@ remarks: |-
     // Bold the text of those cells.
     textCells.getFormat().getFont().setBold(true);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.subtotallocationtype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.subtotallocationtype.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.SubtotalLocationType:enum
 package: ExcelScript!
 fullName: ExcelScript.SubtotalLocationType
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotLayout](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout):
+  [getSubtotalLocation](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-getsubtotallocation-member(1)),
+  [setSubtotalLocation](/javascript/api/office-scripts/excelscript/excelscript.pivotlayout#excelscript-excelscript-pivotlayout-setsubtotallocation-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script displays group subtotals of the "Farms Sales" PivotTable.
    */
@@ -23,6 +35,7 @@ remarks: |-
     // Show all the subtotals at the bottom of each group.
     layout.setSubtotalLocation(ExcelScript.SubtotalLocationType.atBottom);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.subtotals.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.subtotals.yml
@@ -4,7 +4,14 @@ uid: ExcelScript!ExcelScript.Subtotals:interface
 package: ExcelScript!
 fullName: ExcelScript.Subtotals
 summary: Subtotals for the Pivot Field.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotField](/javascript/api/office-scripts/excelscript/excelscript.pivotfield):
+  [getSubtotals](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-getsubtotals-member(1)),
+  [setSubtotals](/javascript/api/office-scripts/excelscript/excelscript.pivotfield#excelscript-excelscript-pivotfield-setsubtotals-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.table.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.table.yml
@@ -4,12 +4,47 @@ uid: ExcelScript!ExcelScript.Table:interface
 package: ExcelScript!
 fullName: ExcelScript.Table
 summary: Represents an Excel table.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Binding](/javascript/api/office-scripts/excelscript/excelscript.binding):
+  [getTable](/javascript/api/office-scripts/excelscript/excelscript.binding#excelscript-excelscript-binding-gettable-member(1))
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getTables](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-gettables-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getTables](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-gettables-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addpivottable-member(1)),
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1)),
+  [addTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addtable-member(1)),
+  [getTable](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettable-member(1)),
+  [getTables](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettables-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addPivotTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addpivottable-member(1)),
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addslicer-member(1)),
+  [addTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addtable-member(1)),
+  [getTable](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-gettable-member(1)),
+  [getTables](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-gettables-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a table from the current sheet's used range.
    * It then adds a total row to the table with the SUM of the last column.
@@ -27,6 +62,7 @@ remarks: |-
       const lastColumn = table.getColumn(table.getColumns().length);
       lastColumn.getTotalRowRange().setFormula(`=SUBTOTAL(109,[${lastColumn.getName()}])`);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.tablecolumn.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.tablecolumn.yml
@@ -4,12 +4,35 @@ uid: ExcelScript!ExcelScript.TableColumn:interface
 package: ExcelScript!
 fullName: ExcelScript.TableColumn
 summary: Represents a column in a table.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Table](/javascript/api/office-scripts/excelscript/excelscript.table):
+  [addColumn](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-addcolumn-member(1)),
+  [getColumn](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getcolumn-member(1)),
+  [getColumnById](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getcolumnbyid-member(1)),
+  [getColumnByName](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getcolumnbyname-member(1)),
+  [getColumns](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getcolumns-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1))
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addslicer-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script shows how to get the range of a table column.
    */
@@ -23,6 +46,7 @@ remarks: |-
 
     // Do something with the range...
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.tablesort.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.tablesort.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.TableSort:interface
 package: ExcelScript!
 fullName: ExcelScript.TableSort
 summary: Manages sorting operations on `Table` objects.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Table](/javascript/api/office-scripts/excelscript/excelscript.table):
+  [getSort](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getsort-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.tablestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.tablestyle.yml
@@ -6,7 +6,17 @@ fullName: ExcelScript.TableStyle
 summary: >-
   Represents a table style, which defines the style elements by region of the
   table.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addtablestyle-member(1)),
+  [getDefaultTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getdefaulttablestyle-member(1)),
+  [getTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettablestyle-member(1)),
+  [getTableStyles](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettablestyles-member(1)),
+  [setDefaultTableStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-setdefaulttablestyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.textconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.textconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.TextConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.TextConditionalFormat
 summary: Represents a specific text conditional format.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getTextComparison](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-gettextcomparison-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds conditional formatting to the first column in the worksheet.
    * This formatting gives the cells a green fill if they have text starting with "Excel".
@@ -33,6 +44,7 @@ remarks: |-
     };
     textConditionFormat.setRule(textRule);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.textframe.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.textframe.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.TextFrame:interface
 package: ExcelScript!
 fullName: ExcelScript.TextFrame
 summary: Represents the text frame of a shape object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [getTextFrame](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-gettextframe-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a star shape with the value from cell A1.
    */
@@ -26,6 +37,7 @@ remarks: |-
     textFrame.getTextRange().setText(value.toString());
     textFrame.setAutoSizeSetting(ExcelScript.ShapeAutoSize.autoSizeShapeToFitText);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.textrange.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.textrange.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.TextRange
 summary: >-
   Contains the text that is attached to a shape, in addition to properties and
   methods for manipulating the text.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.TextFrame](/javascript/api/office-scripts/excelscript/excelscript.textframe):
+  [getTextRange](/javascript/api/office-scripts/excelscript/excelscript.textframe#excelscript-excelscript-textframe-gettextrange-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script adds text to a shape.
    */
@@ -24,6 +35,7 @@ remarks: |-
     const hexText: ExcelScript.TextRange = hexagon.getTextFrame().getTextRange();
     hexText.setText("Forest");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.timelinestyle.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.timelinestyle.yml
@@ -6,7 +6,17 @@ fullName: ExcelScript.TimelineStyle
 summary: >-
   Represents a `TimelineStyle`<!-- -->, which defines style elements by region
   in the timeline.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addTimelineStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addtimelinestyle-member(1)),
+  [getDefaultTimelineStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getdefaulttimelinestyle-member(1)),
+  [getTimelineStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettimelinestyle-member(1)),
+  [getTimelineStyles](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-gettimelinestyles-member(1)),
+  [setDefaultTimelineStyle](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-setdefaulttimelinestyle-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.topbottomconditionalformat.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.topbottomconditionalformat.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.TopBottomConditionalFormat:interface
 package: ExcelScript!
 fullName: ExcelScript.TopBottomConditionalFormat
 summary: Represents a top/bottom conditional format.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.ConditionalFormat](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat):
+  [getTopBottom](/javascript/api/office-scripts/excelscript/excelscript.conditionalformat#excelscript-excelscript-conditionalformat-gettopbottom-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This sample applies conditional formatting to the currently used range in the worksheet. 
    * The conditional formatting is a green fill for the top 10% of values.
@@ -29,6 +40,7 @@ remarks: |-
       type: ExcelScript.ConditionalTopBottomCriterionType.topPercent /* The type of the top/bottom condition. */
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.topbottomselectiontype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.topbottomselectiontype.yml
@@ -6,7 +6,13 @@ fullName: ExcelScript.TopBottomSelectionType
 summary: >-
   A simple enum for top/bottom filters to select whether to filter by the top N
   or bottom N percent, number, or sum of values.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotValueFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotvaluefilter):
+  [selectionType](/javascript/api/office-scripts/excelscript/excelscript.pivotvaluefilter#excelscript-excelscript-pivotvaluefilter-selectiontype-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.valuefiltercondition.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.valuefiltercondition.yml
@@ -8,12 +8,23 @@ summary: >-
   applied. Used to configure the type of PivotFilter that is applied to the
   field. `PivotFilter.exclusive` can be set to `true` to invert many of these
   conditions.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PivotValueFilter](/javascript/api/office-scripts/excelscript/excelscript.pivotvaluefilter):
+  [condition](/javascript/api/office-scripts/excelscript/excelscript.pivotvaluefilter#excelscript-excelscript-pivotvaluefilter-condition-member)
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script applies a PivotValueFilter to the first row hierarchy in the PivotTable.
    */
@@ -40,6 +51,7 @@ remarks: |-
       valueFilter: filter
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.verticalalignment.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.verticalalignment.yml
@@ -4,12 +4,29 @@ uid: ExcelScript!ExcelScript.VerticalAlignment:enum
 package: ExcelScript!
 fullName: ExcelScript.VerticalAlignment
 summary: ''
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.PredefinedCellStyle](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.predefinedcellstyle#excelscript-excelscript-predefinedcellstyle-setverticalalignment-member(1))
+
+  -
+  [ExcelScript.RangeFormat](/javascript/api/office-scripts/excelscript/excelscript.rangeformat):
+  [getVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-getverticalalignment-member(1)),
+  [setVerticalAlignment](/javascript/api/office-scripts/excelscript/excelscript.rangeformat#excelscript-excelscript-rangeformat-setverticalalignment-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script sets the vertical alignment formatting to "top"
    * for every cell in the row.
@@ -22,6 +39,7 @@ remarks: |-
     // Set the vertical alignment formatting on the row.
     firstRow.getFormat().setVerticalAlignment(ExcelScript.VerticalAlignment.top);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.workbooklinksrefreshmode.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.workbooklinksrefreshmode.yml
@@ -4,12 +4,24 @@ uid: ExcelScript!ExcelScript.WorkbookLinksRefreshMode:enum
 package: ExcelScript!
 fullName: ExcelScript.WorkbookLinksRefreshMode
 summary: Represents the refresh mode of the workbook links.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getLinkedWorkbookRefreshMode](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getlinkedworkbookrefreshmode-member(1)),
+  [setLinkedWorkbookRefreshMode](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-setlinkedworkbookrefreshmode-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script refreshes all the links to external workbooks, 
    * if the linked workbook refresh mode is set to manual.
@@ -24,6 +36,7 @@ remarks: |-
       workbook.refreshAllLinksToLinkedWorkbooks();
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.workbookprotection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.workbookprotection.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.WorkbookProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.WorkbookProtection
 summary: Represents the protection of a workbook object.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [getProtection](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getprotection-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.workbookrangeareas.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.workbookrangeareas.yml
@@ -6,12 +6,26 @@ fullName: ExcelScript.WorkbookRangeAreas
 summary: >-
   Represents a collection of one or more rectangular ranges in multiple
   worksheets.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getDependents](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getdependents-member(1)),
+  [getDirectDependents](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getdirectdependents-member(1)),
+  [getDirectPrecedents](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getdirectprecedents-member(1)),
+  [getPrecedents](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getprecedents-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script finds the direct precedents of the active cell.
    * It changes the font and color of those precedent cells. 
@@ -29,6 +43,7 @@ remarks: |-
       range.getFormat().getFont().setBold(true);
     });
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheet.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheet.yml
@@ -6,12 +6,61 @@ fullName: ExcelScript.Worksheet
 summary: >-
   An Excel worksheet is a grid of cells. It can contain data, tables, charts,
   etc.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Chart](/javascript/api/office-scripts/excelscript/excelscript.chart):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.chart#excelscript-excelscript-chart-getworksheet-member(1))
+
+  -
+  [ExcelScript.NamedItem](/javascript/api/office-scripts/excelscript/excelscript.nameditem):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.nameditem#excelscript-excelscript-nameditem-getworksheet-member(1))
+
+  -
+  [ExcelScript.PivotTable](/javascript/api/office-scripts/excelscript/excelscript.pivottable):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.pivottable#excelscript-excelscript-pivottable-getworksheet-member(1))
+
+  -
+  [ExcelScript.Range](/javascript/api/office-scripts/excelscript/excelscript.range):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.range#excelscript-excelscript-range-getworksheet-member(1))
+
+  -
+  [ExcelScript.RangeAreas](/javascript/api/office-scripts/excelscript/excelscript.rangeareas):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.rangeareas#excelscript-excelscript-rangeareas-getworksheet-member(1))
+
+  -
+  [ExcelScript.Shape](/javascript/api/office-scripts/excelscript/excelscript.shape):
+  [copyTo](/javascript/api/office-scripts/excelscript/excelscript.shape#excelscript-excelscript-shape-copyto-member(1))
+
+  -
+  [ExcelScript.Slicer](/javascript/api/office-scripts/excelscript/excelscript.slicer):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.slicer#excelscript-excelscript-slicer-getworksheet-member(1))
+
+  -
+  [ExcelScript.Table](/javascript/api/office-scripts/excelscript/excelscript.table):
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.table#excelscript-excelscript-table-getworksheet-member(1))
+
+  -
+  [ExcelScript.Workbook](/javascript/api/office-scripts/excelscript/excelscript.workbook):
+  [addSlicer](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addslicer-member(1)),
+  [addWorksheet](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-addworksheet-member(1)),
+  [getActiveWorksheet](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getactiveworksheet-member(1)),
+  [getFirstWorksheet](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getfirstworksheet-member(1)),
+  [getLastWorksheet](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getlastworksheet-member(1)),
+  [getWorksheet](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getworksheet-member(1)),
+  [getWorksheets](/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getworksheets-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script creates a new worksheet named "Plum" and sets its tab color to purple.
    */
@@ -19,6 +68,7 @@ remarks: |-
     const newSheet = workbook.addWorksheet("Plum")
     newSheet.setTabColor("purple");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetcustomproperty.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetcustomproperty.yml
@@ -4,7 +4,15 @@ uid: ExcelScript!ExcelScript.WorksheetCustomProperty:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetCustomProperty
 summary: Represents a worksheet-level custom property.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [addWorksheetCustomProperty](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-addworksheetcustomproperty-member(1)),
+  [getCustomProperties](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getcustomproperties-member(1)),
+  [getWorksheetCustomProperty](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getworksheetcustomproperty-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetfreezepanes.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetfreezepanes.yml
@@ -4,7 +4,13 @@ uid: ExcelScript!ExcelScript.WorksheetFreezePanes:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetFreezePanes
 summary: ''
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [getFreezePanes](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getfreezepanes-member(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetpositiontype.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetpositiontype.yml
@@ -6,12 +6,23 @@ fullName: ExcelScript.WorksheetPositionType
 summary: >-
   The position of a worksheet relative to another worksheet or the entire
   worksheet collection.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [copy](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-copy-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script duplicates a worksheet named "Template". 
    * The new worksheet is added after the template.
@@ -30,6 +41,7 @@ remarks: |-
     let date = new Date(Date.now());
     newSheet.setName(`${date.toDateString()}`);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetprotection.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetprotection.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.WorksheetProtection:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetProtection
 summary: Represents the protection of a worksheet object.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [getProtection](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-getprotection-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script pauses the protection of a worksheet by using the provided password.
    * This password could come from a Power Automate flow.
@@ -30,6 +41,7 @@ remarks: |-
       console.log("Incorrect password");
     }
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetprotectionoptions.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetprotectionoptions.yml
@@ -4,12 +4,26 @@ uid: ExcelScript!ExcelScript.WorksheetProtectionOptions:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetProtectionOptions
 summary: Represents the options in sheet protection.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.WorksheetProtection](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection):
+  [getOptions](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-getoptions-member(1)),
+  [getSavedOptions](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-getsavedoptions-member(1)),
+  [protect](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-protect-member(1)),
+  [updateOptions](/javascript/api/office-scripts/excelscript/excelscript.worksheetprotection#excelscript-excelscript-worksheetprotection-updateoptions-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script protects cells from being selected on the current worksheet.
    */
@@ -26,6 +40,7 @@ remarks: |-
     // Apply the given protection options.
     sheetProtection.protect(protectionOptions);
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/excelscript/excelscript.worksheetsearchcriteria.yml
+++ b/docs/docs-ref-autogen/excelscript/excelscript.worksheetsearchcriteria.yml
@@ -4,12 +4,23 @@ uid: ExcelScript!ExcelScript.WorksheetSearchCriteria:interface
 package: ExcelScript!
 fullName: ExcelScript.WorksheetSearchCriteria
 summary: Represents the worksheet search criteria to be used.
-remarks: |-
+remarks: >-
 
+
+
+
+  #### Used by
+
+
+  -
+  [ExcelScript.Worksheet](/javascript/api/office-scripts/excelscript/excelscript.worksheet):
+  [findAll](/javascript/api/office-scripts/excelscript/excelscript.worksheet#excelscript-excelscript-worksheet-findall-member(1))
 
   #### Examples
 
+
   ```TypeScript
+
   /**
    * This script searches through a worksheet and finds cells containing "No". 
    * Those cells are filled with the color red.
@@ -29,6 +40,7 @@ remarks: |-
     // Set the fill color to red.
     noCells.getFormat().getFill().setColor("red");
   }
+
   ```
 
 isPreview: false

--- a/docs/docs-ref-autogen/officescript/officescript.downloadfileproperties.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.downloadfileproperties.yml
@@ -8,8 +8,8 @@ remarks: >-
   #### Used by
 
 
-  - [OfficeScript](/javascript/api/office-scripts/officescript/officescript):
-  [downloadFile](/javascript/api/office-scripts/officescript/officescript#officescript-officescript-downloadfile-function(1))
+  - [OfficeScript](/javascript/api/office-scripts/officescript):
+  [downloadFile](/javascript/api/office-scripts/officescript#officescript-officescript-downloadfile-function(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.downloadfileproperties.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.downloadfileproperties.yml
@@ -4,7 +4,12 @@ uid: OfficeScript!OfficeScript.DownloadFileProperties:interface
 package: OfficeScript!
 fullName: OfficeScript.DownloadFileProperties
 summary: The file to download.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  - [OfficeScript](/javascript/api/office-scripts/officescript/officescript):
+  [downloadFile](/javascript/api/office-scripts/officescript/officescript#officescript-officescript-downloadfile-function(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.emailattachment.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.emailattachment.yml
@@ -8,7 +8,13 @@ summary: >-
   one of the `to`<!-- -->, `cc`<!-- -->, or `bcc` parameters. If no recipient is
   specified, the following error is shown: "The message has no recipient. Please
   enter a value for at least one of the "to", "cc", or "bcc" parameters."
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [OfficeScript.MailProperties](/javascript/api/office-scripts/officescript/officescript.mailproperties):
+  [attachments](/javascript/api/office-scripts/officescript/officescript.mailproperties#officescript-officescript-mailproperties-attachments-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.emailcontenttype.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.emailcontenttype.yml
@@ -4,7 +4,13 @@ uid: OfficeScript!OfficeScript.EmailContentType:enum
 package: OfficeScript!
 fullName: OfficeScript.EmailContentType
 summary: The type of the content. Possible values are text or HTML.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [OfficeScript.MailProperties](/javascript/api/office-scripts/officescript/officescript.mailproperties):
+  [contentType](/javascript/api/office-scripts/officescript/officescript.mailproperties#officescript-officescript-mailproperties-contenttype-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.emailimportance.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.emailimportance.yml
@@ -6,7 +6,13 @@ fullName: OfficeScript.EmailImportance
 summary: >-
   The importance value of the email. Corresponds to "high", "normal", and "low"
   importance values available in the Outlook UI.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  -
+  [OfficeScript.MailProperties](/javascript/api/office-scripts/officescript/officescript.mailproperties):
+  [importance](/javascript/api/office-scripts/officescript/officescript.mailproperties#officescript-officescript-mailproperties-importance-member)
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.mailproperties.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.mailproperties.yml
@@ -8,8 +8,8 @@ remarks: >-
   #### Used by
 
 
-  - [OfficeScript](/javascript/api/office-scripts/officescript/officescript):
-  [sendMail](/javascript/api/office-scripts/officescript/officescript#officescript-officescript-sendmail-function(1))
+  - [OfficeScript](/javascript/api/office-scripts/officescript):
+  [sendMail](/javascript/api/office-scripts/officescript#officescript-officescript-sendmail-function(1))
 
 isPreview: false
 isDeprecated: false

--- a/docs/docs-ref-autogen/officescript/officescript.mailproperties.yml
+++ b/docs/docs-ref-autogen/officescript/officescript.mailproperties.yml
@@ -4,7 +4,12 @@ uid: OfficeScript!OfficeScript.MailProperties:interface
 package: OfficeScript!
 fullName: OfficeScript.MailProperties
 summary: The properties of the email to be sent.
-remarks: ''
+remarks: >-
+  #### Used by
+
+
+  - [OfficeScript](/javascript/api/office-scripts/officescript/officescript):
+  [sendMail](/javascript/api/office-scripts/officescript/officescript#officescript-officescript-sendmail-function(1))
 
 isPreview: false
 isDeprecated: false

--- a/generate-docs/scripts/package-lock.json
+++ b/generate-docs/scripts/package-lock.json
@@ -81,9 +81,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -162,9 +162,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1321,9 +1321,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/generate-docs/scripts/postprocessor.ts
+++ b/generate-docs/scripts/postprocessor.ts
@@ -504,6 +504,12 @@ function convertUidToUrl(uid: string): string {
         anchor = `#${anchorBase}${overloadSuffix}`;
     }
 
+    // Namespace-level members (e.g., OfficeScript.downloadFile) have classPath === packageName.
+    // Their page is /javascript/api/office-scripts/<pkg>, not /.../<pkg>/<pkg>.
+    if (classPathLower === packageName) {
+        return `/javascript/api/office-scripts/${packageName}${anchor}`;
+    }
+
     return `/javascript/api/office-scripts/${packageName}/${classPathLower}${anchor}`;
 }
 
@@ -579,7 +585,14 @@ function generateUsedBySection(references: UsedByReference[]): string {
                 const uidParts = ref.uid.split('!');
                 if (uidParts.length === 2) {
                     const pkgName = uidParts[0].toLowerCase();
-                    classUrl = `/javascript/api/office-scripts/${pkgName}/${className.toLowerCase()}`;
+                    const classNameLower = className.toLowerCase();
+                    // Namespace-level class (e.g., "OfficeScript") has classNameLower === pkgName.
+                    // Its page is /javascript/api/office-scripts/<pkg>, not /.../<pkg>/<pkg>.
+                    if (classNameLower === pkgName) {
+                        classUrl = `/javascript/api/office-scripts/${pkgName}`;
+                    } else {
+                        classUrl = `/javascript/api/office-scripts/${pkgName}/${classNameLower}`;
+                    }
                 }
             }
         }

--- a/generate-docs/scripts/postprocessor.ts
+++ b/generate-docs/scripts/postprocessor.ts
@@ -109,6 +109,38 @@ interface SnippetMap {
     [key: string]: string[];
 }
 
+interface UsedByReference {
+    uid: string;          // Full canonical reference UID of the using member
+    name: string;         // Display name (e.g., "ExcelScript.Workbook.getWorksheet")
+    memberType: string;   // "property", "method", etc.
+    packageName: string;  // Package name (e.g., "ExcelScript")
+    contextText: string;  // Human-readable context (e.g., "property type")
+}
+
+interface UsedByIndex {
+    [typeUID: string]: UsedByReference[];
+}
+
+interface ApiJsonToken {
+    kind: string;
+    text?: string;
+    canonicalReference?: string;
+}
+
+interface ApiJsonMember {
+    kind: string;
+    canonicalReference?: string;
+    name?: string;
+    excerptTokens?: ApiJsonToken[];
+    members?: ApiJsonMember[];
+    returnTypeTokenRange?: { startIndex: number; endIndex: number };
+    propertyTypeTokenRange?: { startIndex: number; endIndex: number };
+    parameters?: Array<{
+        parameterName: string;
+        parameterTypeTokenRange: { startIndex: number; endIndex: number };
+    }>;
+}
+
 /**
  * Loads snippets from the snippets.yaml file
  * @param snippetsPath - Absolute path to snippets.yaml file
@@ -282,6 +314,336 @@ function processYamlItem(
     }
 }
 
+// ---- Used By Index Building ----
+
+/**
+ * Builds a reverse index mapping type UIDs to the members that use them.
+ * Reads the API JSON files produced by api-extractor for each namespace.
+ */
+function buildUsedByIndex(): UsedByIndex {
+    const index: UsedByIndex = {};
+    const jsonFiles = [
+        path.resolve("../json/json-preview/ExcelScript.api.json"),
+        path.resolve("../json/json-preview/OfficeScript.api.json")
+    ];
+
+    for (const jsonPath of jsonFiles) {
+        if (!fsx.existsSync(jsonPath)) {
+            console.warn(`  Warning: JSON file not found: ${jsonPath}`);
+            continue;
+        }
+        try {
+            const apiJson: ApiJsonMember = JSON.parse(fsx.readFileSync(jsonPath, 'utf-8'));
+            const packageName = path.basename(jsonPath, '.api.json');
+            analyzeMembers(apiJson, index, packageName);
+        } catch (error) {
+            console.warn(`  Warning: Failed to process ${jsonPath}: ${error}`);
+        }
+    }
+
+    return index;
+}
+
+/**
+ * Recursively analyzes all members in an API JSON structure.
+ */
+function analyzeMembers(container: ApiJsonMember, index: UsedByIndex, packageName: string): void {
+    if (!container || !container.members) {
+        return;
+    }
+
+    for (const member of container.members) {
+        if (!member.canonicalReference) {
+            continue;
+        }
+        analyzeMemberTypeReferences(member, index, packageName);
+        analyzeMembers(member, index, packageName);
+    }
+}
+
+/**
+ * Analyzes a single member for type references in property types,
+ * method return types, and method parameter types.
+ */
+function analyzeMemberTypeReferences(member: ApiJsonMember, index: UsedByIndex, packageName: string): void {
+    if (!member.excerptTokens || !member.canonicalReference) {
+        return;
+    }
+
+    if (member.kind === 'PropertySignature' || member.kind === 'Property') {
+        const range = member.propertyTypeTokenRange;
+        const tokens = range
+            ? member.excerptTokens.slice(range.startIndex, range.endIndex)
+            : member.excerptTokens;
+        analyzeExcerptTokens(tokens, member.canonicalReference, 'property type', index, packageName);
+    }
+
+    if (member.kind === 'MethodSignature' || member.kind === 'Method' || member.kind === 'Function') {
+        if (member.returnTypeTokenRange) {
+            const returnTokens = member.excerptTokens.slice(
+                member.returnTypeTokenRange.startIndex,
+                member.returnTypeTokenRange.endIndex
+            );
+            analyzeExcerptTokens(returnTokens, member.canonicalReference, 'return type', index, packageName);
+        }
+
+        if (member.parameters) {
+            for (const param of member.parameters) {
+                const paramTokens = member.excerptTokens.slice(
+                    param.parameterTypeTokenRange.startIndex,
+                    param.parameterTypeTokenRange.endIndex
+                );
+                analyzeExcerptTokens(paramTokens, member.canonicalReference, 'parameter type', index, packageName);
+            }
+        }
+    }
+}
+
+/**
+ * Scans excerpt tokens for Reference tokens and adds entries to the index.
+ */
+function analyzeExcerptTokens(
+    tokens: ApiJsonToken[],
+    usingMemberUID: string,
+    contextText: string,
+    index: UsedByIndex,
+    packageName: string
+): void {
+    for (const token of tokens) {
+        if (token.kind === 'Reference' && token.canonicalReference) {
+            // Skip built-in types (e.g., Promise, Array) which start with '!'
+            if (token.canonicalReference.startsWith('!')) {
+                continue;
+            }
+
+            if (!index[token.canonicalReference]) {
+                index[token.canonicalReference] = [];
+            }
+
+            index[token.canonicalReference].push({
+                uid: usingMemberUID,
+                name: formatDisplayName(usingMemberUID),
+                memberType: getMemberType(usingMemberUID),
+                packageName: packageName,
+                contextText: contextText
+            });
+        }
+    }
+}
+
+/**
+ * Converts a canonical reference UID to a human-readable display name.
+ * E.g., "ExcelScript!ExcelScript.Workbook#getWorksheet:member(1)" -> "ExcelScript.Workbook.getWorksheet"
+ */
+function formatDisplayName(uid: string): string {
+    const withoutPackage = uid.replace(/^[^!]+!/, '');
+    return withoutPackage.replace(/#/g, '.').replace(/:[a-z]+(\(\d+\))?$/, '');
+}
+
+/**
+ * Determines the member type from a UID string.
+ */
+function getMemberType(uid: string): string {
+    if (uid.includes(':member')) { return 'property'; }
+    if (uid.includes(':method')) { return 'method'; }
+    if (uid.includes(':function')) { return 'function'; }
+    if (uid.includes(':interface')) { return 'interface'; }
+    if (uid.includes(':class')) { return 'class'; }
+    if (uid.includes(':enum')) { return 'enum'; }
+    if (uid.includes(':type')) { return 'type'; }
+    return 'member';
+}
+
+/**
+ * Converts a canonical reference UID to a documentation URL for office-scripts.
+ * E.g., "ExcelScript!ExcelScript.Workbook#getWorksheet:member(1)"
+ *    -> "/javascript/api/office-scripts/excelscript/excelscript.workbook#excelscript-excelscript-workbook-getworksheet-member(1)"
+ */
+function convertUidToUrl(uid: string): string {
+    const overloadMatch = uid.match(/\((\d+)\)$/);
+    const overloadSuffix = overloadMatch ? `(${overloadMatch[1]})` : '';
+    const cleanUid = uid.replace(/\(\d+\)$/, '');
+
+    const parts = cleanUid.split('!');
+    if (parts.length !== 2) {
+        return '';
+    }
+
+    const packageName = parts[0].toLowerCase(); // "excelscript" or "officescript"
+    const reference = parts[1];
+
+    let classPath: string;
+    let memberPart: string;
+
+    const hashIndex = reference.indexOf('#');
+    if (hashIndex > 0) {
+        classPath = reference.substring(0, hashIndex);
+        memberPart = reference.substring(hashIndex + 1);
+    } else {
+        const colonIndex = reference.indexOf(':');
+        if (colonIndex > 0) {
+            const beforeColon = reference.substring(0, colonIndex);
+            const lastDotIndex = beforeColon.lastIndexOf('.');
+            if (lastDotIndex > 0) {
+                classPath = reference.substring(0, lastDotIndex);
+                memberPart = reference.substring(lastDotIndex + 1);
+            } else {
+                classPath = reference;
+                memberPart = '';
+            }
+        } else {
+            classPath = reference;
+            memberPart = '';
+        }
+    }
+
+    const classPathLower = classPath.toLowerCase();
+    let anchor = '';
+    if (memberPart) {
+        const anchorBase = `${packageName}-${classPath.replace(/\./g, '-')}-${memberPart.replace(/:/g, '-')}`.toLowerCase();
+        anchor = `#${anchorBase}${overloadSuffix}`;
+    }
+
+    return `/javascript/api/office-scripts/${packageName}/${classPathLower}${anchor}`;
+}
+
+/**
+ * Deduplicates method overloads, keeping only the first overload entry.
+ */
+function deduplicateMethodOverloads(references: UsedByReference[]): UsedByReference[] {
+    const seen = new Set<string>();
+    const result: UsedByReference[] = [];
+
+    for (const ref of references) {
+        const baseUID = ref.uid.replace(/\(\d+\)$/, '');
+        if (!seen.has(baseUID)) {
+            seen.add(baseUID);
+            result.push(ref);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Groups references by their containing class name.
+ * E.g., "ExcelScript.Workbook.getWorksheet" -> class is "ExcelScript.Workbook"
+ */
+function groupByContainingClass(references: UsedByReference[]): Record<string, UsedByReference[]> {
+    const grouped: Record<string, UsedByReference[]> = {};
+
+    for (const ref of references) {
+        const lastDotIndex = ref.name.lastIndexOf('.');
+        const className = lastDotIndex > 0 ? ref.name.substring(0, lastDotIndex) : ref.name;
+
+        if (!grouped[className]) {
+            grouped[className] = [];
+        }
+        grouped[className].push(ref);
+    }
+
+    return grouped;
+}
+
+/**
+ * Generates the markdown for the "Used by" section.
+ * Groups references by containing class with inline linked member lists.
+ */
+function generateUsedBySection(references: UsedByReference[]): string {
+    if (references.length === 0) {
+        return '';
+    }
+
+    const lines: string[] = ['\n\n#### Used by\n'];
+    const groupedByClass = groupByContainingClass(references);
+    const classNames = Object.keys(groupedByClass).sort();
+
+    for (const className of classNames) {
+        const members = groupedByClass[className];
+
+        members.sort((a, b) => {
+            const memberA = a.name.substring(className.length + 1);
+            const memberB = b.name.substring(className.length + 1);
+            return memberA.localeCompare(memberB);
+        });
+
+        const memberLinks: string[] = [];
+        let classUrl = '';
+
+        for (const ref of members) {
+            const url = convertUidToUrl(ref.uid);
+            const memberName = ref.name.substring(className.length + 1);
+            memberLinks.push(`[${memberName}](${url})`);
+
+            if (!classUrl) {
+                const uidParts = ref.uid.split('!');
+                if (uidParts.length === 2) {
+                    const pkgName = uidParts[0].toLowerCase();
+                    classUrl = `/javascript/api/office-scripts/${pkgName}/${className.toLowerCase()}`;
+                }
+            }
+        }
+
+        const classLink = classUrl ? `[${className}](${classUrl})` : className;
+        lines.push(`- ${classLink}: ${memberLinks.join(', ')}`);
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Injects a "Used by" section into a YAML item's remarks if the item's UID
+ * appears in the usedByIndex. Filters out self-references.
+ */
+function injectUsedBySection(item: any, usedByIndex: UsedByIndex): boolean {
+    if (!item.uid) {
+        return false;
+    }
+
+    const references = usedByIndex[item.uid];
+    if (!references || references.length === 0) {
+        return false;
+    }
+
+    if (!item.remarks) {
+        item.remarks = '';
+    }
+
+    // Remove any existing "Used by" section before injecting a fresh one
+    if (item.remarks.includes('#### Used by')) {
+        item.remarks = item.remarks.replace(/\n*#### Used by\n[\s\S]*?(?=\n####|\n*$)/g, '');
+    }
+
+    // Extract class name from current item's UID and filter out self-references
+    let filteredReferences = references;
+    const uidParts = item.uid.split('!');
+    if (uidParts.length === 2) {
+        const currentClassName = uidParts[1].split(':')[0].split('#')[0];
+        filteredReferences = references.filter(ref => {
+            const lastDotIndex = ref.name.lastIndexOf('.');
+            const refClassName = lastDotIndex > 0 ? ref.name.substring(0, lastDotIndex) : ref.name;
+            return refClassName !== currentClassName;
+        });
+    }
+
+    if (filteredReferences.length === 0) {
+        return true;
+    }
+
+    const deduplicated = deduplicateMethodOverloads(filteredReferences);
+    const usedBySection = generateUsedBySection(deduplicated);
+
+    if (item.remarks.includes('#### Examples')) {
+        item.remarks = item.remarks.replace('#### Examples', usedBySection + '\n#### Examples');
+    } else if (item.remarks.trim()) {
+        item.remarks += usedBySection;
+    } else {
+        item.remarks = usedBySection.substring(2); // Remove leading \n\n
+    }
+
+    return true;
+}
+
 tryCatch(async () => {
     console.log("\nStarting postprocessor script...");
 
@@ -291,6 +653,11 @@ tryCatch(async () => {
     // Load snippets from json-preview directory
     const snippetsPath = path.resolve("../json/json-preview/snippets.yaml");
     const { snippetsAll, snippetsTracking } = loadSnippets(snippetsPath);
+
+    // Build the "Used By" reverse index from API JSON files
+    console.log("\nBuilding 'Used by' index...");
+    const usedByIndex = buildUsedByIndex();
+    console.log(`Built 'Used by' index with ${Object.keys(usedByIndex).length} referenced types.`);
 
     console.log(`Deleting old docs at: ${docsDestination}`);
     // Delete everything except the 'overview' files.
@@ -325,11 +692,11 @@ tryCatch(async () => {
                 .forEach(interfaceYml => { // Contents of docs-ref-autogen/<host>/<host>script.
                 let subFileName = fileName + '/' + interfaceYml;
                 const ymlFile = fsx.readFileSync(subFileName, "utf8");
-                fsx.writeFileSync(subFileName, cleanUpYmlFile(ymlFile, snippetsAll, snippetsTracking));
+                fsx.writeFileSync(subFileName, cleanUpYmlFile(ymlFile, snippetsAll, snippetsTracking, usedByIndex));
             });
         } else if (fileName.indexOf("toc") < 0 && fileName.indexOf(".yml") > 0) {
             const ymlFile = fsx.readFileSync(fileName, "utf8");
-            fsx.writeFileSync(fileName, cleanUpYmlFile(ymlFile, snippetsAll, snippetsTracking));
+            fsx.writeFileSync(fileName, cleanUpYmlFile(ymlFile, snippetsAll, snippetsTracking, usedByIndex));
         }
     });
 
@@ -414,13 +781,24 @@ function fixToc(tocPath: string): Toc {
 function cleanUpYmlFile(
     ymlFile: string,
     snippetsAll: SnippetMap,
-    snippetsTracking: SnippetMap
+    snippetsTracking: SnippetMap,
+    usedByIndex: UsedByIndex
 ): string {
     const schemaComment = ymlFile.substring(0, ymlFile.indexOf("\n") + 1);
     const apiYaml: ApiYaml = jsyaml.load(ymlFile) as ApiYaml;
 
     // Process the entire YAML tree for examples and API set links
     processYamlItem(apiYaml, snippetsAll, snippetsTracking);
+
+    // Inject "Used by" sections into the top-level item and its members.
+    // Enum fields are excluded because OPS doesn't support remarks on enum fields.
+    injectUsedBySection(apiYaml, usedByIndex);
+    if (apiYaml.properties) {
+        apiYaml.properties.forEach(prop => injectUsedBySection(prop, usedByIndex));
+    }
+    if (apiYaml.methods) {
+        apiYaml.methods.forEach(method => injectUsedBySection(method, usedByIndex));
+    }
 
     // Add links for type aliases.
     if (apiYaml.uid.endsWith(":type")) {


### PR DESCRIPTION
Adds a reverse-reference index built from the API Extractor JSON output. Every type that is used as a property type, return type, or parameter type by another API member now gets a '#### Used by' section in its remarks.

The section groups callers by containing class and links to both the class page and the specific member, helping readers understand the object model and navigate between related pages.