### PR TITLE
[office] Map existing PDF snippet to related functions

### DIFF
--- a/docs/sample-scripts/samples.yaml
+++ b/docs/sample-scripts/samples.yaml
@@ -7790,6 +7790,27 @@
             attachments: [pdfFile]
         })    
     }
+'OfficeScript.DownloadFileProperties:interface':
+  - |-  
+    /**
+     * This script saves a worksheet as a PDF and emails that PDF to a recipient.
+     */
+    function main(workbook: ExcelScript.Workbook) {    
+        // Create the PDF.
+        const pdfObject = OfficeScript.convertToPdf();
+        const pdfFile = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
+
+        // Download the PDF.
+        OfficeScript.downloadFile(pdfFile);
+
+        // Email the PDF.
+        OfficeScript.sendMail({
+            to: "name@email.com", // Enter your recipient email address here.
+            subject: "[Demo] Monthly Sales Report", // This is the subject of your email.
+            content: "Here's the Monthly Sales Report", // This is the content within your email.
+            attachments: [pdfFile]
+        })    
+    }
 'OfficeScript.sendMail:function(1)':
   - |-  
     /**

--- a/docs/sample-scripts/samples.yaml
+++ b/docs/sample-scripts/samples.yaml
@@ -7798,7 +7798,7 @@
     function main(workbook: ExcelScript.Workbook) {    
         // Create the PDF.
         const pdfObject = OfficeScript.convertToPdf();
-        const pdfFile = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
+        const pdfFile: OfficeScript.DownloadFileProperties = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
 
         // Download the PDF.
         OfficeScript.downloadFile(pdfFile);

--- a/docs/sample-scripts/samples.yaml
+++ b/docs/sample-scripts/samples.yaml
@@ -7769,3 +7769,42 @@
             attachments: [pdfFile]
         })    
     }
+'OfficeScript.downloadFile:function(1)':
+  - |-  
+    /**
+     * This script saves a worksheet as a PDF and emails that PDF to a recipient.
+     */
+    function main(workbook: ExcelScript.Workbook) {    
+        // Create the PDF.
+        const pdfObject = OfficeScript.convertToPdf();
+        const pdfFile = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
+
+        // Download the PDF.
+        OfficeScript.downloadFile(pdfFile);
+
+        // Email the PDF.
+        OfficeScript.sendMail({
+            to: "name@email.com", // Enter your recipient email address here.
+            subject: "[Demo] Monthly Sales Report", // This is the subject of your email.
+            content: "Here's the Monthly Sales Report", // This is the content within your email.
+            attachments: [pdfFile]
+        })    
+    }
+'OfficeScript.sendMail:function(1)':
+  - |-  
+    /**
+     * This script saves a worksheet as a PDF and emails that PDF to a recipient.
+     */
+    function main(workbook: ExcelScript.Workbook) {    
+        // Create the PDF.
+        const pdfObject = OfficeScript.convertToPdf();
+        const pdfFile = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
+
+        // Email the PDF.
+        OfficeScript.sendMail({
+            to: "name@email.com", // Enter your recipient email address here.
+            subject: "[Demo] Monthly Sales Report", // This is the subject of your email.
+            content: "Here's the Monthly Sales Report", // This is the content within your email.
+            attachments: [pdfFile]
+        })    
+    }

--- a/docs/sample-scripts/samples.yaml
+++ b/docs/sample-scripts/samples.yaml
@@ -7811,6 +7811,24 @@
             attachments: [pdfFile]
         })    
     }
+'OfficeScript.EmailAttachment:interface':
+  - |-  
+    /**
+     * This script saves a worksheet as a PDF and emails that PDF to a recipient.
+     */
+    function main(workbook: ExcelScript.Workbook) {    
+        // Create the PDF.
+        const pdfObject = OfficeScript.convertToPdf();
+        const pdfFile = { name: "report.pdf", content: pdfObject }; // Enter your desired PDF name here.
+
+        // Email the PDF.
+        OfficeScript.sendMail({
+            to: "name@email.com", // Enter your recipient email address here.
+            subject: "[Demo] Monthly Sales Report", // This is the subject of your email.
+            content: "Here's the Monthly Sales Report", // This is the content within your email.
+            attachments: [pdfFile]
+        })    
+    }
 'OfficeScript.sendMail:function(1)':
   - |-  
     /**


### PR DESCRIPTION
This PR maps an existing snippet, already published in [a docs article](https://learn.microsoft.com/en-us/office/dev/scripts/resources/samples/save-as-pdf-email-as-pdf?view=office-scripts#sample-code-save-as-a-pdf-and-send-via-email), to other functions used in the snippet. 